### PR TITLE
Upgrade to custom build of Seach-Guard 0.5.1

### DIFF
--- a/elasticsearch/install.sh
+++ b/elasticsearch/install.sh
@@ -14,7 +14,7 @@ export CLUSTER_NAME=placeholder
 
 mkdir -p ${HOME}
 ln -s /usr/share/elasticsearch /usr/share/java/elasticsearch
-/usr/share/elasticsearch/bin/plugin -i com.floragunn/search-guard/0.5
+/usr/share/elasticsearch/bin/plugin -i com.floragunn/search-guard/0.5.1 -url https://github.com/lukas-vlcek/origin-aggregated-logging/releases/download/v0.1/search-guard-0.5.1.zip 
 /usr/share/elasticsearch/bin/plugin -i io.fabric8.elasticsearch/openshift-elasticsearch-plugin/0.11
 /usr/share/elasticsearch/bin/plugin -i io.fabric8/elasticsearch-cloud-kubernetes/1.3.0
 mkdir /elasticsearch


### PR DESCRIPTION
Custom SG build found at https://bintray.com/artifact/download/lukas-vlcek/Search-Guard-Custom/search-guard-0.5.1.zip is based on https://github.com/floragunncom/search-guard/pull/85

Basic smoke test performed using @richm [script](https://github.com/richm/scripts/blob/ca22e1a217d73942e953b086dbb0d4e21c4e6f28/oshift-logging-setup.sh).

Before the script was executed I setup a few evn variables:
````
export GITHUB_REPO=lukas-vlcek
export GITHUB_BRANCH=sg-update
export OS_VOL_DIR_BASE=/home/vagrant/logging
````

In the end the script executes several queries against ES node which includes SG logic.

When elasticsearch pod is build the following can be seen in the log:
````
+ /usr/share/elasticsearch/bin/plugin -i search-guard -url https://bintray.com/artifact/download/lukas-vlcek/Search-Guard-Custom/search-guard-0.5.1.zip
-> Installing search-guard...
Trying https://bintray.com/artifact/download/lukas-vlcek/Search-Guard-Custom/search-guard-0.5.1.zip...
Downloading ..........................................................DONE
Installed search-guard into /usr/share/elasticsearch/plugins/search-guard
````

And we can also check installed plugins using:

````
$ curl -s -k --cert ./cert --key ./key 'https://localhost:9200/_cat/plugins?v'
name               component                      version            type url 
Master Pandemonium cloud-kubernetes               1.3.0              j        
Master Pandemonium searchguard                    0.5.1              j        
Master Pandemonium openshift-elasticsearch-plugin ${project.version} j    
````