### PR TITLE
handle authenticated/non-secured registry

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -154,6 +154,8 @@ are available:
 * `KIBANA_OPS_HOSTNAME`, `ES_OPS_INSTANCE_RAM`, `ES_OPS_PVC_SIZE`, `ES_OPS_PVC_PREFIX`, `ES_OPS_CLUSTER_SIZE`, `ES_OPS_NODESELECTOR`, `KIBANA_OPS_NODESELECTOR`, `CURATOR_OPS_NODESELECTOR`: Parallel parameters for the ops log cluster.
 * `IMAGE_PREFIX`: Specify prefix for logging component images; e.g. for "docker.io/openshift/origin-logging-deployer:v1.1", set prefix "docker.io/openshift/origin-"
 * `IMAGE_VERSION`: Specify version for logging component images; e.g. for "docker.io/openshift/origin-logging-deployer:v1.1", set version "v1.1"
+* `IMAGE_PULL_SECRET`: Specify the name of an existing pull secret to be used for pulling component images from an authenticated registry.
+* `INSECURE_REGISTRY`: Allow the registry for logging component images to be non-secure (not secured with a certificate signed by a known CA)
 
 You run the deployer by instantiating a template. Here is an example with some parameters:
 

--- a/deployment/deployer.yaml
+++ b/deployment/deployer.yaml
@@ -105,6 +105,10 @@ items:
             value: ${IMAGE_PREFIX}
           - name: IMAGE_VERSION
             value: ${IMAGE_VERSION}
+          - name: IMAGE_PULL_SECRET
+            value: ${IMAGE_PULL_SECRET}
+          - name: INSECURE_REGISTRY
+            value: ${INSECURE_REGISTRY}
           - name: ENABLE_OPS_CLUSTER
             value: ${ENABLE_OPS_CLUSTER}
           - name: KIBANA_HOSTNAME
@@ -173,14 +177,6 @@ items:
         secret:
           secretName: logging-deployer
   parameters:
-  -
-    description: 'Specify prefix for logging components; e.g. for "openshift/origin-logging-deployer:v1.1", set prefix "openshift/origin-"'
-    name: IMAGE_PREFIX
-    value: "docker.io/openshift/origin-"
-  -
-    description: 'Specify version for logging components; e.g. for "openshift/origin-logging-deployer:v1.1", set version "v1.1"'
-    name: IMAGE_VERSION
-    value: "latest"
   -
     description: "If true, set up to use a second ES cluster for ops logs."
     name: ENABLE_OPS_CLUSTER
@@ -288,3 +284,19 @@ items:
     description: "The mode that the deployer runs in."
     name: MODE
     value: "install"
+  -
+    description: 'Specify prefix for logging components; e.g. for "openshift/origin-logging-deployer:v1.1", set prefix "openshift/origin-"'
+    name: IMAGE_PREFIX
+    value: "docker.io/openshift/origin-"
+  -
+    description: 'Specify version for logging components; e.g. for "openshift/origin-logging-deployer:v1.1", set version "v1.1"'
+    name: IMAGE_VERSION
+    value: "latest"
+  -
+    description: 'Specify the name of an existing pull secret to be used for pulling component images from an authenticated registry.'
+    name: IMAGE_PULL_SECRET
+  -
+    description: 'Allow the registry for logging component images to be non-secure (not secured with a certificate signed by a known CA)'
+    name: INSECURE_REGISTRY
+    value: "false"
+

--- a/deployment/templates/curator.yaml
+++ b/deployment/templates/curator.yaml
@@ -24,6 +24,9 @@ objects:
     description: "The version tag of the image to use."
     name: IMAGE_VERSION
     value: ${IMAGE_VERSION_DEFAULT}
+  -
+    name: IMAGE_PREFIX
+    value: ${IMAGE_PREFIX_DEFAULT}
   objects:
   -
     apiVersion: v1
@@ -65,7 +68,7 @@ objects:
           serviceAccountName: aggregated-logging-curator
           containers:
           - name: curator
-            image: logging-curator
+            image: ${IMAGE_PREFIX}logging-curator:${IMAGE_VERSION}
             imagePullPolicy: Always
             resources:
               limits:
@@ -148,3 +151,4 @@ parameters:
   description: "The version tag of the image to use."
   name: IMAGE_VERSION_DEFAULT
   value: "latest"
+- name: IMAGE_PREFIX_DEFAULT

