### PR TITLE
Add support for ops cluster, .defaults, runhour and runminute

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ is structured like this:
 * $ACTION - the action to take - currently only "delete"
 * $UNIT - one of "days", "weeks", or "months"
 * $VALUE - an integer for the number of units
+* `.defaults` - use `.defaults` as the $PROJECT_NAME to set the defaults for
+projects that are not specified
+** runhour: NUMBER - hour of the day in 24 hour format at which to run the
+curator jobs
+** runminute: NUMBER - minute of the hour at which to run the curator jobs
 
 For example, using::
 
@@ -79,11 +84,18 @@ For example, using::
     .operations:
       delete:
         weeks: 8
-     ...
+
+    .defaults:
+      delete:
+        days: 30
+      runhour: 0
+      runminute: 0
+    ...
 
 Every day, curator will run, and will delete indices in the myapp-dev
 project older than 1 day, and indices in the myapp-qe project older than 1
-week.
+week.  All other projects will have their indices deleted after they are 30
+days old.  The curator jobs will run at midnight every day.
 
 *WARNING*: Using `months` as the unit
 
@@ -109,10 +121,10 @@ Then mount your created secret as a volume in your Curator DC:
 The mount-path value e.g. `/etc/curator` must match the `CURATOR_CONF_LOCATION`
 in the environment.
 
-By default curator will run at midnight and deletes logs older than 30 days.
-The environment variables `CURATOR_CRON_HOUR` AND `CURATOR_CRON_MINUTE` can be
-used to define another hour and minute while `DEFAULT_DAYS` will change the
-default number of days logs will be kept for.
+You can also specify default values for the run hour, run minute, and age in
+days of the indices when processing the curator template.  Use
+`CURATOR_RUN_HOUR` and `CURATOR_RUN_MINUTE` to set the default runhour and
+runminute, and use `CURATOR_DEFAULT_DAYS` to set the default index age.
 
 # Defining local builds
 

--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -12,7 +12,10 @@ ENV HOME=/opt/app-root/src \
     ES_CA=/etc/curator/keys/ca \
     ES_CLIENT_CERT=/etc/curator/keys/cert \
     ES_CLIENT_KEY=/etc/curator/keys/key \
-    CURATOR_CONF_LOCATION=/etc/curator
+    CURATOR_CONF_LOCATION=/etc/curator \
+    CURATOR_DEFAULT_DAYS=30 \
+    CURATOR_RUN_HOUR=0 \
+    CURATOR_RUN_MINUTE=0
 
 LABEL io.k8s.description="Curator elasticsearch container for elasticsearch deletion/archival" \
   io.k8s.display-name="Curator 3.4" \

--- a/deployment/templates/curator.yaml
+++ b/deployment/templates/curator.yaml
@@ -82,10 +82,14 @@ objects:
               value: ${ES_CLIENT_KEY}
             - name: "ES_CA"
               value: ${ES_CA}
-            - name: "DEFAULT_DAYS"
-              value: ${DEFAULT_DAYS}
+            - name: "CURATOR_DEFAULT_DAYS"
+              value: ${CURATOR_DEFAULT_DAYS}
             - name: "CURATOR_CONF_LOCATION"
               value: ${CURATOR_CONF_LOCATION}
+            - name: "CURATOR_RUN_HOUR"
+              value: ${CURATOR_RUN_HOUR}
+            - name: "CURATOR_RUN_MINUTE"
+              value: ${CURATOR_RUN_MINUTE}
           volumes:
           - name: certs
             secret:
@@ -121,9 +125,17 @@ parameters:
   value: "/etc/curator/keys/ca"
 -
   description: "The default number of days that logs will be retained for a project if an index management configuration for it is not provided"
-  name: DEFAULT_DAYS
+  name: CURATOR_DEFAULT_DAYS
   value: "30"
 -
   description: "Location of the directory containing the yaml settings file"
   name: CURATOR_CONF_LOCATION
   value: "/etc/curator"
+-
+  description: "The hour of the day (24 hour format) at which to run the curator jobs."
+  name: CURATOR_RUN_HOUR
+  value: "0"
+-
+  description: "The minute of the hour at which to run the curator jobs."
+  name: CURATOR_RUN_MINUTE
+  value: "0"

--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -19,7 +19,7 @@ else
 fi
 
 if [[ "$CLUSTER" == "true" ]]; then
