### PR TITLE
build/release: transition "deployment" to "deployer"

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -18,6 +18,7 @@ declare -A source_for=(
   [logging-kibana]=kibana
   [logging-curator]=deployer/common/curator
   [logging-auth-proxy]=deployer/common/openshift-auth-proxy
+  [logging-deployer]=deployer
   [logging-deployment]=deployer
 )
 for component in ${!source_for[@]} ; do

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -38,6 +38,7 @@ images=(
   ${PREFIX}logging-elasticsearch
   ${PREFIX}logging-kibana
   ${PREFIX}logging-auth-proxy
+  ${PREFIX}logging-deployer
   ${PREFIX}logging-deployment
 )
 


### PR DESCRIPTION
Reduce confusion as much as possible by calling the image "logging-deployer". Keeping "logging-deployment" around for one release cycle to prevent a period where the deployer template refers to the wrong one.