### PR TITLE
Fluentd activesupport 4.x

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -14,6 +14,7 @@ LABEL io.k8s.description="Fluentd container for collecting of docker container l
   io.openshift.expose-services="9200:http, 9300:http" \
   io.openshift.tags="logging,elk,fluentd"
 
+# activesupport version 5.x requires ruby 2.2
 RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   yum install -y --setopt=tsflags=nodocs \
   gcc-c++ \
@@ -22,7 +23,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   libcurl-devel \
   make && \
   mkdir -p ${HOME} && \
-  gem install --no-rdoc --no-ri fluentd:${FLUENTD_VERSION} fluent-plugin-kubernetes_metadata_filter fluent-plugin-elasticsearch fluent-plugin-flatten-hash && \
+  gem install --no-rdoc --no-ri fluentd:${FLUENTD_VERSION} 'activesupport:<5' fluent-plugin-kubernetes_metadata_filter fluent-plugin-elasticsearch fluent-plugin-flatten-hash && \
   mkdir -p ${THROTTLE_CONF_LOCATION} && \
   touch ${THROTTLE_CONF_LOCATION}/settings
 


### PR DESCRIPTION
activesupport 5.0 was released today, and promptly broke our fluentd build, which requires ruby 2.0, while activesupport 5.0 requires ruby 2.2