### PR TITLE
several logging automated testing improvements

### DIFF
--- a/hack/testing/check-logs.go
+++ b/hack/testing/check-logs.go
@@ -24,7 +24,7 @@ func main() {
         hostname = strings.Split(hostname, ".")[0]
 
         // instead of receiving jsonStream as an Arg, we'll make the call ourselves...
-        queryCommand := `oc exec `+kibana_pod+` -- curl -s -k --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert -XGET "https://`+es_svc+`/`+index+`.*/fluentd/_search?q=hostname:`+hostname+`*&fields=message&size=`+querySize+`"`
+        queryCommand := `oc exec `+kibana_pod+` -- curl -s -k --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert -XGET "https://`+es_svc+`/`+index+`.*/fluentd/_search?q=hostname:`+hostname+`&fields=message&size=`+querySize+`"`
         queryCmdName := "bash"
         queryCmdArgs := []string{"-c", queryCommand}
 
@@ -104,7 +104,11 @@ func main() {
         }
 
         if foundEntries == totalEntries {
-              fmt.Printf("Success - [%v/%v] log entries found in %s\n", foundEntries, totalEntries, filePath)
+               if totalEntries == 0 {
+                       fmt.Printf("Failure - no log entries found in Elasticsearch %s for index %s\n", es_svc, index)
+               } else {
+                       fmt.Printf("Success - [%v/%v] log entries found in %s\n", foundEntries, totalEntries, filePath)
+               }
         } else {
               fmt.Printf("Failure - [%v/%v] log entries found in %s\n%s", foundEntries, totalEntries, filePath, missesBuffer.String())
         }

--- a/hack/testing/check-logs.sh
+++ b/hack/testing/check-logs.sh
@@ -77,7 +77,9 @@ for pod in "${PODS[@]}"; do
       done
 
       if [[ $READY -eq 1 ]]; then
-        go run check-logs.go "$KIBANA" "$ES" "$index" "$FILE_PATH" "$QUERY_SIZE"
+        # this needs to read from the system log files, so use sudo, and use -E and set PATH
+        # because it needs to use the oc commands  
+        sudo -E env PATH=$PATH go run check-logs.go "$KIBANA" "$ES" "$index" "$FILE_PATH" "$QUERY_SIZE"
         echo $TEST_DIVIDER
       else
         echo "$ES_NAME not ready to be queried within $TIMES attempts..."

--- a/hack/testing/e2e-test.sh
+++ b/hack/testing/e2e-test.sh
@@ -22,11 +22,3 @@ else
   echo "Errors found when checking installation of the EFK stack -- not checking log entry matches. Please resolve errors and retest."
   exit 1
 fi
-
-if [[ $? -eq 0 ]]; then
-  echo "Checking curator ..."
-  KIBANA_CLUSTER_SIZE=$KIBANA_CLUSTER_SIZE KIBANA_OPS_CLUSTER_SIZE=$KIBANA_OPS_CLUSTER_SIZE ES_CLUSTER_SIZE=$ES_CLUSTER_SIZE ES_OPS_CLUSTER_SIZE=$ES_OPS_CLUSTER_SIZE ./check-curator.sh "$CLUSTER"
-else
-  echo "Errors found when checking installation of the EFK stack or checking log matches -- not checking curator. Please resolve errors and retest."
-  exit 1
-fi


### PR DESCRIPTION
* override LOG_DIR and ARTIFACT_DIR for vagrant
  download-artifacts-origin-aggregated-logging
* have tests output logs and other files to ARTIFACT_DIR so that
  they can be downloaded to the ci system
* use sudo to run check-logs.go because it needs access to the system
  logs and other protected files
* make e2e-test.sh only run the check-* scripts which do not modify
  data and are safe to run in production
* rename the other test scripts to be test-* - these do modify data
  and are not generally safe to run in production
* make the check and test output go directly to the console instead
  of being buffered by the test command
* remove the wildcard at the end of the hostname search in check-logs.go
* if check-logs.go finds no messages in the index, this is an error -
  if there is an index in ES, there must be at least 1 message in it
* fixes to allow working with set -o nounset