### PR TITLE
fix build-images script for origin release process

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin:latest
+FROM openshift/origin:v1.1.6
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -1,0 +1,1 @@
+#place holder to minimize patching of hack/release.sh from origin

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,0 +1,2 @@
+# place holder for common functionality and to facilitate
+# merging with the origin/hack/common.sh

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# This script pushes all of the built images to a registry.
+#
+# Set OS_PUSH_BASE_REGISTRY to prefix the destination images
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+STARTTIME=$(date +%s)
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${OS_ROOT}/hack/common.sh"
+
+PREFIX="${PREFIX:-openshift/origin-}"
+
+# Go to the top of the tree.
+cd "${OS_ROOT}"
+
+# Allow a release to be repushed with a tag
+tag="${OS_PUSH_TAG:-}"
+if [[ -n "${tag}" ]]; then
+  tag=":${tag}"
+else
+  tag=":latest"
+fi
+
+# Source tag
+source_tag="${OS_TAG:-}"
+if [[ -z "${source_tag}" ]]; then
+  source_tag="latest"
+fi
+
+images=(
+  ${PREFIX}logging-curator
+  ${PREFIX}logging-fluentd
+  ${PREFIX}logging-elasticsearch
+  ${PREFIX}logging-kibana
+  ${PREFIX}logging-deployment
+)
+
+PUSH_OPTS=""
+if docker push --help | grep -q force; then
+  PUSH_OPTS="--force"
+fi
+
+if [[ "${OS_PUSH_BASE_REGISTRY-}" != "" || "${tag}" != "" ]]; then
+  set -e
+  for image in "${images[@]}"; do
+    docker tag -f "${image}:${source_tag}" "${OS_PUSH_BASE_REGISTRY-}${image}${tag}"
+  done
+  set +e
+fi
+
+for image in "${images[@]}"; do
+  docker push ${PUSH_OPTS} "${OS_PUSH_BASE_REGISTRY-}${image}${tag}"
+done
+
+ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This script builds and pushes a release to DockerHub.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OS_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${OS_ROOT}/hack/common.sh"
+
+# Go to the top of the tree.
+cd "${OS_ROOT}"
+
+if [[ -z "${OS_TAG}" ]]; then
+  echo "You must specify the OS_TAG variable as the name of the tag to create, e.g. 'v1.0.1'."
+  exit 1
+fi
+tag="${OS_TAG}"
+
+if [[ "$(git name-rev --name-only --tags HEAD)" != "${tag}^0" ]]; then
+  if git rev-parse -q --short "${tag}" &>/dev/null; then
+    echo "Tag ${tag} already exists"
+    exit 1
+  else
+    git tag "${tag}" -a -m "${tag}" HEAD
+  fi
+fi
+
+function removeimage() {
+  for i in $@; do
+    if docker inspect $i &>/dev/null; then
+      docker rmi $i
+    fi
+    if docker inspect docker.io/$i &>/dev/null; then
+      docker rmi docker.io/$i
+    fi
+  done
+}
+
+removeimage openshift/origin:v1.1.6 centos:centos7 openshift/base-centos7
+
+docker pull openshift/origin:v1.1.6
+docker pull openshift/base-centos7
+docker pull centos:centos7
+
+hack/build-release.sh
+OS_TAG=${tag} hack/build-images.sh
+OS_PUSH_TAG="${tag}" OS_TAG="" OS_PUSH_LOCAL="1" hack/push-release.sh
+
+echo
+echo "Pushed ${tag} to DockerHub"
+echo "1. Push tag to GitHub with: git push origin --tags # (ensure you have no extra tags in your environment)"


### PR DESCRIPTION
cc @richm @sosiouxme  Updates to allow the origin release build to call our build script with a desired version for tagging.