### PR TITLE
some improvements for testing the es-copy feature

### DIFF
--- a/hack/testing/test-es-copy.sh
+++ b/hack/testing/test-es-copy.sh
@@ -23,6 +23,27 @@ if [ ! -d $ARTIFACT_DIR ] ; then
     mkdir -p $ARTIFACT_DIR
 fi
 
+# $1 - shell command or function to call to test if wait is over -
+#      this command/function should return true if the condition
+#      has been met, or false if still waiting for condition to be met
+# $2 - shell command or function to call if we timed out for error handling
+# $3 - timeout in seconds - should be a multiple of $4 (interval)
+# $4 - loop interval in seconds
+wait_until_cmd_or_err() {
+    let ii=$3
+    interval=${4:-1}
+    while [ $ii -gt 0 ] ; do
+        $1 && break
+        sleep $interval
+        let ii=ii-$interval
+    done
+    if [ $ii -le 0 ] ; then
+        $2
+        return 1
+    fi
+    return 0
+}
+
 get_running_pod() {
     # $1 is component for selector
     oc get pods -l component=$1 | awk -v sel=$1 '$1 ~ sel && $3 == "Running" {print $1}'
@@ -65,20 +86,58 @@ wait_for_pod_ACTION() {
     return 0
 }
 
+# $1 - kibana pod name
+# $2 - es hostname (e.g. logging-es or logging-es-ops)
+# $3 - project name (e.g. logging, test, .operations, etc.)
+# $4 - _count or _search
+# $5 - field to search
+# $6 - search string
+# stdout is the JSON output from Elasticsearch
+# stderr is curl errors
+curl_es_from_kibana() {
+    oc exec $1 -- curl --connect-timeout 1 -s -k \
+       --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
+       https://${2}:9200/${3}*/${4}\?q=${5}:${6}
+}
+
+# stdin is JSON output from Elasticsearch for _count search
+# stdout is the integer count
+# stderr is JSON parsing errors if bogus input (i.e. search error, empty JSON)
+get_count_from_json() {
+    python -c 'import json, sys; print json.loads(sys.stdin.read())["count"]'
+}
+
+# return true if the actual count matches the expected count, false otherwise
+test_count_expected() {
+    myfield=${myfield:-message}
+    nrecs=`curl_es_from_kibana $kpod $myhost $myproject _count $myfield $mymessage | \
+           get_count_from_json`
+    test "$nrecs" = $expected
+}
+
+# display an appropriate error message if the expected count did not match
+# the actual count
+test_count_err() {
+    myfield=${myfield:-message}
+    nrecs=`curl_es_from_kibana $kpod $myhost $myproject _count $myfield $mymessage | \
+           get_count_from_json`
+    echo Error: found $nrecs for project $myproject message $mymessage - expected $expected
+    for thetype in _count _search ; do
+        curl_es_from_kibana $kpod $myhost $myproject $thetype $myfield $mymessage | python -mjson.tool
+    done
+}
+
 write_and_verify_logs() {
     # expected number of matches
     expected=$1
 
     # write a log message to the test app
     logmessage=`uuidgen`
-    curl -s http://$testip:$testport/$logmessage > /dev/null 2>&1 || echo will generate a 404
+    curl --connect-timeout 1 -s http://$testip:$testport/$logmessage > /dev/null 2>&1 || echo will generate a 404
 
     # write a message to the system log
     logmessage2=`uuidgen`
     logger -i -p local6.info -t $logmessage2 $logmessage2
-
-    # wait a bit for fluentd + es to digest
-    sleep 20
 
     # get current kibana pod
     kpod=`get_running_pod kibana`
@@ -89,40 +148,37 @@ write_and_verify_logs() {
     fi
 
     rc=0
-    # count the matching records
-    nrecs=`oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
-           https://logging-es:9200/test*/_count\?q=message:$logmessage | \
-           python -c 'import json; import sys; print json.loads(sys.stdin.read())["count"]'`
-    if [ "$nrecs" = $expected ] ; then
+    # poll for logs to show up
+    if myhost=logging-es myproject=test mymessage=$logmessage expected=$expected \
+             wait_until_cmd_or_err test_count_expected test_count_err 20 ; then
         if [ -n "$VERBOSE" ] ; then
-            echo good - found $expected records for $logmessage
+            echo good - found $expected records project test for $logmessage
         fi
     else
-        echo Error: found $nrecs for $logmessage - expected $expected
-        oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
-           https://logging-es:9200/test*/_count\?q=message:$logmessage | python -mjson.tool
-        oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
-           https://logging-es:9200/test*/_search\?q=message:$logmessage | python -mjson.tool
         rc=1
     fi
 
-    nrecs=`oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
-           https://logging-es${ops}:9200/.operations*/_count\?q=ident:$logmessage2 | \
-           python -c 'import json; import sys; print json.loads(sys.stdin.read())["count"]'`
-    if [ "$nrecs" = $expected ] ; then
+    if myhost=logging-es${ops} myproject=.operations mymessage=$logmessage2 expected=$expected myfield=ident \
+             wait_until_cmd_or_err test_count_expected test_count_err 20 ; then
         if [ -n "$VERBOSE" ] ; then
-            echo good - found $expected records for $logmessage2
+            echo good - found $expected records project .operations for $logmessage2
         fi
     else
-        echo Error: found $nrecs for $logmessage2 - expected $expected
-        oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
-           https://logging-es${ops}:9200/.operations*/_count\?q=ident:$logmessage2 | python -mjson.tool
-        oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
-           https://logging-es${ops}:9200/.operations*/_search\?q=ident:$logmessage2 | python -mjson.tool
         rc=1
     fi
 
     return $rc
+}
+
+restart_fluentd() {
+    # delete daemonset which also stops fluentd
+    oc delete daemonset logging-fluentd
+    # wait for fluentd to stop
+    wait_for_pod_ACTION stop $fpod
+    # create the daemonset which will also start fluentd
+    oc process logging-fluentd-template | oc create -f -
+    # wait for fluentd to start
+    wait_for_pod_ACTION start fluentd
 }
 
 TEST_DIVIDER="------------------------------------------"
@@ -139,9 +195,33 @@ testport=5432
 
 fpod=`get_running_pod fluentd`
 
+# first, make sure copy is off
+cfg=`mktemp`
+oc get template logging-fluentd-template -o yaml | \
+    sed '/- name: ES_COPY/,/value:/ s/value: .*$/value: "false"/' | \
+    oc replace -f -
+restart_fluentd
+fpod=`get_running_pod fluentd`
+
 # save original template config
 origconfig=`mktemp`
 oc get template logging-fluentd-template -o yaml > $origconfig
+
+# run test to make sure fluentd is working normally - no copy
+write_and_verify_logs 1 || {
+    oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1
+    exit 1
+}
+
+cleanup() {
+    # may have already been cleaned up
+    if [ ! -f $origconfig ] ; then return 0 ; fi
+    # put back original configuration
+    oc replace --force -f $origconfig
+    rm -f $origconfig
+    restart_fluentd
+}
+trap "cleanup" INT TERM EXIT
 
 nocopy=`mktemp`
 # strip off the copy settings, if any
@@ -157,7 +237,7 @@ s/OPS_/OPS_COPY_/
 p
 }' $nocopy > $envpatch
 
-# add the scheme
+# add the scheme, and turn on verbose
 cat >> $envpatch <<EOF
           - name: ES_COPY
             value: "true"
@@ -176,15 +256,7 @@ cat $nocopy | \
 
 rm -f $envpatch $nocopy
 
-# delete daemonset which also stops fluentd
-oc delete daemonset logging-fluentd
-# wait for fluentd to stop
-wait_for_pod_ACTION stop $fpod
-# create the daemonset which will also start fluentd
-oc process logging-fluentd-template | oc create -f -
-# wait for fluentd to start
-wait_for_pod_ACTION start fluentd
-
+restart_fluentd
 fpod=`get_running_pod fluentd`
 
 write_and_verify_logs 2 || {
@@ -196,15 +268,7 @@ write_and_verify_logs 2 || {
 oc replace --force -f $origconfig
 rm -f $origconfig
 
-# delete daemonset which also stops fluentd
-oc delete daemonset logging-fluentd
-# wait for fluentd to stop
-wait_for_pod_ACTION stop $fpod
-# create the daemonset which will also start fluentd
-oc process logging-fluentd-template | oc create -f -
-# wait for fluentd to start
-wait_for_pod_ACTION start fluentd
-
+restart_fluentd
 fpod=`get_running_pod fluentd`
 
 write_and_verify_logs 1 || {


### PR DESCRIPTION
* code refactor
* add timeouts for curl so curl won't hang forever if es is down
* use polling instead of sleep to speed up test
* make sure the initial configuration does not use ES_COPY, and test
  it to make sure no copies are found
* try very hard to ensure final configuration does not use ES_COPY
* for the .operations log, search for the unique string in the ident
  field to avoid false positives

The way elasticsearch works, it will return a match with a very low
score, even when doing a search like message=$uuid, because some
components of the uuid may be in other log messages.