### PR TITLE
reduce fluentd deps versions

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -24,6 +24,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum clean all
 RUN mkdir -p ${HOME} && \
     gem install --no-rdoc --no-ri \
+      --conservative --minimal-deps \
       fluentd:${FLUENTD_VERSION} \
       'activesupport:<5' \
       fluent-plugin-kubernetes_metadata_filter \


### PR DESCRIPTION
get around these sorts of errors without upgrading ruby:

```
ERROR:  Error installing fluent-plugin-kubernetes_metadata_filter:
	serverengine requires Ruby version >= 2.1.0.
ERROR:  Error installing fluent-plugin-elasticsearch:
	serverengine requires Ruby version >= 2.1.0.
ERROR:  Error installing fluent-plugin-flatten-hash:
	serverengine requires Ruby version >= 2.1.0.
```