### PR TITLE
Allow setting curator runhour/runminute timezone - default is UTC

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -2,20 +2,21 @@ FROM centos:centos7
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
-# by default, run the curator cron job at midnight every night, and delete
+# by default, run the curator cron job at midnight UTC every night, and delete
 # indices older than 30 days old
 ENV HOME=/opt/app-root/src \
     ES_HOST=localhost \
     ES_PORT=9200 \
-    CURATOR_CRON_MINUTE=0 \
-    CURATOR_CRON_HOUR=0 \
     ES_CA=/etc/curator/keys/ca \
     ES_CLIENT_CERT=/etc/curator/keys/cert \
     ES_CLIENT_KEY=/etc/curator/keys/key \
     CURATOR_CONF_LOCATION=/etc/curator/settings/config.yaml \
     CURATOR_DEFAULT_DAYS=30 \
     CURATOR_RUN_HOUR=0 \
-    CURATOR_RUN_MINUTE=0
+    CURATOR_RUN_MINUTE=0 \
+    CURATOR_RUN_TIMEZONE=UTC \
+    CURATOR_LOG_LEVEL=ERROR \
+    CURATOR_SCRIPT_LOG_LEVEL=INFO
 
 LABEL io.k8s.description="Curator elasticsearch container for elasticsearch deletion/archival" \
   io.k8s.display-name="Curator 3.5.1" \

--- a/curator/install.sh
+++ b/curator/install.sh
@@ -5,7 +5,8 @@ set -ex
 rpm -q epel-release || yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum install -y --setopt=tsflags=nodocs \
   python-pip \
-  PyYAML
+  PyYAML \
+  pytz
 pip install 'elasticsearch-curator<4.0' python-crontab
 yum clean all
 

--- a/curator/run_cron.py
+++ b/curator/run_cron.py
@@ -7,15 +7,26 @@ import time
 import logging
 
 from crontab import CronTab
-from datetime import datetime
+from datetime import datetime, timedelta
+from pytz import timezone, UnknownTimeZoneError
 
 logger = logging.getLogger()
 # log at INFO by default
-logger.setLevel(logging.INFO)
+lvl = logging._levelNames.get(os.getenv('CURATOR_SCRIPT_LOG_LEVEL', 'INFO'), None)
+if not lvl:
+    logger.error('The CURATOR_SCRIPT_LOG_LEVEL must be one of CRITICAL, ERROR, WARNING, INFO or DEBUG')
+    sys.exit(1)
+
+logger.setLevel(lvl)
 lh = logging.StreamHandler()
-lh.setLevel(logging.INFO)
+lh.setLevel(lvl)
 lh.setFormatter(logging._defaultFormatter)
 logger.addHandler(lh)
+
+curlvl = os.getenv('CURATOR_LOG_LEVEL', 'ERROR')
+if not curlvl in logging._levelNames:
+    logger.error('The CURATOR_LOG_LEVEL must be one of CRITICAL, ERROR, WARNING, INFO or DEBUG')
+    sys.exit(1)
 
 # we can't allow 'hours' since our index timestamp format doesn't allow for that level of granularity
 #allowed_units = {'hours': 'hours', 'days': 'days', 'weeks': 'weeks', 'months': 'months'}
