### PR TITLE
Use unique, consistent searchguard index per instance

### DIFF
--- a/deployment/templates/kibana.yaml
+++ b/deployment/templates/kibana.yaml
@@ -83,7 +83,7 @@ objects:
                   readOnly: true
             -
               name: "kibana-proxy"
-              image: openshift-auth-proxy
+              image: logging-auth-proxy
               imagePullPolicy: Always
               ports:
                 -

--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -32,7 +32,7 @@ path:
   work: /elasticsearch/${CLUSTER_NAME}/work
 
 searchguard:
-  config_index_name: ${HOSTNAME}
+  config_index_name: ".searchguard.${HOSTNAME}"
   key_path: /elasticsearch/${CLUSTER_NAME}
   allow_all_from_loopback: false
   authentication:

--- a/elasticsearch/run.sh
+++ b/elasticsearch/run.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 mkdir -p /elasticsearch/$CLUSTER_NAME
 ln -s /etc/elasticsearch/keys/searchguard.key /elasticsearch/$CLUSTER_NAME/searchguard_node_key.key
@@ -14,7 +14,7 @@ sed --in-place=.bak '
 network.host: 127.0.0.1
 	' $ES_CONF
 
-nohup /usr/share/elasticsearch/bin/elasticsearch -Des.pidfile=./elasticsearch.pid &
+/usr/share/elasticsearch/bin/elasticsearch -Des.pidfile=./elasticsearch.pid -d
 until $(curl -s -f -o /dev/null --connect-timeout 1 -m 1 --head http://localhost:9200); do
     sleep 0.1;
 done
@@ -24,8 +24,8 @@ until $(curl -s -f -o /dev/null --connect-timeout 1 -m 1 --head http://localhost
   sleep 0.1;
 done
 
-if [ -z $(curl -s -f 'http://localhost:9200/searchguard/ac/ac') ]; then
-  curl -q -XPUT 'http://localhost:9200/searchguard/ac/ac?pretty' -d '
+if [ -z $(curl -s -f "http://localhost:9200/.searchguard.${HOSTNAME}/ac/ac") ]; then
+  curl -q -XPUT "http://localhost:9200/.searchguard.${HOSTNAME}/ac/ac?pretty" -d '
   {"acl": [
       {
         "__Comment__": "Default is to deny all access",
@@ -54,7 +54,7 @@ if [ -z $(curl -s -f 'http://localhost:9200/searchguard/ac/ac') ]; then
   ]}'
 
   # check to make sure the ACL has been persisted
-  until $(curl -s -f -o /dev/null --connect-timeout 1 -m 1 http://localhost:9200/searchguard/ac/ac); do
+  until $(curl -s -f -o /dev/null --connect-timeout 1 -m 1 http://localhost:9200/.searchguard.${HOSTNAME}/ac/ac); do
     sleep 0.1;
   done
 fi

--- a/hack/templates/dev-builds.yaml
+++ b/hack/templates/dev-builds.yaml
@@ -50,8 +50,8 @@ objects:
   kind: ImageStream
   metadata:
     labels:
-      build: openshift-auth-proxy
-    name: openshift-auth-proxy
+      build: logging-auth-proxy
+    name: logging-auth-proxy
   spec: {}
 - apiVersion: v1
   kind: ImageStream
@@ -172,13 +172,13 @@ objects:
   kind: BuildConfig
   metadata:
     labels:
-      build: openshift-auth-proxy
-    name: openshift-auth-proxy
+      build: logging-auth-proxy
+    name: logging-auth-proxy
   spec:
     output:
       to:
         kind: ImageStreamTag
-        name: openshift-auth-proxy:latest
+        name: logging-auth-proxy:latest
     resources: {}
     source:
       git:


### PR DESCRIPTION
Basing the SG index on hostname in config, it wasn't matching in the initialization script. Now it does. Also added a ".searchguard." in front of the name to ensure it can't conflict with project indexes.

Independently, fixing up the dev builds.