### PR TITLE
do not process the kibana template twice - add master_url to kibana-ops

### DIFF
--- a/deployment/run.sh
+++ b/deployment/run.sh
@@ -181,12 +181,11 @@ es_ops_params=$(join , \
 oc process -f templates/es.yaml -v "${es_params}" | oc create -f -
 es_host=logging-es.${project}.svc.cluster.local
 es_ops_host=${es_host}
-oc process -f templates/kibana.yaml -v "OAP_PUBLIC_MASTER_URL=${public_master_url}" | oc create -f -
 oc process -f templates/kibana.yaml -v "OAP_PUBLIC_MASTER_URL=${public_master_url},OAP_MASTER_URL=${master_url}" | oc create -f -
 if [ "${ENABLE_OPS_CLUSTER}" == true ]; then
 	oc process -f templates/es.yaml -v "${es_ops_params}" | oc create -f -
 	es_ops_host=logging-es-ops.${project}.svc.cluster.local
-	oc process -f templates/kibana.yaml -v "OAP_PUBLIC_MASTER_URL=${public_master_url},KIBANA_DEPLOY_NAME=kibana-ops,ES_HOST=logging-es-ops" | oc create -f -
+	oc process -f templates/kibana.yaml -v "OAP_PUBLIC_MASTER_URL=${public_master_url},OAP_MASTER_URL=${master_url},KIBANA_DEPLOY_NAME=kibana-ops,ES_HOST=logging-es-ops" | oc create -f -
 fi
 oc process -f templates/fluentd.yaml -v "ES_HOST=${es_host},OPS_HOST=${es_ops_host}"| oc create -f -
 


### PR DESCRIPTION
@ewolinetz @sosiouxme  PTAL

I'm not sure how the previous commit ever worked.  The kibana.yaml template was being processed twice.  The second one causes an error. The script has set -e so it bails out.

The fix is to process kibana.yaml once, with both the master and public master url. I also added the master url to the kibana-ops processing.