### PR TITLE
Route reencrypt fails because of kibana_keys vars

### DIFF
--- a/deployment/scripts/install.sh
+++ b/deployment/scripts/install.sh
@@ -261,16 +261,20 @@ function generate_objects() {
     # note: dev builds aren't labeled and won't be deleted. if you need to preserve imagestreams, you can just remove the label.
     # note: no automatic deletion of persistentvolumeclaim; didn't seem wise
     oc process logging-support-template | oc create -f -
-    kibana_keys=""; [ -e "$dir/kibana.crt" ] && kibana_keys="--cert='$dir/kibana.crt' --key='$dir/kibana.key'"
+    kibana_cert=""; [ -e "$dir/kibana.crt" ] && kibana_cert="$dir/kibana.crt"
+    kibana_key=""; [ -e "$dir/kibana.key" ] && kibana_key="$dir/kibana.key"
     oc create route reencrypt --service="logging-kibana" \
                               --hostname="${hostname}" \
                               --{dest-,}ca-cert="$dir/ca.crt" \
-                                    $kibana_keys
-    kibana_keys=""; [ -e "$dir/kibana-ops.crt" ] && kibana_keys="--cert='$dir/kibana-ops.crt' --key='$dir/kibana-ops.key'"
+                              --cert="${kibana_cert}" \
+                              --key="${kibana_key}"
+    kibana_cert=""; [ -e "$dir/kibana-ops.crt" ] && kibana_cert="$dir/kibana-ops.crt"
+    kibana_key=""; [ -e "$dir/kibana-ops.key" ] && kibana_key="$dir/kibana-ops.key"
     oc create route reencrypt --service="logging-kibana-ops" \
                               --hostname="${ops_hostname}" \
                               --{dest-,}ca-cert="$dir/ca.crt" \
-                                    $kibana_keys
+                              --cert="${kibana_cert}" \
+                              --key="${kibana_key}"
     # note: route labels are copied from service, no need to add
   fi
   oc new-app logging-imagestream-template || : # these may fail if created independently; that's ok

--- a/deployment/scripts/install.sh
+++ b/deployment/scripts/install.sh
@@ -261,20 +261,16 @@ function generate_objects() {
     # note: dev builds aren't labeled and won't be deleted. if you need to preserve imagestreams, you can just remove the label.
     # note: no automatic deletion of persistentvolumeclaim; didn't seem wise
     oc process logging-support-template | oc create -f -
-    kibana_cert=""; [ -e "$dir/kibana.crt" ] && kibana_cert="$dir/kibana.crt"
-    kibana_key=""; [ -e "$dir/kibana.key" ] && kibana_key="$dir/kibana.key"
+    kibana_keys=""; [ -e "$dir/kibana.crt" ] && kibana_keys="--cert=$dir/kibana.crt --key=$dir/kibana.key"
     oc create route reencrypt --service="logging-kibana" \
                               --hostname="${hostname}" \
                               --{dest-,}ca-cert="$dir/ca.crt" \
-                              --cert="${kibana_cert}" \
-                              --key="${kibana_key}"
-    kibana_cert=""; [ -e "$dir/kibana-ops.crt" ] && kibana_cert="$dir/kibana-ops.crt"
-    kibana_key=""; [ -e "$dir/kibana-ops.key" ] && kibana_key="$dir/kibana-ops.key"
+                              $kibana_keys
+    kibana_keys=""; [ -e "$dir/kibana-ops.crt" ] && kibana_keys="--cert=$dir/kibana-ops.crt --key=$dir/kibana-ops.key"
     oc create route reencrypt --service="logging-kibana-ops" \
                               --hostname="${ops_hostname}" \
                               --{dest-,}ca-cert="$dir/ca.crt" \
-                              --cert="${kibana_cert}" \
-                              --key="${kibana_key}"
+                              $kibana_keys
     # note: route labels are copied from service, no need to add
   fi
   oc new-app logging-imagestream-template || : # these may fail if created independently; that's ok


### PR DESCRIPTION
The command ```oc create route reencrypt --service="logging-kibana" ...``` leads to :

```
# oc create route reencrypt --service=logging-kibana --hostname=kibana.node2.cnamts.octo.com --dest-ca-cert=/etc/deploy/ca.crt --ca-cert=/etc/deploy/ca.crt '--cert='\''/etc/deploy/kibana.crt'\''' '--key='\''/etc/deploy/kibana.key'\'''
# error: open '/etc/deploy/kibana.crt': no such file or directory
```

The error comes from mis-evaluation/interpretation of : ```kibana_keys="--cert='$dir/kibana.crt' --key='$dir/kibana.key'"```

Hence : splitting ```kibana_keys``` in two vars (```kibana_cert``` and ```kibana_key```), providing each flag with its content only.