### PR TITLE
deployer: ensure desired tag is imported

### DIFF
--- a/deployer/scripts/install.sh
+++ b/deployer/scripts/install.sh
@@ -82,6 +82,7 @@ function generate_support_objects() {
      --param KIBANA_HOSTNAME=${hostname} \
      --param KIBANA_OPS_HOSTNAME=${ops_hostname} \
      --param IMAGE_PREFIX_DEFAULT=${image_prefix} \
+     --param IMAGE_VERSION_DEFAULT=${image_version} \
      --param INSECURE_REGISTRY=${insecure_registry}
 
   oc new-app logging-support-template

--- a/deployer/scripts/upgrade.sh
+++ b/deployer/scripts/upgrade.sh
@@ -348,10 +348,11 @@ function updateImages() {
   # create any missing imagestreams and then update them all
   oc new-app logging-imagestream-template || : # these may fail if created independently; that's ok
 
-  oc import-image logging-elasticsearch || :
-  oc import-image logging-fluentd || :
-  oc import-image logging-kibana || :
-  oc import-image logging-curator || :
+  oc import-image logging-elasticsearch:${IMAGE_VERSION} --from=${IMAGE_PREFIX}logging-elasticsearch:${IMAGE_VERSION} --insecure=${INSECURE_REGISTRY} || :
+  oc import-image logging-fluentd:${IMAGE_VERSION} --from=${IMAGE_PREFIX}logging-fluentd:${IMAGE_VERSION} --insecure=${INSECURE_REGISTRY} || :
+  oc import-image logging-kibana:${IMAGE_VERSION} --from=${IMAGE_PREFIX}logging-kibana:${IMAGE_VERSION} --insecure=${INSECURE_REGISTRY} || :
+  oc import-image logging-auth-proxy:${IMAGE_VERSION} --from=${IMAGE_PREFIX}logging-auth-proxy:${IMAGE_VERSION} --insecure=${INSECURE_REGISTRY} || :
+  oc import-image logging-curator:${IMAGE_VERSION} --from=${IMAGE_PREFIX}logging-curator:${IMAGE_VERSION} --insecure=${INSECURE_REGISTRY} || :
 
   # patch all es
   patchImageVersion "logging-infra=elasticsearch" "logging-elasticsearch"

--- a/deployer/templates/support.yaml
+++ b/deployer/templates/support.yaml
@@ -19,9 +19,13 @@ parameters:
   name: KIBANA_OPS_HOSTNAME
   value: kibana-ops.example.com
 -
-  description: 'Specify prefix for logging component images; e.g. for "openshift/origin-logging-deployment:v1.1", set prefix "openshift/origin-"'
+  description: 'Specify prefix for logging component images; e.g. for "openshift/origin-logging-deployment:v1.2", set prefix "openshift/origin-"'
   name: IMAGE_PREFIX_DEFAULT
   value: "docker.io/openshift/origin-"
+-
+  description: 'Specify version for logging component images; e.g. for "openshift/origin-logging-deployment:v1.2", set version "v1.2"'
+  name: IMAGE_VERSION_DEFAULT
+  value: "latest"
 -
   description: 'Set to "true" if the image registry is not secured with a properly-signed certificate.'
   name: INSECURE_REGISTRY
@@ -148,9 +152,13 @@ objects:
     component: support
   parameters:
   -
-    description: 'Specify prefix for logging component images; e.g. for "openshift/origin-logging-deployer:v1.1", set prefix "openshift/origin-"'
+    description: 'Specify prefix for logging component images; e.g. for "openshift/logging-deployer:v1.2", set prefix "openshift/"'
     name: IMAGE_PREFIX
     value: ${IMAGE_PREFIX_DEFAULT}
+  -
+    description: 'Specify version for logging component images; e.g. for "openshift/logging-deployer:v1.2", set version "v1.2"'
+    name: IMAGE_VERSION
+    value: ${IMAGE_VERSION_DEFAULT}
   objects:
   -
     apiVersion: v1
@@ -161,6 +169,11 @@ objects:
       name: logging-auth-proxy
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-auth-proxy
+      tags:
+      - name: ${IMAGE_VERSION}
+        from:
+          kind: DockerImage
+          name: ${IMAGE_PREFIX}logging-auth-proxy:${IMAGE_VERSION}
   -
     apiVersion: v1
     kind: ImageStream
@@ -170,6 +183,11 @@ objects:
       name: logging-elasticsearch
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-elasticsearch
+      tags:
+      - name: ${IMAGE_VERSION}
+        from:
+          kind: DockerImage
+          name: ${IMAGE_PREFIX}logging-elasticsearch:${IMAGE_VERSION}
   -
     apiVersion: v1
     kind: ImageStream
@@ -179,6 +197,11 @@ objects:
       name: logging-fluentd
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-fluentd
+      tags:
+      - name: ${IMAGE_VERSION}
+        from:
+          kind: DockerImage
+          name: ${IMAGE_PREFIX}logging-fluentd:${IMAGE_VERSION}
   -
     apiVersion: v1
     kind: ImageStream
@@ -188,6 +211,11 @@ objects:
       name: logging-kibana
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-kibana
+      tags:
+      - name: ${IMAGE_VERSION}
+        from:
+          kind: DockerImage
+          name: ${IMAGE_PREFIX}logging-kibana:${IMAGE_VERSION}
   -
     apiVersion: v1
     kind: ImageStream
@@ -197,6 +225,11 @@ objects:
       name: logging-curator
     spec:
       dockerImageRepository: ${IMAGE_PREFIX}logging-curator
+      tags:
+      - name: ${IMAGE_VERSION}
+        from:
+          kind: DockerImage
+          name: ${IMAGE_PREFIX}logging-curator:${IMAGE_VERSION}
 - apiVersion: "v1"
   kind: "Template"
   parameters:


### PR DESCRIPTION
technical fix for https://github.com/openshift/origin/issues/8948
In order to ensure that the triggers on the DCs fire, seed the tags on
each ImageStream with the desired version. Otherwise, if there are
more than 5 tags available, the IS may not have the desired tag
imported automatically (or may have it imported by another name).