-  NEEDED_COMPONENTS=("logging-es-[a-ZA-Z0-9]+?0" "logging-kibana0" "logging-fluentd0" "logging-es-ops-[a-zA-Z0-9]+?0" "logging-kibana-ops0" "logging-curator0")
+  NEEDED_COMPONENTS=("logging-es-[a-ZA-Z0-9]+?0" "logging-kibana0" "logging-fluentd0" "logging-es-ops-[a-zA-Z0-9]+?0" "logging-kibana-ops0" "logging-curator-ops0")
 else
   NEEDED_COMPONENTS=("logging-es-[a-zA-Z0-9]+?0" "logging-kibana0" "logging-fluentd0" "logging-curator0")
 fi

--- a/hack/testing/check-curator.sh
+++ b/hack/testing/check-curator.sh
@@ -11,16 +11,116 @@ if [[ $# -ne 1 || "$1" = "false" ]]; then
   CLUSTER="false"
 else
   CLUSTER="$1"
-  ops="-ops"
+  OPS="-ops"
 fi
 
-TEST_DIVIDER="------------------------------------------"
+add_message_to_index() {
+    # index is $1
+    # message is $2
+    # ops is $3
+    message=${2:-"curatortest message"}
+    if [ -z "$3" ] ; then
+        host=logging-es
+    else
+        host=logging-es-ops
+    fi
+    ca=/etc/fluent/keys/ca
+    cert=/etc/fluent/keys/cert
+    key=/etc/fluent/keys/key
+    url="https://${host}:9200/$1/curatortest/"
+    oc exec $fpod -- curl -s --cacert $ca --cert $cert --key $key -XPOST "$url" -d '{
+    "message" : "'"$message $3"'"
+}' > /dev/null
+}
 
-# projects:
-# project-dev-YYYY.mm.dd delete 24 hours
-# project-qe-YYYY.mm.dd delete 7 days
-# project-prod-YYYY.mm.dd delete 4 weeks
-# .operations-YYYY.mm.dd delete 2 months
+get_running_pod() {
+    # $1 is component for selector
+    oc get pods -l component=$1 | awk -v sel=$1 '$1 ~ sel && $3 == "Running" {print $1}'
+}
+
+wait_for_pod_ACTION() {
+    # action is $1 - start or stop
+    # $2 - if action is stop, $2 is the pod name
+    #    - if action is start, $2 is the component selector
+    ii=120
+    incr=10
+    if [ $1 = start ] ; then
+        curpod=`get_running_pod $2`
+    else
+        curpod=$2
+    fi
+    while [ $ii -gt 0 ] ; do
+        if [ $1 = stop ] && oc describe pod/$curpod > /dev/null 2>&1 ; then
+            if [ -n "$VERBOSE" ] ; then
+                echo pod $curpod still running
+            fi
+        elif [ $1 = start ] && [ -z "$curpod" ] ; then
+            if [ -n "$VERBOSE" ] ; then
+                echo pod for component=$2 not running yet
+            fi
+        else
+            break # pod is either started or stopped
+        fi
+        sleep $incr
+        ii=`expr $ii - $incr`
+        if [ $1 = start ] ; then
+            curpod=`get_running_pod $2`
+        fi
+    done
+    if [ $ii -le 0 ] ; then
+        echo ERROR: pod $2 not in state $1 after 2 minutes
+        return 1
+    fi
+    return 0
+}
+
+create_indices() {
+    myops="$1"
+    set -- project-dev "$today" project-dev "$yesterday" project-qe "$today" project-qe "$lastweek" project-prod "$today" project-prod "$fourweeksago" .operations "$today" .operations "$twomonthsago" default-index "$today" default-index "$thirtydaysago"
+    while [ -n "$1" ] ; do
+        proj="$1" ; shift
+        add_message_to_index "${proj}.$1" "$proj $1 message" $myops
+        shift
+    done
+}
+
+verify_indices() {
+    myops=$2
+    curout=`mktemp`
+    oc exec $1 -- curator --host logging-es${myops} --use_ssl --certificate /etc/curator/keys/ca \
+       --client-cert /etc/curator/keys/cert --client-key /etc/curator/keys/key --loglevel ERROR \
+       show indices --all-indices > $curout 2>&1
+    set -- project-dev "$today" project-dev "$yesterday" project-qe "$today" project-qe "$lastweek" project-prod "$today" project-prod "$fourweeksago" .operations "$today" .operations "$twomonthsago" default-index "$today" default-index "$thirtydaysago"
+    rc=0
+    while [ -n "$1" ] ; do
+        proj="$1" ; shift
+        idx="${proj}.$1"
+        if [ "$1" = "$today" ] ; then
+            # index must be present
+            if grep \^"$idx"\$ $curout > /dev/null 2>&1 ; then
+                echo good - index "$idx" is present
+            else
+                echo ERROR: index "$idx" is missing
+                rc=1
+            fi
+        else
+            # index must be absent
+            if grep \^"$idx"\$ $curout > /dev/null 2>&1 ; then
+                echo ERROR: index "$idx" was not deleted
+                rc=1
+            else
+                echo good - index "$idx" is missing
+            fi
+        fi
+        shift
+    done
+    if [ $rc -ne 0 ] ; then
+        echo ERROR: The index list is:
+        cat $curout
+    fi
+    rm -f $curout
+    return $rc
+}
 
 # use the fluentd credentials to add records and indices for these projects
 # oc get secret logging-fluentd --template='{{.data.ca}}' | base64 -d > ca-fluentd
@@ -29,15 +129,20 @@ TEST_DIVIDER="------------------------------------------"
 # key=./key-fluentd
 # oc get secret logging-fluentd --template='{{.data.cert}}' | base64 -d > cert-fluentd
 # cert=./cert-fluentd
-fpod=`oc get pods | awk '/-deploy/ {next}; /-build/ {next}; /^logging-fluentd-.* Running / {print $1}'`
-
-# where "yesterday", "today", etc. are the dates in UTC in YYYY.mm.dd format
+fpod=`oc get pods -l component=fluentd | awk '/fluentd/ {print $1}'`
 tf='%Y.%m.%d'
 today=`date -u +"$tf"`
 yesterday=`date -u +"$tf" --date=yesterday`
 lastweek=`date -u +"$tf" --date="last week"`
 fourweeksago=`date -u +"$tf" --date="4 weeks ago"`
 thirtydaysago=`date -u +"$tf" --date="30 days ago"`
+# projects:
+# project-dev-YYYY.mm.dd delete 24 hours
+# project-qe-YYYY.mm.dd delete 7 days
+# project-prod-YYYY.mm.dd delete 4 weeks
+# .operations-YYYY.mm.dd delete 2 months
+
+# where "yesterday", "today", etc. are the dates in UTC in YYYY.mm.dd format
 # When is a month not a month?  When it is a curator month!  When you use
 # month based trimming, curator starts counting at the first day of the
 # current month, not the current day of the current month.  For example, if
@@ -57,36 +162,31 @@ twomonthsago=`date -u +"$tf" --date="$(date +%Y-%m-1) -2 months -1 day"`
 # project-prod-4weeksago project-today
 # .operations-2monthsago .operations-today
 
-add_message_to_index() {
-    # index is $1
-    # message is $2
-    message=${2:-"curatortest message"}
-    ca=/etc/fluent/keys/ca
-    cert=/etc/fluent/keys/cert
-    key=/etc/fluent/keys/key
-    url="https://logging-es${ops}:9200/$1/curatortest/"
-    oc exec $fpod -- curl -s --cacert $ca --cert $cert --key $key -XPOST "$url" -d '{
-    "message" : "'"$message"'"
-}'
-}
+TEST_DIVIDER="------------------------------------------"
 
