### PR TITLE
oc process: --value no longer accepts comma-separated lists of values.

### DIFF
--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -344,7 +344,7 @@ else
 
     os::cmd::expect_success "oc process -o yaml \
        -f $OS_O_A_L_DIR/hack/templates/dev-builds.yaml \
-       -v LOGGING_FORK_URL=$GIT_URL,LOGGING_FORK_BRANCH=$GIT_BRANCH \
+       -v LOGGING_FORK_URL=$GIT_URL -v LOGGING_FORK_BRANCH=$GIT_BRANCH \
        | build_filter | oc create -f -"
     post_build
     os::cmd::expect_success "wait_for_builds_complete"
@@ -357,7 +357,7 @@ if [ "$ENABLE_OPS_CLUSTER" = "true" ]; then
         sudo mkdir -p $ES_OPS_VOLUME
         sudo chown 1000:1000 $ES_OPS_VOLUME
     fi
-    os::cmd::expect_success "oc process -f $OS_O_A_L_DIR/hack/templates/pv-hostmount.yaml -v SIZE=10,PATH=${ES_OPS_VOLUME} | oc create -f -"
+    os::cmd::expect_success "oc process -f $OS_O_A_L_DIR/hack/templates/pv-hostmount.yaml -v SIZE=10 -v PATH=${ES_OPS_VOLUME} | oc create -f -"
     pvc_params="-p ES_OPS_PVC_SIZE=10 -p ES_OPS_PVC_PREFIX=es-ops-pvc-" # deployer will create PVC
 fi
 # TODO: put this back to hostmount-anyuid once we've resolved the SELinux problem with that

--- a/hack/testing/test-upgrade.sh
+++ b/hack/testing/test-upgrade.sh
@@ -105,7 +105,7 @@ function useFluentdDC() {
   waitFor "[[ -z \"\$(oc get pod \$fluentdpod -o name)\" ]]" "$(( 3 * TIME_MIN ))"
 
   oc process -f templates/fluentd_dc.yaml \
-     -v IMAGE_PREFIX_DEFAULT=$imageprefix,OPS_HOST=$ops_host,OPS_PORT=$ops_port | oc create -f -
+     -v IMAGE_PREFIX_DEFAULT=$imageprefix -v OPS_HOST=$ops_host -v OPS_PORT=$ops_port | oc create -f -
 
   oc new-app logging-fluentd-template
 


### PR DESCRIPTION
We need to replace '-v "TYPE=VALUE,TYPE=VALUE"' with '-v "TYPE=VALUE" -v "TYPE=VALUE"'.
