### PR TITLE
Allow fluentd to send copies of logs to another Elasticsearch

### DIFF
--- a/deployment/templates/fluentd.yaml
+++ b/deployment/templates/fluentd.yaml
@@ -86,6 +86,40 @@ objects:
               value: ${OPS_CLIENT_KEY}
             - name: "OPS_CA"
               value: ${OPS_CA}
+            - name: "ES_COPY"
+              value: ${ES_COPY}
+            - name: "ES_COPY_HOST"
+              value: ${ES_COPY_HOST}
+            - name: "ES_COPY_PORT"
+              value: ${ES_COPY_PORT}
+            - name: "ES_COPY_SCHEME"
+              value: ${ES_COPY_SCHEME}
+            - name: "ES_COPY_CLIENT_CERT"
+              value: ${ES_COPY_CLIENT_CERT}
+            - name: "ES_COPY_CLIENT_KEY"
+              value: ${ES_COPY_CLIENT_KEY}
+            - name: "ES_COPY_CA"
+              value: ${ES_COPY_CA}
+            - name: "ES_COPY_USERNAME"
+              value: ${ES_COPY_USERNAME}
+            - name: "ES_COPY_PASSWORD"
+              value: ${ES_COPY_PASSWORD}
+            - name: "OPS_COPY_HOST"
+              value: ${OPS_COPY_HOST}
+            - name: "OPS_COPY_PORT"
+              value: ${OPS_COPY_PORT}
+            - name: "OPS_COPY_SCHEME"
+              value: ${OPS_COPY_SCHEME}
+            - name: "OPS_COPY_CLIENT_CERT"
+              value: ${OPS_COPY_CLIENT_CERT}
+            - name: "OPS_COPY_CLIENT_KEY"
+              value: ${OPS_COPY_CLIENT_KEY}
+            - name: "OPS_COPY_CA"
+              value: ${OPS_COPY_CA}
+            - name: "OPS_COPY_USERNAME"
+              value: ${OPS_COPY_USERNAME}
+            - name: "OPS_COPY_PASSWORD"
+              value: ${OPS_COPY_PASSWORD}
           volumes:
           - name: varlog
             hostPath:
@@ -121,7 +155,7 @@ parameters:
   name: ES_CLIENT_KEY
   value: "/etc/fluent/keys/key"
 -
-  description: "Location of CA cert for validating connectiong to ElasticSearch to write logs"
+  description: "Location of CA cert for validating connection to ElasticSearch to write logs"
   name: ES_CA
   value: "/etc/fluent/keys/ca"
 -
@@ -141,7 +175,7 @@ parameters:
   name: OPS_CLIENT_KEY
   value: "/etc/fluent/keys/key"
 -
-  description: "Location of CA cert for validating connectiong to ElasticSearch to write cluster logs"
+  description: "Location of CA cert for validating connection to ElasticSearch to write cluster logs"
   name: OPS_CA
   value: "/etc/fluent/keys/ca"
 -
@@ -151,4 +185,72 @@ parameters:
 -
   description: "The image version for the Fluentd image to use"
   name: IMAGE_VERSION
+  value: ""
+-
+  description: "Send a copy of the logs to an additional Elasticsearch instance."
+  name: ES_COPY
+  value: "false"
+-
+  description: "Hostname (or IP) for additional ElasticSearch"
+  name: ES_COPY_HOST
+  value: ""
+-
+  description: "Port number for additional ElasticSearch"
+  name: ES_COPY_PORT
+  value: ""
+-
+  description: "URL scheme for additional ElasticSearch - http or https - default is https"
+  name: ES_COPY_SCHEME
+  value: "https"
+-
+  description: "Location of client certificate for authenticating to additional ElasticSearch"
+  name: ES_COPY_CLIENT_CERT
+  value: ""
+-
+  description: "Location of client key for authenticating to additional ElasticSearch"
+  name: ES_COPY_CLIENT_KEY
+  value: ""
+-
+  description: "Location of CA cert for validating connection to additional ElasticSearch"
+  name: ES_COPY_CA
+  value: ""
+-
+  description: "Username for username/password auth to connection to additional ElasticSearch"
+  name: ES_COPY_USERNAME
+  value: ""
+-
+  description: "Password for username/password auth to connection to additional ElasticSearch"
+  name: ES_COPY_PASSWORD
+  value: ""
+-
+  description: "Hostname (or IP) for additional ElasticSearch to write cluster logs"
+  name: OPS_COPY_HOST
+  value: ""
+-
+  description: "Port number for additional ElasticSearch to write cluster logs"
+  name: OPS_COPY_PORT
+  value: ""
+-
+  description: "URL scheme for additional ElasticSearch to write cluster logs - http or https - default is https"
+  name: OPS_COPY_SCHEME
+  value: "https"
+-
+  description: "Location of client certificate for authenticating to additional ElasticSearch to write cluster logs"
+  name: OPS_COPY_CLIENT_CERT
+  value: ""
+-
+  description: "Location of client key for authenticating to additional ElasticSearch to write cluster logs"
+  name: OPS_COPY_CLIENT_KEY
+  value: ""
+-
+  description: "Location of CA cert for validating connectiong to additional ElasticSearch to write cluster logs"
+  name: OPS_COPY_CA
+  value: ""
+-
+  description: "Username for username/password auth to connection to additional ElasticSearch to write cluster logs"
+  name: OPS_COPY_USERNAME
+  value: ""
+-
+  description: "Password for username/password auth to connection to additional ElasticSearch to write cluster logs"
+  name: OPS_COPY_PASSWORD
   value: ""

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -28,7 +28,9 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 
 ADD fluent.conf /etc/fluent/fluent.conf
 ADD configs.d/ /etc/fluent/configs.d/