-set -- project-dev "$today" project-dev "$yesterday" project-qe "$today" project-qe "$lastweek" project-prod "$today" project-prod "$fourweeksago" .operations "$today" .operations "$twomonthsago" default-index "$today" default-index "$thirtydaysago"
-while [ -n "$1" ] ; do
-    proj="$1" ; shift
-    add_message_to_index "${proj}.$1" "$proj $1 message"
-    shift
-done
 
-# get current curator pod
-curpod=`oc get pods | awk -v "pat=^logging-curator${ops}-.* Running" '/-deploy/ {next}; /-build/ {next}; $0 ~ pat {print $1}'`
-# show current indices
-echo current indices are:
-oc exec $curpod -- curator --host logging-es${ops} --use_ssl --certificate /etc/curator/keys/ca \
-   --client-cert /etc/curator/keys/cert --client-key /etc/curator/keys/key --loglevel ERROR \
-   show indices --all-indices
-# add the curator config yaml settings file
-curtest=`mktemp --suffix=.yaml`
-cat > $curtest <<EOF
+basictest() {
+    ops="$1"
+    create_indices "$ops"
+
+    # get current curator pod
+    curpod=`get_running_pod curator${ops}`
+    # show current indices
+    echo current indices are:
+    oc exec $curpod -- curator --host logging-es${ops} --use_ssl --certificate /etc/curator/keys/ca \
+       --client-cert /etc/curator/keys/cert --client-key /etc/curator/keys/key --loglevel ERROR \
+       show indices --all-indices
+    # add the curator config yaml settings file
+    curtest=`mktemp --suffix=.yaml`
+    # calculate the runhour and runminute to run 5 minutes from now
+    runhour=`date -u +%H --date="5 minutes hence"`
+    runminute=`date -u +%M --date="5 minutes hence"`
+    cat > $curtest <<EOF
+.defaults:
+  delete:
+    days: 30
+  runhour: $runhour
+  runminute: $runminute
 project-dev:
   delete:
     days: 1
@@ -100,66 +200,35 @@ project-prod:
   delete:
     months: 2
 EOF
-oc delete secret curator-config || echo no such secret curator-config - ignore
-oc secrets new curator-config settings=$curtest
-oc volumes dc/logging-curator --add --type=secret --secret-name=curator-config --mount-path=/etc/curator --name=curator-config --overwrite
-# scale down dc
-oc scale --replicas=0 dc logging-curator
-# wait for pod to go away
-ii=120
-incr=10
-while [ $ii -gt 0 ] ; do
-    if oc describe pod/$curpod > /dev/null ; then
-        echo $curpod still running
-    else
-        break
-    fi
-    sleep $incr
-    ii=`expr $ii - $incr`
-done
-# scale up dc
-oc scale --replicas=1 dc logging-curator
-# wait for pod to start
-ii=120
-incr=10
-while [ $ii -gt 0 ] ; do
-    curpod=`oc get pods | awk -v "pat=^logging-curator${ops}-.* Running" '/-deploy/ {next}; /-build/ {next}; $0 ~ pat {print $1}'`
-    if [ -n "$curpod" ] ; then
-        break
-    fi
-    sleep $incr
-    ii=`expr $ii - $incr`
-done
-# query ES
-curout=`mktemp`
-oc exec $curpod -- curator --host logging-es${ops} --use_ssl --certificate /etc/curator/keys/ca \
-   --client-cert /etc/curator/keys/cert --client-key /etc/curator/keys/key --loglevel ERROR \
-   show indices --all-indices > $curout 2>&1
-# verify that project-dev-yesterday project-qe-lastweek project-prod-fourweeksago .operations-twomonthsago are deleted
-set -- project-dev "$today" project-dev "$yesterday" project-qe "$today" project-qe "$lastweek" project-prod "$today" project-prod "$fourweeksago" .operations "$today" .operations "$twomonthsago" default-index "$today" default-index "$thirtydaysago"
-rc=0
-while [ -n "$1" ] ; do
-    proj="$1" ; shift
-    idx="${proj}.$1"
-    if [ "$1" = "$today" ] ; then
-        # index must be present
-        if grep \^"$idx"\$ $curout > /dev/null 2>&1 ; then
-            echo good - index "$idx" is present
-        else
-            echo ERROR: index "$idx" is missing
-            rc=1
-        fi
-    else
-        # index must be absent
-        if grep \^"$idx"\$ $curout > /dev/null 2>&1 ; then
-            echo ERROR: index "$idx" was not deleted
-            rc=1
-        else
-            echo good - index "$idx" is missing
-        fi
-    fi
-    shift
-done
-#rm -f $curout
-echo output is $curout
-exit $rc
+    oc delete secret curator-config${ops} || echo no such secret curator-config${ops} - ignore
+    oc secrets new curator-config${ops} settings=$curtest
+    oc volumes dc/logging-curator${ops} --add --type=secret --secret-name=curator-config${ops} --mount-path=/etc/curator --name=curator-config --overwrite
+    # scale down dc
+    oc scale --replicas=0 dc logging-curator${ops}
+    # wait for pod to go away
+    wait_for_pod_ACTION stop $curpod
+    # scale up dc
+    oc scale --replicas=1 dc logging-curator${ops}
+    # wait for pod to start
+    wait_for_pod_ACTION start curator${ops}
+    # query ES
+    curpod=`get_running_pod curator${ops}`
+    verify_indices $curpod $ops
+
+    # now, add back the same messages/indices and see if runhour and runminute are working
+    create_indices $ops
+
+    echo sleeping 5 minutes to see if runhour and runminute are working . . .
+    sleep 300 # 5 minutes
+    echo verify indices deletion again
+    verify_indices $curpod $ops
+
+    return 0
+}
+
+# test without ops cluster first
+basictest || exit $?
+if [ "$CLUSTER" = "true" ] ; then
+    basictest "$OPS" || exit $?
+fi
+exit 0


### PR DESCRIPTION
Add support for testing curator with the ops cluster.

You can now use the settings .yaml file to set the default parameters
for the index deletion age, and the run hour and minute, instead of
using the env. vars./deploy parameters.

    .defaults:
      delete:
        days: 30
      runhour: 0
      runminute: 0

Changed CURATOR_CRON_HOUR and MINUTE to CURATOR_RUN_HOUR and
CURATOR_RUN_MINUTE.  Can use the settings yaml .default instead
to set runhour and runminute

Renamed DEFAULT_DAYS to CURATOR_DEFAULT_DAYS.

Added check-curator.sh test for runhour and runminute