### PR TITLE
use wildcard to look up hostname field

### DIFF
--- a/hack/testing/check-logs.go
+++ b/hack/testing/check-logs.go
@@ -24,7 +24,7 @@ func main() {
         hostname = strings.Split(hostname, ".")[0]
 
         // instead of receiving jsonStream as an Arg, we'll make the call ourselves...
-        queryCommand := `oc exec `+kibana_pod+` -- curl -s -k --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert -XGET "https://`+es_svc+`/`+index+`.*/fluentd/_search?q=hostname:`+hostname+`&fields=message&size=`+querySize+`"`
+        queryCommand := `oc exec `+kibana_pod+` -- curl -s -k --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert -XGET "https://`+es_svc+`/`+index+`.*/fluentd/_search?q=hostname:`+hostname+`*&fields=message&size=`+querySize+`"`
         queryCmdName := "bash"
         queryCmdArgs := []string{"-c", queryCommand}
 


### PR DESCRIPTION
I'm not sure what is the purpose of::

    hostname = strings.Split(hostname, ".")[0]

but on my system, the ES logs have the FQDN, so doing the search for hostname fails.  If I add a '*' wildcard to the end, it works.