### PR TITLE
Adding OAP_MASTER_URL variable when processing kibana.yaml

### DIFF
--- a/deployment/run.sh
+++ b/deployment/run.sh
@@ -182,6 +182,7 @@ oc process -f templates/es.yaml -v "${es_params}" | oc create -f -
 es_host=logging-es.${project}.svc.cluster.local
 es_ops_host=${es_host}
 oc process -f templates/kibana.yaml -v "OAP_PUBLIC_MASTER_URL=${public_master_url}" | oc create -f -
+oc process -f templates/kibana.yaml -v "OAP_PUBLIC_MASTER_URL=${public_master_url},OAP_MASTER_URL=${master_url}" | oc create -f -
 if [ "${ENABLE_OPS_CLUSTER}" == true ]; then
 	oc process -f templates/es.yaml -v "${es_ops_params}" | oc create -f -
 	es_ops_host=logging-es-ops.${project}.svc.cluster.local


### PR DESCRIPTION
Motivation:
When running in a Vagrant VM we noticed that we were hitting a redirect
loop when trying to access the kibana console. We created the and issue
for this in openshift-docs (see Issue section below).

When processing the template we specify the following:
```shell
$ oc process logging-deployer-template -n openshift \
-v KIBANA_HOSTNAME=kibana.local.feedhenry.io,ES_CLUSTER_SIZE=1, \
PUBLIC_MASTER_URL=https://local.feedhenry.io:8443, \
MASTER_URL=https://kubernetes.default.svc.cluster.local:8443 \
| oc create -f -
```
Notice that we have specified a MASTER_URL. But when I tried run
describe on the pod I see it with out the port (defaulting to 443):
```shell
$ oc describe po logging-kibana-6-9aac9
...
Environment Variables:
    OAP_BACKEND_URL: http://localhost:5601
    OAP_AUTH_MODE:   oauth2
    OAP_TRANSFORM:   user_header,token_header
    OAP_OAUTH_ID:    kibana-proxy
    OAP_MASTER_URL:  https://kubernetes.default.svc.cluster.local
```

It looks like the environment variable OAP_MASTER_URL is never set when
deployment/templates/kibana.yaml is processed. So the default value
specified in that file is used which is:
```
name: OAP_MASTER_URL
value: "https://kubernetes.default.svc.cluster.local"
```
Modifications:
Added OAP_MASTER_URL to the run.sh script when processing
templates/kibana.yaml

Result:
We can now access the Kibana console via the OpenShift console and also
directly.

Issue:
https://github.com/openshift/openshift-docs/issues/1457