### PR TITLE
Add support for curator for Elasticsearch index management

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,76 @@ proxy is required that runs in front of Kibana.
 The deployer enables the user to generate all of the necessary
 key/certs/secrets and deploy all of the components in concert.
 
-## Defining local builds
+#### Curator
+
+Curator allows the admin to remove old indices from Elasticsearch on a per-project
+basis.  The pod will read its configuration from a mounted yaml file that
+is structured like this:
+
+    $PROJECT_NAME:
+      $ACTION:
+        $UNIT: $VALUE
+
+    $PROJECT_NAME:
+      $ACTION:
+        $UNIT: $VALUE
+     ...
+
+* $PROJECT_NAME - the actual name of a project - "myapp-devel"
+** For operations logs, use the name `.operations` as the project name
+* $ACTION - the action to take - currently only "delete"
+* $UNIT - one of "days", "weeks", or "months"
+* $VALUE - an integer for the number of units
+
+For example, using::
+
+    myapp-dev:
+     delete:
+       days: 1
+
+    myapp-qe:
+      delete:
+        weeks: 1
+
+    .operations:
+      delete:
+        weeks: 8
+     ...
+
+Every day, curator will run, and will delete indices in the myapp-dev
+project older than 1 day, and indices in the myapp-qe project older than 1
+week.
+
+*WARNING*: Using `months` as the unit
+
+When you use month based trimming, curator starts counting at the _first_ day of
+the current month, not the _current_ day of the current month.  For example, if
+today is April 15, and you want to delete indices that are 2 months older than
+today (`delete: months: 2`), curator doesn't delete indices that are dated
+older than February 15, it deletes indices older than _February 1_.  That is,
+it goes back to the first day of the current month, _then_ goes back two whole
+months from that date.
+If you want to be exact with curator, it is best to use `days` e.g. `delete: days: 30`
+[Curator issue](https://github.com/elastic/curator/issues/569)
+
+To create the curator configuration, do the following:
+
+Create a yaml file with your configuration settings using your favorite editor.
+Next create a secret from your created yaml file:
+`oc secrets new index_management settings=</path/to/your/yaml/file>`
+
+Then mount your created secret as a volume in your Curator DC:
+`oc volumes dc/logging-curator --add --type=secret --secret-name=index_management --mount-path=/etc/curator --name=index_management --overwrite`
+
+The mount-path value e.g. `/etc/curator` must match the `CURATOR_CONF_LOCATION`
+in the environment.
+
+By default curator will run at midnight and deletes logs older than 30 days.
+The environment variables `CURATOR_CRON_HOUR` AND `CURATOR_CRON_MINUTE` can be
+used to define another hour and minute while `DEFAULT_DAYS` will change the
+default number of days logs will be kept for.
+
+# Defining local builds
 
 Choose the project you want to hold your logging infrastructure. It can be
 any project.

--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -1,0 +1,26 @@
+FROM centos:centos7
+
+MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
+
+# by default, run the curator cron job at midnight every night, and delete
+# indices older than 30 days old
+ENV HOME=/opt/app-root/src \
+    ES_HOST=localhost \
+    ES_PORT=9200 \
+    CURATOR_CRON_MINUTE=0 \
+    CURATOR_CRON_HOUR=0 \
+    ES_CA=/etc/curator/keys/ca \
+    ES_CLIENT_CERT=/etc/curator/keys/cert \
+    ES_CLIENT_KEY=/etc/curator/keys/key \
+    CURATOR_CONF_LOCATION=/etc/curator
+
+LABEL io.k8s.description="Curator elasticsearch container for elasticsearch deletion/archival" \
+  io.k8s.display-name="Curator 3.4" \
+  io.openshift.tags="logging,elk,elasticsearch,curator"
+
+ADD run.sh install.sh run_cron.py ${HOME}/
+RUN ${HOME}/install.sh
+
+WORKDIR ${HOME}
+USER nobody
+CMD ["sh", "run.sh"]

--- a/curator/install.sh
+++ b/curator/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -ex
+
+rpm -q epel-release || yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum install -y --setopt=tsflags=nodocs \
+  python-pip \
+  PyYAML
+pip install elasticsearch-curator python-crontab
+yum clean all
+
+# HACK HACK HACK - remove when fixed upstream
+yum install -y --setopt=tsflags=nodocs \
+    git
+git clone -b issue-344 https://github.com/richm/elasticsearch-py.git
+pushd elasticsearch-py
+python setup.py install
+popd
+git clone -b issue-520 https://github.com/richm/curator.git
+pushd curator
+python setup.py install
+popd
+yum clean all
+# HACK HACK HACK - remove when fixed upstream
+
+mkdir -p ${HOME}
+mkdir -p ${CURATOR_CONF_LOCATION}
+touch ${CURATOR_CONF_LOCATION}/settings

--- a/curator/run.sh
+++ b/curator/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# this will parse out the retention settings, combine like settings, create cron line definitions for them with curator, run the jobs immediately, then run the jobs again every CURATOR_CRON_HOUR and CURATOR_CRON_MINUTE (by default, every midnight)
+python -u run_cron.py

--- a/curator/run_cron.py
+++ b/curator/run_cron.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python
+
+import sys
+import yaml
+import os
+import time
+import logging
+
+from crontab import CronTab
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+# log at INFO by default
+logger.setLevel(logging.INFO)
+lh = logging.StreamHandler()
+lh.setLevel(logging.INFO)
+lh.setFormatter(logging._defaultFormatter)
+logger.addHandler(lh)
+
+# we can't allow 'hours' since our index timestamp format doesn't allow for that level of granularity
+#allowed_units = {'hours': 'hours', 'days': 'days', 'weeks': 'weeks', 'months': 'months'}
+allowed_units = {'days': 'days', 'weeks': 'weeks', 'months': 'months'}
+
+# allowed operations, currently we'll just allow delete
+allowed_operations = {'delete': 'delete'}
+curator_settings = {'delete': {}}
+
+filename = os.getenv('CURATOR_CONF_LOCATION', '/etc/curator') + '/settings'
+
+decoded = []
+with open(filename, 'r') as stream:
+    decoded = yaml.load(stream) or []
+
+connection_info = '--host ' + os.getenv('ES_HOST') + ' --port ' + os.getenv('ES_PORT') + ' --use_ssl --certificate ' + os.getenv('ES_CA') + ' --client-cert ' + os.getenv('ES_CLIENT_CERT') + ' --client-key ' + os.getenv('ES_CLIENT_KEY')
+
+base_default_cmd = '/usr/bin/curator --loglevel ERROR ' + connection_info + ' delete indices --timestring %Y.%m.%d'
+default_command = base_default_cmd + ' --older-than ' + os.getenv('DEFAULT_DAYS') + ' --time-unit days' + ' --exclude .searchguard*' + ' --exclude .kibana*'
+
+for project in decoded:
+    for operation in decoded[project]:
+        if operation in allowed_operations:
+            for unit in decoded[project][operation]:
+                value = int(decoded[project][operation][unit])
+
+                if unit in allowed_units:
+                    default_command = default_command + " --exclude " + project + '.*'
+
+                    if unit.lower() == "days":
+                        if value%7 == 0:
+                            unit = "weeks"
+                            value = value/7
+
+                    curator_settings[operation].setdefault(unit, {}).setdefault(value, []).append(project)
+                else:
+                    if unit.lower() == "hours":
+                        logger.error('time unit "hours" is currently not supported due to our current index level granularity is in days')
+                    else:
+                        logger.error('an unknown time unit of ' + unit + ' was provided... Record skipped')
+        else:
+            logger.error('an unsupported or unknown operation ' + operation + ' was provided... Record skipped')
+
+my_cron  = CronTab()
+default_job = my_cron.new(command=default_command, comment='Default generated job for curator')
+default_job.every().day()
+
+for operation in curator_settings:
+    for unit in curator_settings[operation]:
+        for value in curator_settings[operation][unit]:
+
+            base_cmd = '/usr/bin/curator --loglevel ERROR ' + connection_info + ' ' + operation + ' indices --timestring %Y.%m.%d'
+            tab_command = base_cmd + ' --older-than ' + str(value) + ' --time-unit ' + unit
+
+            for project in curator_settings[operation][unit][value]:
+                tab_command = tab_command + ' --prefix ' + project + '.'
+
+            job = my_cron.new(command=tab_command, comment='Generated job based on settings')
+            job.every().day()
+
+def run_all_jobs(joblist):
+    logger.info("logging-curator running [%d] jobs" % len(joblist))
+    for job in joblist:
+        logger.debug("logging-curator running job [%s]" % job)
+        output = job.run()
+        if output:
+            logger.info(output)
+        else:
+            logger.debug("logging-curator job [%s] was successful" % job)
+    logger.info("logging-curator run finish")
+
+# run jobs now
+run_all_jobs(my_cron)
+
+thehour = int(os.environ.get('CURATOR_CRON_HOUR', 0))
+theminute = int(os.environ.get('CURATOR_CRON_MINUTE', 0))
+
+while True:
+    # get time when next run should happen
+    nextruntime = time.mktime(datetime.now().replace(hour=thehour, minute=theminute,
+                                                     second=0, microsecond=0).timetuple())+86400
+    # sleep until then
+    time.sleep(nextruntime - time.time())
+    run_all_jobs(my_cron)

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -31,6 +31,12 @@ The deployer enables the system administrator to generate all of the
 necessary key/certs/secrets and deploy all of the logging components
 in concert.
 
+## Curator
+
+Curator allows the admin to remove old data from Elasticsearch on a per-project
+basis, and is configurable on a per-project basis.  See the parent README.md
+for details.
+
 # Using the Logging Deployer
 
 The deployer pod can enable deploying the full stack of the aggregated
@@ -331,6 +337,10 @@ Thus a separate ElasticSearch cluster and a separate Kibana are deployed
 to index and access operations logs. These deployments are set apart with
 the `-ops` included in their names. The same considerations apply as
 for the main cluster.
+
+### Curator
+
+It is recommended to have one curator for each Elasticsearch cluster.
 
 ## Using Kibana
 

--- a/deployment/templates/curator.yaml
+++ b/deployment/templates/curator.yaml
@@ -1,0 +1,129 @@
+apiVersion: "v1"
+kind: "Template"
+metadata:
+  name: logging-curator-template-maker
+  annotations:
+    description: "Template to create template for deploying curator"
+    tags: "infrastructure"
+objects:
+- apiVersion: "v1"
+  kind: "Template"
+  metadata:
+    name: logging-${CURATOR_DEPLOY_NAME}-template
+    annotations:
+      description: "Template for logging curator deployment."
+      tags: "infrastructure"
+    labels:
+      logging-infra: curator
+  labels:
+    logging-infra: curator
+    provider: openshift
+    component: ${CURATOR_DEPLOY_NAME}
+  objects:
+  -
+    apiVersion: v1
+    kind: "DeploymentConfig"
+    metadata:
+      name: "logging-${CURATOR_DEPLOY_NAME}"
+      labels:
+        provider: openshift
+        component: "${CURATOR_DEPLOY_NAME}"
+    spec:
+      replicas: 1
+      selector:
+        provider: openshift
+        component: "${CURATOR_DEPLOY_NAME}"
+      triggers:
+      - type: ConfigChange
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - curator
+          from:
+            kind: ImageStreamTag
+            name: logging-curator:latest
+      strategy:
+        resources: {}
+        rollingParams:
+          intervalSeconds: 1
+          timeoutSeconds: 600
+          updatePeriodSeconds: 1
+        type: Recreate
+      template:
+        metadata:
+          name: ${CURATOR_DEPLOY_NAME}
+          labels:
+            provider: openshift
+            component: "${CURATOR_DEPLOY_NAME}"
+        spec:
+          serviceAccountName: aggregated-logging-curator
+          containers:
+          - name: curator
+            image: logging-curator
+            imagePullPolicy: Always
+            resources:
+              limits:
+                cpu: 100m
+            volumeMounts:
+            - name: certs
+              mountPath: /etc/curator/keys
+              readOnly: true
+            env:
+            - name: "K8S_HOST_URL"
+              value: ${MASTER_URL}
+            - name: "ES_HOST"
+              value: ${ES_HOST}
+            - name: "ES_PORT"
+              value: ${ES_PORT}
+            - name: "ES_CLIENT_CERT"
+              value: ${ES_CLIENT_CERT}
+            - name: "ES_CLIENT_KEY"
+              value: ${ES_CLIENT_KEY}
+            - name: "ES_CA"
+              value: ${ES_CA}
+            - name: "DEFAULT_DAYS"
+              value: ${DEFAULT_DAYS}
+            - name: "CURATOR_CONF_LOCATION"
+              value: ${CURATOR_CONF_LOCATION}
+          volumes:
+          - name: certs
+            secret:
+              secretName: logging-${CURATOR_DEPLOY_NAME}
+parameters:
+-
+  name: CURATOR_DEPLOY_NAME
+  description: "Modify to differentiate regular and ops Curator."
+  value: "curator"
+-
+  description: "Internal url for reaching the master API to query pod labels"
+  name: MASTER_URL
+  value: "https://kubernetes.default.svc.cluster.local"
+-
+  description: "Hostname (or IP) for reaching ElasticSearch"
+  name: ES_HOST
+  value: "logging-es"
+-
+  description: "Port number for reaching ElasticSearch"
+  name: ES_PORT
+  value: "9200"
+-
+  description: "Location of client certificate for authenticating to ElasticSearch"
+  name: ES_CLIENT_CERT
+  value: "/etc/curator/keys/cert"
+-
+  description: "Location of client key for authenticating to ElasticSearch"
+  name: ES_CLIENT_KEY
+  value: "/etc/curator/keys/key"
+-
+  description: "Location of CA cert for validating connecting to ElasticSearch"
+  name: ES_CA
+  value: "/etc/curator/keys/ca"
+-
+  description: "The default number of days that logs will be retained for a project if an index management configuration for it is not provided"
+  name: DEFAULT_DAYS
+  value: "30"
+-
+  description: "Location of the directory containing the yaml settings file"
+  name: CURATOR_CONF_LOCATION
+  value: "/etc/curator"

--- a/deployment/templates/support-pre.yaml
+++ b/deployment/templates/support-pre.yaml
@@ -44,6 +44,13 @@ objects:
     secrets:
       - name: logging-fluentd
   -
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: aggregated-logging-curator
+    secrets:
+      - name: logging-curator
+  -
     apiVersion: "v1"
     kind: "Service"
     metadata:

--- a/deployment/templates/support.yaml
+++ b/deployment/templates/support.yaml
@@ -89,6 +89,15 @@ objects:
       name: logging-kibana
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-kibana:${IMAGE_VERSION}
+  -
+    apiVersion: v1
+    kind: ImageStream
+    metadata:
+      annotations:
+        openshift.io/image.insecureRepository: "true"
+      name: logging-curator
+    spec:
+      dockerImageRepository: ${IMAGE_PREFIX}logging-curator:${IMAGE_VERSION}
 parameters:
 -
   description: "A shared secret for the authentication proxy oauth client in front of Kibana"

--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -19,7 +19,7 @@ gateway:
   expected_nodes: ${RECOVER_EXPECTED_NODES}
   recover_after_time: ${RECOVER_AFTER_TIME}
 
-io.fabric8.elasticsearch.authentication.users: ["system.logging.kibana", "system.logging.fluentd"]
+io.fabric8.elasticsearch.authentication.users: ["system.logging.kibana", "system.logging.fluentd", "system.logging.curator"]
 
 cloud:
   k8s:
@@ -53,6 +53,7 @@ searchguard:
           admin: ["root"]
           fluentd: ["fluentd"]
           kibana: ["kibana"]
+          curator: ["curator"]
   ssl:
     transport:
       http:
@@ -64,11 +65,13 @@ searchguard:
         truststore_filepath: /etc/elasticsearch/keys/truststore
         truststore_password: tspass
   actionrequestfilter:
-    names: ["readonly", "fluentd", "kibana"]
+    names: ["readonly", "fluentd", "kibana", "curator"]
     readonly:
       allowed_actions: ["indices:data/read/*", "*monitor*"]
       forbidden_actions: ["cluster:*", "indices:admin*"]
     fluentd:
       allowed_actions: ["indices:data/write/*", "indices:admin/create"]
     kibana:
-     allowed_actions: ["indices:data/read/*", "*monitor*", "indices:admin/read", "indices:admin/mappings/fields/get*"]
+      allowed_actions: ["indices:data/read/*", "*monitor*", "indices:admin/read", "indices:admin/mappings/fields/get*"]
+    curator:
+      allowed_actions: ["indices:admin/get", "indices:admin/delete"]

--- a/elasticsearch/install.sh
+++ b/elasticsearch/install.sh
@@ -15,7 +15,7 @@ export CLUSTER_NAME=placeholder
 mkdir -p ${HOME}
 ln -s /usr/share/elasticsearch /usr/share/java/elasticsearch
 /usr/share/elasticsearch/bin/plugin -i com.floragunn/search-guard/0.5
-/usr/share/elasticsearch/bin/plugin -i io.fabric8.elasticsearch/openshift-elasticsearch-plugin/0.7
+/usr/share/elasticsearch/bin/plugin -i io.fabric8.elasticsearch/openshift-elasticsearch-plugin/0.8
 /usr/share/elasticsearch/bin/plugin -i io.fabric8/elasticsearch-cloud-kubernetes/1.3.0
 mkdir /elasticsearch
 chmod -R og+w /usr/share/java/elasticsearch ${HOME} /elasticsearch

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -4,14 +4,11 @@ set -ex
 
 prefix=${PREFIX:-${1:-openshift/origin-}}
 version=${VERSION:-${2:-latest}}
-docker build -t "${prefix}logging-fluentd:${version}"       ../fluentd/
-docker build -t "${prefix}logging-elasticsearch:${version}" ../elasticsearch/
-docker build -t "${prefix}logging-kibana:${version}"        ../kibana/
-docker build -t "${prefix}logging-deployment:${version}"    ../deployment/
-
+for component in fluentd elasticsearch kibana deployment curator ; do
+    docker build -t "${prefix}logging-${component}:${version}"       ../$component/
+done
 if [ -n "${PUSH:-$3}" ]; then
-	docker push "${prefix}logging-fluentd:${version}"
-	docker push "${prefix}logging-elasticsearch:${version}"
-	docker push "${prefix}logging-kibana:${version}"
-	docker push "${prefix}logging-deployment:${version}"
+    for component in fluentd elasticsearch kibana deployment curator ; do
+	    docker push "${prefix}logging-${component}:${version}"
+    done
 fi

--- a/hack/templates/dev-builds.yaml
+++ b/hack/templates/dev-builds.yaml
@@ -50,6 +50,13 @@ objects:
   kind: ImageStream
   metadata:
     labels:
+      build: logging-curator
+    name: logging-curator
+  spec: {}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
       build: logging-auth-proxy
     name: logging-auth-proxy
   spec: {}
@@ -156,6 +163,32 @@ objects:
     resources: {}
     source:
       contextDir: kibana
+      git:
+        uri: ${LOGGING_FORK_URL}
+        ref: ${LOGGING_FORK_BRANCH}
+      type: Git
+    strategy:
+      dockerStrategy:
+        from:
+          kind: DockerImage
+          name: openshift/base-centos7
+      type: Docker
+    triggers:
+    - type: ConfigChange
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      build: logging-curator
+    name: logging-curator
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: logging-curator:latest
+    resources: {}
+    source:
+      contextDir: curator
       git:
         uri: ${LOGGING_FORK_URL}
         ref: ${LOGGING_FORK_BRANCH}

--- a/hack/testing/README.md
+++ b/hack/testing/README.md
@@ -38,6 +38,31 @@ to have been created (based on the logs of the Elasticsearch pods).
 This Go script will query the appropriate ES pod (if an OPS cluster was used)
 and check the local log files for the each result message.
 
+## check-curator.sh
+
+The purpose of this script is to verify the curator pod is working.  It will
+add curator configs for the following projects and trimming parameters:
+
+* project "project-dev" logs should be deleted if they are more than a day old
+* project "project-qe" logs should be deleted if they are more than a week old
+* project "project-prod" logs should be deleted if they are more than 4 weeks old
+* project ".operations" logs should be deleted if they are more than 2 months
+old
+
+The script will create ES indices for these projects using the fluentd user
+credentials (which is allowed to create ES indices and records).  One index per
+project will be for "today", and one will be for outside of the time window for
+the project as described above.
+
+The script will redeploy the curator pod using the trimming parameters as
+described above and wait for the new curator pod with the new config to be
+running.
+
+The script will then use the curator credentials to run curator to list the
+indices afterwards, and verify that the indices created for "today" are still
+present, and the indices created outside of the time window for each project
+have been removed.
+
 ## Environment values for testing
 
 In addition to providing the argument `true` to `e2e-test.sh` to indicate that

--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -19,13 +19,13 @@ else
 fi
 
 if [[ "$CLUSTER" == "true" ]]; then
-  NEEDED_COMPONENTS=("logging-es-[a-ZA-Z0-9]+?0" "logging-kibana0" "logging-fluentd0" "logging-es-ops-[a-zA-Z0-9]+?0" "logging-kibana-ops0")
+  NEEDED_COMPONENTS=("logging-es-[a-ZA-Z0-9]+?0" "logging-kibana0" "logging-fluentd0" "logging-es-ops-[a-zA-Z0-9]+?0" "logging-kibana-ops0" "logging-curator0")
 else
-  NEEDED_COMPONENTS=("logging-es-[a-zA-Z0-9]+?0" "logging-kibana0" "logging-fluentd0")
+  NEEDED_COMPONENTS=("logging-es-[a-zA-Z0-9]+?0" "logging-kibana0" "logging-fluentd0" "logging-curator0")
 fi
 
 TEST_DIVIDER="-------------------------------------------------------"
-NEEDED_STREAMS=("logging-fluentd" "logging-elasticsearch" "logging-auth-proxy" "logging-kibana")
+NEEDED_STREAMS=("logging-fluentd" "logging-elasticsearch" "logging-auth-proxy" "logging-kibana" "logging-curator")
 COMPONENTS_COUNT=${#NEEDED_COMPONENTS[@]}
 STREAMS_COUNT=${#NEEDED_STREAMS[@]}
 
@@ -41,7 +41,7 @@ if [[ $IS_COUNT -ne $STREAMS_COUNT ]]; then
   echo "Error - $IS_MESSAGE"
   EXIT_CODE=1
 
-  # check for elasticsearch, kibana, auth-proxy, and kibana images
+  # check for elasticsearch, kibana, auth-proxy, kibana, and curator images
   for stream in "${NEEDED_STREAMS[@]}"; do
     if [[ ! ( ${FOUND_STREAMS[@]} =~ $stream ) ]]; then
       echo " ! image stream $stream is missing..."

--- a/hack/testing/check-curator.sh
+++ b/hack/testing/check-curator.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+if [[ $VERBOSE ]]; then
+  set -ex
+else
+  set -e
+fi
+
+if [[ $# -ne 1 || "$1" = "false" ]]; then
+  # assuming not using OPS cluster
+  CLUSTER="false"
+else
+  CLUSTER="$1"
+  ops="-ops"
+fi
+
+TEST_DIVIDER="------------------------------------------"
+
+# projects:
+# project-dev-YYYY.mm.dd delete 24 hours
+# project-qe-YYYY.mm.dd delete 7 days
+# project-prod-YYYY.mm.dd delete 4 weeks
+# .operations-YYYY.mm.dd delete 2 months
+
+# use the fluentd credentials to add records and indices for these projects
+# oc get secret logging-fluentd --template='{{.data.ca}}' | base64 -d > ca-fluentd
+# ca=./ca-fluentd
+# oc get secret logging-fluentd --template='{{.data.key}}' | base64 -d > key-fluentd
+# key=./key-fluentd
+# oc get secret logging-fluentd --template='{{.data.cert}}' | base64 -d > cert-fluentd
+# cert=./cert-fluentd
+fpod=`oc get pods | awk '/-deploy/ {next}; /-build/ {next}; /^logging-fluentd-.* Running / {print $1}'`
+
+# where "yesterday", "today", etc. are the dates in UTC in YYYY.mm.dd format
+tf='%Y.%m.%d'
+today=`date -u +"$tf"`
+yesterday=`date -u +"$tf" --date=yesterday`
+lastweek=`date -u +"$tf" --date="last week"`
+fourweeksago=`date -u +"$tf" --date="4 weeks ago"`
+thirtydaysago=`date -u +"$tf" --date="30 days ago"`
+# When is a month not a month?  When it is a curator month!  When you use
+# month based trimming, curator starts counting at the first day of the
+# current month, not the current day of the current month.  For example, if
+# today is April 15, and you want to delete indices that are 2 months older
+# than today (--time-unit months --older-than 2 --timestring %Y.%m.%d),
+# curator doesn't delete indices that are dated older than February 15, it
+# deletes indices older than _February 1_.  That is, it goes back to the
+# first day of the current month, _then_ goes back two whole months from
+# that date.
+# If you want to be exact with curator, it is best to use
+# day based trimming e.g. --time-unit days --older-than 60 --timestring %Y.%m.%d
+# There is apparently no way to tell curator to delete indices exactly N
+# months older than the current date.
+twomonthsago=`date -u +"$tf" --date="$(date +%Y-%m-1) -2 months -1 day"`
+# project-dev-yesterday project-dev-today
+# project-qe-lastweek project-qe-today
+# project-prod-4weeksago project-today
+# .operations-2monthsago .operations-today
+
+add_message_to_index() {
+    # index is $1
+    # message is $2
+    message=${2:-"curatortest message"}
+    ca=/etc/fluent/keys/ca
+    cert=/etc/fluent/keys/cert
+    key=/etc/fluent/keys/key
+    url="https://logging-es${ops}:9200/$1/curatortest/"
+    oc exec $fpod -- curl -s --cacert $ca --cert $cert --key $key -XPOST "$url" -d '{
+    "message" : "'"$message"'"
+}'
+}
+
+set -- project-dev "$today" project-dev "$yesterday" project-qe "$today" project-qe "$lastweek" project-prod "$today" project-prod "$fourweeksago" .operations "$today" .operations "$twomonthsago" default-index "$today" default-index "$thirtydaysago"
+while [ -n "$1" ] ; do
+    proj="$1" ; shift
+    add_message_to_index "${proj}.$1" "$proj $1 message"
+    shift
+done
+
+# get current curator pod
+curpod=`oc get pods | awk -v "pat=^logging-curator${ops}-.* Running" '/-deploy/ {next}; /-build/ {next}; $0 ~ pat {print $1}'`
+# show current indices
+echo current indices are:
+oc exec $curpod -- curator --host logging-es${ops} --use_ssl --certificate /etc/curator/keys/ca \
+   --client-cert /etc/curator/keys/cert --client-key /etc/curator/keys/key --loglevel ERROR \
+   show indices --all-indices
+# add the curator config yaml settings file
+curtest=`mktemp --suffix=.yaml`
+cat > $curtest <<EOF
+project-dev:
+  delete:
+    days: 1
+project-qe:
+  delete:
+    days: 7
+project-prod:
+  delete:
+    weeks: 4
+.operations:
+  delete:
+    months: 2
+EOF
+oc delete secret curator-config || echo no such secret curator-config - ignore
+oc secrets new curator-config settings=$curtest
+oc volumes dc/logging-curator --add --type=secret --secret-name=curator-config --mount-path=/etc/curator --name=curator-config --overwrite
+# scale down dc
+oc scale --replicas=0 dc logging-curator
+# wait for pod to go away
+ii=120
+incr=10
+while [ $ii -gt 0 ] ; do
+    if oc describe pod/$curpod > /dev/null ; then
+        echo $curpod still running
+    else
+        break
+    fi
+    sleep $incr
+    ii=`expr $ii - $incr`
+done
+# scale up dc
+oc scale --replicas=1 dc logging-curator
+# wait for pod to start
+ii=120
+incr=10
+while [ $ii -gt 0 ] ; do
+    curpod=`oc get pods | awk -v "pat=^logging-curator${ops}-.* Running" '/-deploy/ {next}; /-build/ {next}; $0 ~ pat {print $1}'`
+    if [ -n "$curpod" ] ; then
+        break
+    fi
+    sleep $incr
+    ii=`expr $ii - $incr`
+done
+# query ES
+curout=`mktemp`
+oc exec $curpod -- curator --host logging-es${ops} --use_ssl --certificate /etc/curator/keys/ca \
+   --client-cert /etc/curator/keys/cert --client-key /etc/curator/keys/key --loglevel ERROR \
+   show indices --all-indices > $curout 2>&1
+# verify that project-dev-yesterday project-qe-lastweek project-prod-fourweeksago .operations-twomonthsago are deleted
+set -- project-dev "$today" project-dev "$yesterday" project-qe "$today" project-qe "$lastweek" project-prod "$today" project-prod "$fourweeksago" .operations "$today" .operations "$twomonthsago" default-index "$today" default-index "$thirtydaysago"
+rc=0
+while [ -n "$1" ] ; do
+    proj="$1" ; shift
+    idx="${proj}.$1"
+    if [ "$1" = "$today" ] ; then
+        # index must be present
+        if grep \^"$idx"\$ $curout > /dev/null 2>&1 ; then
+            echo good - index "$idx" is present
+        else
+            echo ERROR: index "$idx" is missing
+            rc=1
+        fi
+    else
+        # index must be absent
+        if grep \^"$idx"\$ $curout > /dev/null 2>&1 ; then
+            echo ERROR: index "$idx" was not deleted
+            rc=1
+        else
+            echo good - index "$idx" is missing
+        fi
+    fi
+    shift
+done
+#rm -f $curout
+echo output is $curout
+exit $rc

--- a/hack/testing/e2e-test.sh
+++ b/hack/testing/e2e-test.sh
@@ -21,3 +21,10 @@ if [[ $? -eq 0 ]]; then
 else
   echo "Errors found when checking installation of the EFK stack -- not checking log entry matches. Please resolve errors and retest."
 fi
+
+if [[ $? -eq 0 ]]; then
+  echo "Checking curator ..."
+  KIBANA_CLUSTER_SIZE=$KIBANA_CLUSTER_SIZE KIBANA_OPS_CLUSTER_SIZE=$KIBANA_OPS_CLUSTER_SIZE ES_CLUSTER_SIZE=$ES_CLUSTER_SIZE ES_OPS_CLUSTER_SIZE=$ES_OPS_CLUSTER_SIZE ./check-curator.sh "$CLUSTER"
+else
+  echo "Errors found when checking installation of the EFK stack or checking log matches -- not checking curator. Please resolve errors and retest."
+fi


### PR DESCRIPTION
Curator allows the admin to remove old data from Elasticsearch
on a per-project basis.  It runs as a separate pod within the
logging project.  See the README.md for more details about how
it is configured and run.