@@ -30,6 +41,18 @@ filename = os.getenv('CURATOR_CONF_LOCATION', '/etc/curator/settings/config.yaml
 decoded = {}
 with open(filename, 'r') as stream:
     decoded = yaml.load(stream) or {}
+
+tzstr = decoded.get('.defaults', {}).get('timezone', os.getenv('CURATOR_RUN_TIMEZONE', 'UTC'))
+tz = None
+if tzstr:
+    try:
+        tz = timezone(tzstr)
+    except (AttributeError, UnknownTimeZoneError) as myex:
+        logger.error('The timezone must be specified as a string in the tzselect(8) or timedatectl(1) "Region/Locality" format e.g. "America/New_York" or "UTC".  [%s] is not a valid timezone string: error [%s]' % (str(tzstr), str(myex)))
+        sys.exit(1)
+    except: # unexpected error
+        logger.error('The timezone must be specified as a string in the tzselect(8) or timedatectl(1) "Region/Locality" format e.g. "America/New_York" or "UTC".  Unexpected error [%s] attempting to parse timezone [%s]' % (str(sys.exc_info()[0]), str(tzstr)))
+        sys.exit(1)
 
 connection_info = '--host ' + os.getenv('ES_HOST') + ' --port ' + os.getenv('ES_PORT') + ' --use_ssl --certificate ' + os.getenv('ES_CA') + ' --client-cert ' + os.getenv('ES_CLIENT_CERT') + ' --client-key ' + os.getenv('ES_CLIENT_KEY')
 
@@ -49,7 +72,7 @@ if default_time_unit.lower() == "weeks":
     default_time_unit = "days"
     default_value = default_value * 7
 
-base_default_cmd = '/usr/bin/curator --loglevel ERROR ' + connection_info + ' delete indices --timestring %Y.%m.%d'
+base_default_cmd = '/usr/bin/curator --loglevel ' + curlvl + ' ' + connection_info + ' delete indices --timestring %Y.%m.%d'
 default_command = base_default_cmd + ' --older-than ' + str(default_value) + ' --time-unit ' + default_time_unit + ' --exclude .searchguard* --exclude .kibana* --exclude .apiman_*'
 
 for project in decoded:
@@ -84,7 +107,7 @@ for operation in curator_settings:
     for unit in curator_settings[operation]:
         for value in curator_settings[operation][unit]:
 
-            base_cmd = '/usr/bin/curator --loglevel ERROR ' + connection_info + ' ' + operation + ' indices --timestring %Y.%m.%d'
+            base_cmd = '/usr/bin/curator --loglevel ' + curlvl + ' ' + connection_info + ' ' + operation + ' indices --timestring %Y.%m.%d'
             tab_command = base_cmd + ' --older-than ' + str(value) + ' --time-unit ' + unit
 
             for project in curator_settings[operation][unit][value]:
@@ -102,6 +125,7 @@ def run_all_jobs(joblist):
             logger.info(output)
         else:
             logger.debug("curator job [%s] was successful" % job)
+    # test-curator looks for this string to mean the jobs are complete
     logger.info("curator run finish")
 
 # run jobs now
@@ -122,15 +146,15 @@ if not theminute:
 thehour = int(thehour)
 theminute = int(theminute)
 while True:
-    # get time when next run should happen
-    nextruntime = time.mktime(datetime.now().replace(hour=thehour, minute=theminute,
-                                                     second=0, microsecond=0).timetuple())
-    timenow = time.time()
-    if nextruntime < timenow:
-        # the next runtime is less than now, so run a day from now
-        nextruntime = nextruntime + 86400
-        # else run later today
-    logger.debug("curator hour [%d] minute [%d] nextruntime [%d] now [%d]" % (thehour, theminute, nextruntime, time.time()))
+    # get time when next run should happen - number of seconds until the next thehour and theminute
+    timenow = datetime.now(tz)
+    lastruntime = timenow.replace(hour=thehour, minute=theminute, second=0, microsecond=0)
+    offset = 0
+    if timenow > lastruntime:
+        # run it same time tomorrow
+        offset = 86400
+    untilnextruntime = (lastruntime + timedelta(seconds=offset) - timenow).seconds
+    logger.debug("curator hour [%d] minute [%d] seconds until next runtime [%d] now [%s]" % (thehour, theminute, untilnextruntime, str(timenow)))
     # sleep until then
-    time.sleep(nextruntime - time.time())
+    time.sleep(untilnextruntime)
     run_all_jobs(my_cron)

--- a/deployer/templates/curator.yaml
+++ b/deployer/templates/curator.yaml
@@ -90,6 +90,12 @@ objects:
               value: ${CURATOR_RUN_HOUR}
             - name: "CURATOR_RUN_MINUTE"
               value: ${CURATOR_RUN_MINUTE}
+            - name: "CURATOR_RUN_TIMEZONE"
+              value: ${CURATOR_RUN_TIMEZONE}
+            - name: "CURATOR_SCRIPT_LOG_LEVEL"
+              value: ${CURATOR_SCRIPT_LOG_LEVEL}
+            - name: "CURATOR_LOG_LEVEL"
+              value: ${CURATOR_LOG_LEVEL}
           volumes:
           - name: certs
             secret:
@@ -127,19 +133,31 @@ parameters:
   name: ES_CA
   value: "/etc/curator/keys/ca"
 -
-  description: "The default number of days that logs will be retained for a project if an index management configuration for it is not provided"
+  description: "(Deprecated) The default number of days that logs will be retained for a project if an index management configuration for it is not provided"
   name: CURATOR_DEFAULT_DAYS
   value: "30"
 -
-  description: "The hour of the day (24 hour format) at which to run the curator jobs."
+  description: "(Deprecated) The hour of the day (24 hour format) at which to run the curator jobs."
   name: CURATOR_RUN_HOUR
   value: "0"
 -
-  description: "The minute of the hour at which to run the curator jobs."
+  description: "(Deprecated) The minute of the hour at which to run the curator jobs."
   name: CURATOR_RUN_MINUTE
   value: "0"
+-
+  description: "(Deprecated) The timezone of the runhour and runminute for the curator jobs."
+  name: CURATOR_RUN_TIMEZONE
+  value: "UTC"
 -
   description: "The version tag of the image to use."
   name: IMAGE_VERSION_DEFAULT
   value: "latest"
 - name: IMAGE_PREFIX_DEFAULT
+-
+  description: "Log level for script that runs curator - one of CRITICAL, ERROR, WARNING, INFO or DEBUG"
+  name: CURATOR_SCRIPT_LOG_LEVEL
+  value: "INFO"
+-
+  description: "Log level for curator command - one of CRITICAL, ERROR, WARNING, INFO or DEBUG"
+  name: CURATOR_LOG_LEVEL
+  value: "ERROR"


### PR DESCRIPTION
https://github.com/openshift/origin-aggregated-logging/issues/182
Clarify in the documentation that the curator date/time settings
are with respect to the timezone of the curator pod, and change
the test to use that timezone.