--- a/deployment/templates/es.yaml
+++ b/deployment/templates/es.yaml
@@ -61,7 +61,7 @@ objects:
           containers:
             -
               name: "elasticsearch"
-              image: logging-elasticsearch
+              image: ${IMAGE_PREFIX}logging-elasticsearch:${IMAGE_VERSION}
               imagePullPolicy: Always
               ports:
               -
@@ -134,6 +134,9 @@ objects:
     name: RECOVER_AFTER_TIME
     value: ${ES_RECOVER_AFTER_TIME}
   -
+    name: IMAGE_PREFIX
+    value: ${IMAGE_PREFIX_DEFAULT}
+  -
     description: "The version tag of the image to use."
     name: IMAGE_VERSION
     value: ${IMAGE_VERSION_DEFAULT}
@@ -144,5 +147,6 @@ parameters:
 - name: ES_RECOVER_AFTER_NODES
 - name: ES_RECOVER_EXPECTED_NODES
 - name: ES_RECOVER_AFTER_TIME
+- name: IMAGE_PREFIX_DEFAULT
 - name: IMAGE_VERSION_DEFAULT
   value: "latest"

--- a/deployment/templates/kibana.yaml
+++ b/deployment/templates/kibana.yaml
@@ -24,6 +24,9 @@ objects:
     description: "The version tag of the image to use."
     name: IMAGE_VERSION
     value: ${IMAGE_VERSION_DEFAULT}
+  -
+    name: IMAGE_PREFIX
+    value: ${IMAGE_PREFIX_DEFAULT}
   objects:
   -
     apiVersion: "v1"
@@ -74,7 +77,7 @@ objects:
           containers:
             -
               name: "kibana"
-              image: logging-kibana
+              image: ${IMAGE_PREFIX}logging-kibana:${IMAGE_VERSION}
               imagePullPolicy: Always
               ports:
               env:
@@ -162,3 +165,4 @@ parameters:
   description: "The version tag of the image to use."
   name: IMAGE_VERSION_DEFAULT
   value: "latest"
+- name: IMAGE_PREFIX_DEFAULT

--- a/deployment/templates/support.yaml
+++ b/deployment/templates/support.yaml
@@ -22,6 +22,10 @@ parameters:
   description: 'Specify prefix for logging component images; e.g. for "openshift/origin-logging-deployment:v1.1", set prefix "openshift/origin-"'
   name: IMAGE_PREFIX_DEFAULT
   value: "docker.io/openshift/origin-"
+-
+  description: 'Set to "true" if the image registry is not secured with a properly-signed certificate.'
+  name: INSECURE_REGISTRY
+  value: "false"
 objects:
 - apiVersion: "v1"
   kind: "Template"
@@ -148,7 +152,7 @@ objects:
     kind: ImageStream
     metadata:
       annotations:
-        openshift.io/image.insecureRepository: "true"
+        openshift.io/image.insecureRepository: "${INSECURE_REGISTRY}"
       name: logging-auth-proxy
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-auth-proxy
@@ -157,7 +161,7 @@ objects:
     kind: ImageStream
     metadata:
       annotations:
-        openshift.io/image.insecureRepository: "true"
+        openshift.io/image.insecureRepository: "${INSECURE_REGISTRY}"
       name: logging-elasticsearch
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-elasticsearch
@@ -166,7 +170,7 @@ objects:
     kind: ImageStream
     metadata:
       annotations:
-        openshift.io/image.insecureRepository: "true"
+        openshift.io/image.insecureRepository: "${INSECURE_REGISTRY}"
       name: logging-fluentd
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-fluentd
@@ -175,7 +179,7 @@ objects:
     kind: ImageStream
     metadata:
       annotations:
-        openshift.io/image.insecureRepository: "true"
+        openshift.io/image.insecureRepository: "${INSECURE_REGISTRY}"
       name: logging-kibana
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-kibana
@@ -184,7 +188,7 @@ objects:
     kind: ImageStream
     metadata:
       annotations:
-        openshift.io/image.insecureRepository: "true"
+        openshift.io/image.insecureRepository: "${INSECURE_REGISTRY}"
       name: logging-curator
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-curator


### PR DESCRIPTION
provide deployer parameters for:
1. "insecure" registry in imagestream
2. applying pull secret if provided

also, DC pod specs now specify the actual image expected, although
normally the trigger will overwrite this. may lead to less confusion
when users try `oc deploy` explicitly due to IS failures.