### PR TITLE
support travis ci; build images for every PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+
+language: ruby
+
+services:
+  - docker
+
+script:
+  - cd hack && PREFIX="openshift/origin-" ./build-images.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Origin-Aggregated-Logging
+# Origin-Aggregated-Logging [![Build Status](https://travis-ci.org/openshift/origin-aggregated-logging.svg?branch=master)](https://travis-ci.org/openshift/origin-aggregated-logging)
 
 This repo contains the image definitions of the components of the logging
 stack as well as tools for building and deploying them.


### PR DESCRIPTION
This will do hack/build-images.sh for every PR.  If this proves to be too onerous, we can either do a simple test, or just use `true` and at least make the travis report `green` for our PRs.