### PR TITLE
Remove wildcard from /var/log/messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,50 @@ Mount the created secret to your Fluentd container
 ```
 oc volumes dc/logging-fluentd --add --type=secret --secret-name=fluentd-throttle --mount-path=/etc/throttle-settings --name=throttle-settings --overwrite
 ```
+
+## Upgrading your EFK stack
+
+If you need to upgrade your EFK stack with new images, you'll need to take the
+following steps to safely upgrade with minimal disruption to your log data.
+
+Scale down your Fluentd instances to 0.
+
+    $ oc scale dc/logging-fluentd --replicas=0
+
+Wait until they have properly terminated, this gives them time to properly
+flush their current buffer and send any logs they were processing to
+Elasticsearch. This helps prevent loss of data.
+
+You can scale down your Kibana instances at this time as well.
+
+    $ oc scale dc/logging-kibana --replicas=0
+    $ oc scale dc/logging-kibana-ops --replicas=0 (if applicable)
+
+Once your Fluentd and Kibana pods are confirmed to be terminated we can safely
+scale down the Elasticsearch pods.
+
+    $ oc scale dc/logging-es-{unique_name} --replicas=0
+    $ oc scale dc/logging-es-ops-{unique_name} --replicas=0 (if applicable)
+
+Once your ES pods are confirmed to be terminated we can now pull in the latest
+EFK images to use as described [here](https://docs.openshift.org/latest/install_config/upgrading/manual_upgrades.html#importing-the-latest-images),
+replacing the default namespace with the namespace where logging was installed.
+
+With the latest images in your repository we can now begin to scale back up.
+We want to scale ES back up incrementally so that the cluster has time to rebuild.
+
+    $ oc scale dc/logging-es-{unique_name} --replicas=1
+
+We want to tail the logs of the resulting pod to ensure that it was able to recover
+its indices correctly and that there were no errors.  If that is successful, we
+can then do the same for the operations cluster if one was previously used.
+
+Once all ES nodes have recovered their indices, we can then scale it back up to
+the size it was prior to doing maintenance. It is recommended to check the logs
+of the ES members to verify that they have correctly joined the cluster and
+recovered.
+
+We can now scale Kibana and Fluentd back up to their previous state.  Since Fluentd
+was shut down and allowed to push its remaining records to ES in the previous
+steps it can now pick back up from where it left off with no loss of logs -- so long
+as the log files that were not read in are still available on the node.

--- a/fluentd/generate_throttle_configs.rb
+++ b/fluentd/generate_throttle_configs.rb
@@ -38,6 +38,12 @@ def seed_file(file_name, project, isSyslog)
     path = get_project_pattern(project)
   end
 
+
+  excluded = Array.new
+  for ex_path in path.split(',') do
+    excluded.push("#{ex_path}.gz")
+  end
+
   File.open(file_name, 'w') { |file|
     file.write(<<-CONF)
 <source>
@@ -45,6 +51,7 @@ def seed_file(file_name, project, isSyslog)
   @label @INGRESS
   path #{path}
   pos_file #{pos_file}
+  exclude_path #{excluded}
     CONF
   }
 end
@@ -129,6 +136,7 @@ def create_default_syslog()
   @type tail
   @label @INGRESS
   path /var/log/messages*
+  exclude_path ["/var/log/messages*.gz"]
   pos_file /var/log/node.log.pos
   tag system.*
   format multiline


### PR DESCRIPTION
Having that wildcard causes fluentd to try and watch compressed messages files.