-ADD run.sh generate_throttle_configs.rb ${HOME}/
+ADD run.sh generate_throttle_configs.rb \
+    fluentd_es_copy_config.conf fluentd_es_ops_copy_config.conf \
+    ${HOME}/
 
 WORKDIR ${HOME}
 

--- a/fluentd/configs.d/output/applications.conf
+++ b/fluentd/configs.d/output/applications.conf
@@ -1,17 +1,5 @@
 <match **>
-   @type elasticsearch_dynamic
-   host "#{ENV['ES_HOST']}"
-   port "#{ENV['ES_PORT']}"
-   scheme https
-   index_name ${record['kubernetes_namespace_name']}.${Time.at(time).getutc.strftime(@logstash_dateformat)}
-   user fluentd
-   password changeme
-
-   client_key "#{ENV['ES_CLIENT_KEY']}"
-   client_cert "#{ENV['ES_CLIENT_CERT']}"
-   ca_file "#{ENV['ES_CA']}"
-     
-   flush_interval 5s
-   max_retry_wait 300
-   disable_retry_limit
+   @type copy
+   @include fluentd_es_config.conf
+   @include fluentd_es_copy_config.conf
 </match>

--- a/fluentd/configs.d/output/fluentd_es_config.conf
+++ b/fluentd/configs.d/output/fluentd_es_config.conf
@@ -1,0 +1,17 @@
+    <store>
+      @type elasticsearch_dynamic
+      host "#{ENV['ES_HOST']}"
+      port "#{ENV['ES_PORT']}"
+      scheme https
+      index_name ${record['kubernetes_namespace_name']}.${Time.at(time).getutc.strftime(@logstash_dateformat)}
+      user fluentd
+      password changeme
+
+      client_key "#{ENV['ES_CLIENT_KEY']}"
+      client_cert "#{ENV['ES_CLIENT_CERT']}"
+      ca_file "#{ENV['ES_CA']}"
+
+      flush_interval 5s
+      max_retry_wait 300
+      disable_retry_limit
+    </store>

--- a/fluentd/configs.d/output/fluentd_es_ops_config.conf
+++ b/fluentd/configs.d/output/fluentd_es_ops_config.conf
@@ -1,0 +1,17 @@
+    <store>
+      @type elasticsearch_dynamic
+      host "#{ENV['OPS_HOST']}"
+      port "#{ENV['OPS_PORT']}"
+      scheme https
+      index_name .operations.${record['time'].nil? ? Time.at(time).getutc.strftime(@logstash_dateformat) : Time.parse(record['time']).getutc.strftime(@logstash_dateformat)}
+      user fluentd
+      password changeme
+
+      client_key "#{ENV['OPS_CLIENT_KEY']}"
+      client_cert "#{ENV['OPS_CLIENT_CERT']}"
+      ca_file "#{ENV['OPS_CA']}"
+
+      flush_interval 5s
+      max_retry_wait 300
+      disable_retry_limit
+    </store>

--- a/fluentd/configs.d/output/operations.conf
+++ b/fluentd/configs.d/output/operations.conf
@@ -1,18 +1,5 @@
 <match system.var.log** **_default_** **_openshift_** **_openshift-infra_**>
