### PR TITLE
addressing k8s_host missing

### DIFF
--- a/fluentd/fluent.conf
+++ b/fluentd/fluent.conf
@@ -157,7 +157,7 @@
     type record_transformer
     enable_ruby
     <record>
-      log ${(err || msg) || log}
+      log ${(err rescue nil) || (msg rescue nil) || log}
     </record>
     remove_keys req,res,msg,name,level,v,pid,err
   </filter>
@@ -169,7 +169,7 @@
     type record_transformer
     enable_ruby
     <record>
-      hostname ${kubernetes_host}
+      hostname ${(kubernetes_host rescue nil) || File.open('/etc/docker-hostname') { |f| f.readline }.rstrip}
       message ${log}
       version 1.0.6
     </record>


### PR DESCRIPTION
I noticed warn statements that variables or methods could not be found for 'kubernetes_host', same for 'err'.

@sosiouxme @richm PTAL