### PR TITLE
Default to keeping 31 days of logs

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:centos7
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
 # by default, run the curator cron job at midnight UTC every night, and delete
-# indices older than 30 days old
+# indices older than 31 days old
 ENV HOME=/opt/app-root/src \
     ES_HOST=localhost \
     ES_PORT=9200 \
@@ -11,7 +11,7 @@ ENV HOME=/opt/app-root/src \
     ES_CLIENT_CERT=/etc/curator/keys/cert \
     ES_CLIENT_KEY=/etc/curator/keys/key \
     CURATOR_CONF_LOCATION=/etc/curator/settings/config.yaml \
-    CURATOR_DEFAULT_DAYS=30 \
+    CURATOR_DEFAULT_DAYS=31 \
     CURATOR_RUN_HOUR=0 \
     CURATOR_RUN_MINUTE=0 \
     CURATOR_RUN_TIMEZONE=UTC \

--- a/curator/README.md
+++ b/curator/README.md
@@ -42,7 +42,7 @@ For example, using::
     
     .defaults:
       delete:
-        days: 30
+        days: 31
       runhour: 0
       runminute: 0
       timezone: America/New_York
@@ -50,7 +50,7 @@ For example, using::
 
 Every day, curator will run, and will delete indices in the myapp-dev project
 older than 1 day, and indices in the myapp-qe project older than 1 week.  All
-other projects will have their indices deleted after they are 30 days old.  The
+other projects will have their indices deleted after they are 31 days old.  The
 curator jobs will run every day at midnight in the `America/New_York` timezone,
 regardless of geographical location where the pod is running, or the timezone
 setting of the pod, host, etc.
@@ -64,7 +64,7 @@ today (`delete: months: 2`), curator doesn't delete indices that are dated
 older than February 15, it deletes indices older than _February 1_.  That is,
 it goes back to the first day of the current month, _then_ goes back two whole
 months from that date.
-If you want to be exact with curator, it is best to use `days` e.g. `delete: days: 30`
+If you want to be exact with curator, it is best to use `days` e.g. `delete: days: 31`
 [Curator issue](https://github.com/elastic/curator/issues/569)
 
 To create the curator configuration, you can just edit the current

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -618,7 +618,7 @@ For example, using:
 
     .defaults:
       delete:
-        days: 30
+        days: 31
       runhour: 0
       runminute: 0
       timezone: America/New_York
@@ -626,7 +626,7 @@ For example, using:
 
 Every day, curator runs to delete indices in the myapp-dev project older than 1
 day, and indices in the myapp-qe project older than 1 week.  All other projects
-have their indices deleted after they are 30 days old.  The curator jobs run at
+have their indices deleted after they are 31 days old.  The curator jobs run at
 midnight every day in the `America/New_York` timezone, regardless of
 geographical location where the pod is running, or the timezone setting of the
 pod, host, etc.
@@ -640,7 +640,7 @@ today (`delete: months: 2`), curator doesn't delete indices that are dated
 older than February 15, it deletes indices older than _February 1_.  That is,
 it goes back to the first day of the current month, _then_ goes back two whole
 months from that date.
-If you want to be exact with curator, it is best to use `days` e.g. `delete: days: 30`
+If you want to be exact with curator, it is best to use `days` e.g. `delete: days: 31`
 [Curator issue](https://github.com/elastic/curator/issues/569)
 
 To create the curator configuration, you can just edit the current

--- a/deployer/conf/curator.yml
+++ b/deployer/conf/curator.yml
@@ -3,7 +3,7 @@
 # uncomment and use this to override the defaults from env vars
 #.defaults:
 #  delete:
-#    days: 30
+#    days: 31
 #  runhour: 0
 #  runminute: 0
 

--- a/deployer/templates/curator.yaml
+++ b/deployer/templates/curator.yaml
@@ -135,7 +135,7 @@ parameters:
 -
   description: "(Deprecated) The default number of days that logs will be retained for a project if an index management configuration for it is not provided"
   name: CURATOR_DEFAULT_DAYS
-  value: "30"
+  value: "31"
 -
   description: "(Deprecated) The hour of the day (24 hour format) at which to run the curator jobs."
   name: CURATOR_RUN_HOUR

--- a/hack/testing/test-curator.sh
+++ b/hack/testing/test-curator.sh
@@ -128,7 +128,7 @@ skip_list=("^\." "^default")
 
 create_indices() {
     myops=${1:-""}
-    set -- project-dev "$today" project-dev "$yesterday" project-qe "$today" project-qe "$lastweek" project-prod "$today" project-prod "$fourweeksago" .operations "$today" .operations "$twomonthsago" default-index "$today" default-index "$thirtydaysago" project2-qe "$today" project2-qe "$lastweek" project3-qe "$today" project3-qe "$lastweek"
+    set -- project-dev "$today" project-dev "$yesterday" project-qe "$today" project-qe "$lastweek" project-prod "$today" project-prod "$fourweeksago" .operations "$today" .operations "$twomonthsago" default-index "$today" default-index "$thirtyonedaysago" project2-qe "$today" project2-qe "$lastweek" project3-qe "$today" project3-qe "$lastweek"
     while [ -n "${1:-}" ] ; do
         proj="$1" ; shift
         this_proj="project.${proj}"
@@ -150,7 +150,7 @@ verify_indices() {
     oc exec $1 -- curator --host logging-es${myops} --use_ssl --certificate /etc/curator/keys/ca \
        --client-cert /etc/curator/keys/cert --client-key /etc/curator/keys/key --loglevel ERROR \
        show indices --all-indices > $curout 2>&1
-    set -- project-dev "$today" project-dev "$yesterday" project-qe "$today" project-qe "$lastweek" project-prod "$today" project-prod "$fourweeksago" .operations "$today" .operations "$twomonthsago" default-index "$today" default-index "$thirtydaysago" project2-qe "$today" project2-qe "$lastweek" project3-qe "$today" project3-qe "$lastweek"
+    set -- project-dev "$today" project-dev "$yesterday" project-qe "$today" project-qe "$lastweek" project-prod "$today" project-prod "$fourweeksago" .operations "$today" .operations "$twomonthsago" default-index "$today" default-index "$thirtyonedaysago" project2-qe "$today" project2-qe "$lastweek" project3-qe "$today" project3-qe "$lastweek"
     rc=0
     while [ -n "${1:-}" ] ; do
         proj="$1" ; shift
@@ -264,7 +264,7 @@ today=`date -u +"$tf"`
 yesterday=`date -u +"$tf" --date=yesterday`
 lastweek=`date -u +"$tf" --date="last week"`
 fourweeksago=`date -u +"$tf" --date="4 weeks ago"`
-thirtydaysago=`date -u +"$tf" --date="30 days ago"`
+thirtyonedaysago=`date -u +"$tf" --date="31 days ago"`
 # projects:
 # project-dev-YYYY.mm.dd delete 24 hours
 # project-qe-YYYY.mm.dd delete 7 days
@@ -377,7 +377,7 @@ basictest() {
     cat > $curtest <<EOF
 .defaults:
   delete:
-    days: 30
+    days: 31
   runhour: $runhour
   runminute: $runminute
   timezone: $tz


### PR DESCRIPTION
This will allow searching a full month of logs if "this month" is selected in Kibana on the last day of a month with 31 days.