-  @type elasticsearch_dynamic
-  host "#{ENV['OPS_HOST']}"
-  port "#{ENV['OPS_PORT']}"
-  scheme https
-  index_name .operations.${record['time'].nil? ? Time.at(time).getutc.strftime(@logstash_dateformat) : Time.parse(record['time']).getutc.strftime(@logstash_dateformat)}
-
-  user fluentd
-  password changeme
-
-  client_key "#{ENV['OPS_CLIENT_KEY']}"
-  client_cert "#{ENV['OPS_CLIENT_CERT']}"
-  ca_file "#{ENV['OPS_CA']}"
-
-  flush_interval 5s
-  max_retry_wait 300
-  disable_retry_limit
+  @type copy
+  @include fluentd_es_ops_config.conf
+  @include fluentd_es_ops_copy_config.conf
 </match>

--- a/fluentd/fluentd_es_copy_config.conf
+++ b/fluentd/fluentd_es_copy_config.conf
@@ -1,0 +1,17 @@
+    <store>
+      @type elasticsearch_dynamic
+      host "#{ENV['ES_COPY_HOST']}"
+      port "#{ENV['ES_COPY_PORT']}"
+      scheme "#{ENV['ES_COPY_SCHEME']}"
+      index_name ${record['kubernetes_namespace_name']}.${Time.at(time).getutc.strftime(@logstash_dateformat)}
+      user "#{ENV['ES_COPY_USERNAME']}"
+      password "#{ENV['ES_COPY_PASSWORD']}"
+
+      client_key "#{ENV['ES_COPY_CLIENT_KEY']}"
+      client_cert "#{ENV['ES_COPY_CLIENT_CERT']}"
+      ca_file "#{ENV['ES_COPY_CA']}"
+
+      flush_interval 5s
+      max_retry_wait 300
+      disable_retry_limit
+    </store>

--- a/fluentd/fluentd_es_ops_copy_config.conf
+++ b/fluentd/fluentd_es_ops_copy_config.conf
@@ -1,0 +1,17 @@
+    <store>
+      @type elasticsearch_dynamic
+      host "#{ENV['OPS_COPY_HOST']}"
+      port "#{ENV['OPS_COPY_PORT']}"
+      scheme "#{ENV['OPS_COPY_SCHEME']}"
+      index_name .operations.${record['time'].nil? ? Time.at(time).getutc.strftime(@logstash_dateformat) : Time.parse(record['time']).getutc.strftime(@logstash_dateformat)}
+      user "#{ENV['OPS_COPY_USERNAME']}"
+      password "#{ENV['OPS_COPY_PASSWORD']}"
+
+      client_key "#{ENV['OPS_COPY_CLIENT_KEY']}"
+      client_cert "#{ENV['OPS_COPY_CLIENT_CERT']}"
+      ca_file "#{ENV['OPS_COPY_CA']}"
+
+      flush_interval 5s
+      max_retry_wait 300
+      disable_retry_limit
+    </store>

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -1,12 +1,41 @@
+#!/bin/bash
+
 if [[ $VERBOSE ]]; then
   set -ex
+  fluentdargs="-vv"
 else
   set -e
+  fluentdargs=  
 fi
 
-mkdir -p /etc/fluent/configs.d/input/docker
-mkdir -p /etc/fluent/configs.d/input/syslog
+OPS_COPY_HOST="${OPS_COPY_HOST:-$ES_COPY_HOST}"
+OPS_COPY_PORT="${OPS_COPY_PORT:-$ES_COPY_PORT}"
+OPS_COPY_SCHEME="${OPS_COPY_SCHEME:-$ES_COPY_SCHEME}"
+OPS_COPY_CLIENT_CERT="${OPS_COPY_CLIENT_CERT:-$ES_COPY_CLIENT_CERT}"
+OPS_COPY_CLIENT_KEY="${OPS_COPY_CLIENT_KEY:-$ES_COPY_CLIENT_KEY}"
+OPS_COPY_CA="${OPS_COPY_CA:-$ES_COPY_CA}"
+OPS_COPY_USERNAME="${OPS_COPY_USERNAME:-$ES_COPY_USERNAME}"
+OPS_COPY_PASSWORD="${OPS_COPY_PASSWORD:-$ES_COPY_PASSWORD}"
+export OPS_COPY_HOST OPS_COPY_PORT OPS_COPY_SCHEME OPS_COPY_CLIENT_CERT \
+       OPS_COPY_CLIENT_KEY OPS_COPY_CA OPS_COPY_USERNAME OPS_COPY_PASSWORD
+
+CFG_IN_DIR=/etc/fluent/configs.d/input
+CFG_OUT_DIR=/etc/fluent/configs.d/output
+
+mkdir -p $CFG_IN_DIR/docker
+mkdir -p $CFG_IN_DIR/syslog
 
 ruby generate_throttle_configs.rb
 
