### PR TITLE
Bumping OpenShift Elasticsearch Plugin version

### DIFF
--- a/elasticsearch/install.sh
+++ b/elasticsearch/install.sh
@@ -7,7 +7,7 @@ ln -s /usr/share/elasticsearch /usr/share/java/elasticsearch
 
 /usr/share/elasticsearch/bin/plugin -i com.floragunn/search-guard/0.5.1 -url https://github.com/lukas-vlcek/origin-aggregated-logging/releases/download/v0.1/search-guard-0.5.1.zip
 
-/usr/share/elasticsearch/bin/plugin -i io.fabric8.elasticsearch/openshift-elasticsearch-plugin/0.15
+/usr/share/elasticsearch/bin/plugin -i io.fabric8.elasticsearch/openshift-elasticsearch-plugin/0.17
 
 /usr/share/elasticsearch/bin/plugin -i io.fabric8/elasticsearch-cloud-kubernetes/1.3.0
 

--- a/hack/templates/dev-builds.yaml
+++ b/hack/templates/dev-builds.yaml
@@ -17,7 +17,7 @@ objects:
       build: logging-elasticsearch
     name: centos
   spec:
-    dockerImageRepository: library/centos:7
+    dockerImageRepository: library/centos
 - apiVersion: v1
   kind: ImageStream
   metadata:

--- a/hack/testing/check-logs.sh
+++ b/hack/testing/check-logs.sh
@@ -35,8 +35,8 @@ TEST_DIVIDER="------------------------------------------"
 # we need logic for ES_OPS
 KIBANA_POD=`oc get pods | grep 'logging-kibana-[0-9]' | grep -v -- "-build" | grep -v -- "-deploy" | cut -d" " -f 1`
 KIBANA_OPS_POD=`oc get pods | grep 'logging-kibana-ops-[0-9]' | cut -d" " -f 1`
-ES_SVC=`oc get svc | grep '^logging-es ' | awk '{print $2 ":" $4}' | rev | cut -c 5- | rev`
-ES_OPS_SVC=`oc get svc | grep '^logging-es-ops ' | awk '{print $2 ":" $4}' | rev | cut -c 5- | rev`
+ES_SVC=`oc get svc | grep '^logging-es ' | awk '{print $1 ":" $4}' | rev | cut -c 5- | rev`
+ES_OPS_SVC=`oc get svc | grep '^logging-es-ops ' | awk '{print $1 ":" $4}' | rev | cut -c 5- | rev`
 
 # get names of the ES pods to check their logs
 PODS=(`oc get pods | grep 'logging-es-' | grep 'Running' | cut -d" " -f 1`)

--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -442,14 +442,14 @@ function wait_for_app() {
 
   echo "[INFO] Waiting for database service to start"
   os::cmd::try_until_text "oc get -n $1 services" 'database' "$(( 2 * TIME_MIN ))"
-  DB_IP=$(oc get -n $1 --output-version=v1beta3 --template="{{ .spec.portalIP }}" service database)
+  DB_IP=$(oc get -n $1 --output-version=v1beta3 --template="{{ .spec.clusterIP }}" service database)
 
   echo "[INFO] Waiting for frontend pod to start"
   os::cmd::try_until_text "oc get -n $1 pods" 'frontend.+Running' "$(( 2 * TIME_MIN ))"
 
   echo "[INFO] Waiting for frontend service to start"
   os::cmd::try_until_text "oc get -n $1 services" 'frontend' "$(( 2 * TIME_MIN ))"
-  FRONTEND_IP=$(oc get -n $1 --output-version=v1beta3 --template="{{ .spec.portalIP }}" service frontend)
+  FRONTEND_IP=$(oc get -n $1 --output-version=v1beta3 --template="{{ .spec.clusterIP }}" service frontend)
 
   echo "[INFO] Waiting for database to start..."
   wait_for_url_timed "http://${DB_IP}:5434" "[INFO] Database says: " $((3*TIME_MIN))

--- a/hack/testing/test-es-copy.sh
+++ b/hack/testing/test-es-copy.sh
@@ -184,7 +184,7 @@ restart_fluentd() {
 TEST_DIVIDER="------------------------------------------"
 
 # this is the OpenShift origin sample app
-testip=$(oc get -n test --output-version=v1beta3 --template="{{ .spec.portalIP }}" service frontend)
+testip=$(oc get -n test --output-version=v1beta3 --template="{{ .spec.clusterIP }}" service frontend)
 testport=5432
 
 # configure fluentd to just use the same ES instance for the copy


### PR DESCRIPTION
Pretty straight forward -- bumping this up pulls in the removal of the .all alias for non-cluster admin users and does a null check when looking for the default index pattern to cover cases where the Kibana version has changed.

@jcantrill @sosiouxme @richm PTAL