### PR TITLE
deployer: scale down to preserve data

### DIFF
--- a/deployer/run.sh
+++ b/deployer/run.sh
@@ -32,9 +32,11 @@ case "${mode}" in
     install_logging
     ;;
   uninstall)
+    scaleDown || :
     delete_logging
     ;;
   reinstall)
+    scaleDown || :
     delete_logging
     install_logging
     ;;


### PR DESCRIPTION
When uninstalling or reinstalling, it seems wise to first shut
everything down safely so that if the user wants to re-create with
preserved persistent data, it will not be in a state that requires
excessive recovery.