-fluentd
+if [ "$ES_COPY" = "true" ] ; then
+    # user wants to split the output of fluentd into two different elasticsearch
+    # user will provide the necessary COPY environment variables as above
+    cp $HOME/fluentd_es_copy_config.conf $HOME/fluentd_es_ops_copy_config.conf $CFG_OUT_DIR
+else
+    # create empty files for the ES copy config
+    rm -f $CFG_OUT_DIR/fluentd_es_copy_config.conf $CFG_OUT_DIR/fluentd_es_ops_copy_config.conf
+    touch $CFG_OUT_DIR/fluentd_es_copy_config.conf $CFG_OUT_DIR/fluentd_es_ops_copy_config.conf
+fi
+
+
+fluentd $fluentdargs

--- a/hack/testing/test-es-copy.sh
+++ b/hack/testing/test-es-copy.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+
+if [[ $VERBOSE ]]; then
+  set -ex
+else
+  set -e
+  VERBOSE=
+fi
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 1 || "$1" = "false" ]]; then
+  # assuming not using OPS cluster
+  CLUSTER="false"
+  ops=
+else
+  CLUSTER="$1"
+  ops="-ops"
+fi
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-${TMPDIR:-/tmp}/origin-aggregated-logging}
+if [ ! -d $ARTIFACT_DIR ] ; then
+    mkdir -p $ARTIFACT_DIR
+fi
+
+get_running_pod() {
+    # $1 is component for selector
+    oc get pods -l component=$1 | awk -v sel=$1 '$1 ~ sel && $3 == "Running" {print $1}'
+}
+
+wait_for_pod_ACTION() {
+    # action is $1 - start or stop
+    # $2 - if action is stop, $2 is the pod name
+    #    - if action is start, $2 is the component selector
+    ii=120
+    incr=10
+    if [ $1 = start ] ; then
+        curpod=`get_running_pod $2`
+    else
+        curpod=$2
+    fi
+    while [ $ii -gt 0 ] ; do
+        if [ $1 = stop ] && oc describe pod/$curpod > /dev/null 2>&1 ; then
+            if [ -n "$VERBOSE" ] ; then
+                echo pod $curpod still running
+            fi
+        elif [ $1 = start ] && [ -z "$curpod" ] ; then
+            if [ -n "$VERBOSE" ] ; then
+                echo pod for component=$2 not running yet
+            fi
+        else
+            break # pod is either started or stopped
+        fi
+        sleep $incr
+        ii=`expr $ii - $incr`
+        if [ $1 = start ] ; then
+            curpod=`get_running_pod $2`
+        fi
+    done
+    if [ $ii -le 0 ] ; then
+        echo ERROR: pod $2 not in state $1 after 2 minutes
+        oc get pods
+        return 1
+    fi
+    return 0
+}
+
+write_and_verify_logs() {
+    # expected number of matches
+    expected=$1
+
+    # write a log message to the test app
+    logmessage=`uuidgen`
+    curl -s http://$testip:$testport/$logmessage > /dev/null 2>&1 || echo will generate a 404
+
+    # write a message to the system log
+    logmessage2=`uuidgen`
+    logger -i -p local6.info -t $logmessage2 $logmessage2
+
+    # wait a bit for fluentd + es to digest
+    sleep 20
+
+    # get current kibana pod
+    kpod=`get_running_pod kibana`
+    if [ -z "$kpod" ] ; then
+        echo Error: no kibana pod found
+        oc get pods
+        return 1
+    fi
+
+    rc=0
+    # count the matching records
+    nrecs=`oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
+           https://logging-es:9200/test*/_count\?q=message:$logmessage | \
+           python -c 'import json; import sys; print json.loads(sys.stdin.read())["count"]'`
+    if [ "$nrecs" = $expected ] ; then
+        if [ -n "$VERBOSE" ] ; then
+            echo good - found $expected records for $logmessage
+        fi
+    else
+        echo Error: found $nrecs for $logmessage - expected $expected
+        oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
+           https://logging-es:9200/test*/_count\?q=message:$logmessage | python -mjson.tool
+        oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
+           https://logging-es:9200/test*/_search\?q=message:$logmessage | python -mjson.tool
+        rc=1
+    fi
+
+    nrecs=`oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
+           https://logging-es${ops}:9200/.operations*/_count\?q=ident:$logmessage2 | \
+           python -c 'import json; import sys; print json.loads(sys.stdin.read())["count"]'`
+    if [ "$nrecs" = $expected ] ; then
+        if [ -n "$VERBOSE" ] ; then
+            echo good - found $expected records for $logmessage2
+        fi
+    else
+        echo Error: found $nrecs for $logmessage2 - expected $expected
+        oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
+           https://logging-es${ops}:9200/.operations*/_count\?q=ident:$logmessage2 | python -mjson.tool
+        oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
+           https://logging-es${ops}:9200/.operations*/_search\?q=ident:$logmessage2 | python -mjson.tool
+        rc=1
+    fi
+
+    return $rc
+}
+
+TEST_DIVIDER="------------------------------------------"
+
+# this is the OpenShift origin sample app
+testip=$(oc get -n test --output-version=v1beta3 --template="{{ .spec.portalIP }}" service frontend)
+testport=5432
+
+# configure fluentd to just use the same ES instance for the copy
+# cause messages to be written to a container - verify that ES contains
+# two copies
+# cause messages to be written to the system log - verify that OPS contains
+# two copies
+
+fpod=`get_running_pod fluentd`
+
+# save original template config
+origconfig=`mktemp`
+oc get template logging-fluentd-template -o yaml > $origconfig
+
+nocopy=`mktemp`
+# strip off the copy settings, if any
+sed '/_COPY/,/value/d' $origconfig > $nocopy
+# for every ES_ or OPS_ setting, create a copy called ES_COPY_ or OPS_COPY_
+envpatch=`mktemp`
+sed -n '/^        - env:/,/^          image:/ {
+/^          image:/d
+/^        - env:/d
+/name: K8S_HOST_URL/,/value/d
+s/ES_/ES_COPY_/
+s/OPS_/OPS_COPY_/
+p
+}' $nocopy > $envpatch
+
+# add the scheme
+cat >> $envpatch <<EOF
+          - name: ES_COPY
+            value: "true"
+          - name: ES_COPY_SCHEME
+            value: https
+          - name: OPS_COPY_SCHEME
+            value: https
+          - name: VERBOSE
+            value: "true"
+EOF
+
+# add this back to the dc config
+cat $nocopy | \
+    sed '/^        - env:/r '$envpatch | \
+    oc replace -f -
+
+rm -f $envpatch $nocopy
+
+# delete daemonset which also stops fluentd
+oc delete daemonset logging-fluentd
+# wait for fluentd to stop
+wait_for_pod_ACTION stop $fpod
+# create the daemonset which will also start fluentd
+oc process logging-fluentd-template | oc create -f -
+# wait for fluentd to start
+wait_for_pod_ACTION start fluentd
+
+fpod=`get_running_pod fluentd`
+
+write_and_verify_logs 2 || {
+    oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1
+    exit 1
+}
+
+# put back original configuration
+oc replace --force -f $origconfig
+rm -f $origconfig
+
+# delete daemonset which also stops fluentd
+oc delete daemonset logging-fluentd
+# wait for fluentd to stop
+wait_for_pod_ACTION stop $fpod
+# create the daemonset which will also start fluentd
+oc process logging-fluentd-template | oc create -f -
+# wait for fluentd to start
+wait_for_pod_ACTION start fluentd
+
+fpod=`get_running_pod fluentd`
+
+write_and_verify_logs 1 || {
+    oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1
+    exit 1
+}


### PR DESCRIPTION
If the environment variable ES_COPY is set, fluentd will send a copy
of the logs to another Elasticsearch.  The settings for the copy are
just like the current ES_HOST, etc. and OPS_HOST, etc. settings, except
that they add _COPY: ES_COPY_HOST, OPS_COPY_HOST, etc.
There are some additional parameters added:
ES_COPY_SCHEME, OPS_COPY_SCHEME - can use either http or https - defaults to https
ES_COPY_USERNAME, OPS_COPY_USERNAME - user name to use to authenticate
    to elasticsearch using username/password auth
ES_COPY_PASSWORD, OPS_COPY_PASSWORD - password to use to authenticate
    to elasticsearch using username/password auth