### PR TITLE
Correct origin default prefix and force install bower components

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-prefix=${PREFIX:-${1:-openshift/}}
+prefix=${PREFIX:-${1:-openshift/origin-}}
 version=${VERSION:-${2:-latest}}
 docker build -t "${prefix}logging-fluentd:${version}"       ../fluentd/
 docker build -t "${prefix}logging-elasticsearch:${version}" ../elasticsearch/

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -23,7 +23,7 @@ RUN   wget -q https://download.elastic.co/kibana/kibana/kibana-4.1.1-linux-x64.t
       cd /opt/origin-kibana/ && \
       yum install -y npm --nogpgcheck && \
       npm install --ignore-scripts && \
-      ./node_modules/bower/bin/bower install --allow-root && \
+      ./node_modules/bower/bin/bower install --allow-root --force && \
       ./node_modules/grunt-cli/bin/grunt && \
       rm -rf node_modules && \
       yum erase npm nodejs -y && \


### PR DESCRIPTION
This PR provides:

* Force install of bower components until we can remove them from the repo
* Fix the default prefix to allow build and push to dockerhub