### PR TITLE
os::log::install_errexit bash function not found

### DIFF
--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -42,6 +42,12 @@ source "${OS_ROOT}/hack/cmd_util.sh"
 source "${OS_ROOT}/hack/lib/test/junit.sh"
 source "${OS_ROOT}/hack/common.sh"
 source "${OS_ROOT}/hack/lib/log.sh"
+# in case cmd_util.sh does not include util.sh and text.sh
+fn=`type -t os::log::install_errexit || :`
+if [ x"$fn" != xfunction ] ; then
+    source "${OS_ROOT}/hack/util.sh"
+    source "${OS_ROOT}/hack/text.sh"
+fi
 os::log::install_errexit
 
 source "${OS_ROOT}/hack/lib/util/environment.sh"


### PR DESCRIPTION
origin hack/cmd_util.sh changed - it does not include util.sh and
text.sh any more.  Change the test to see if os::log::install_errexit
and if not, source util.sh and text.sh