### PR TITLE
support json-file docker log driver with common data model

### DIFF
--- a/fluentd/configs.d/openshift/filter-k8s-record-transform.conf
+++ b/fluentd/configs.d/openshift/filter-k8s-record-transform.conf
@@ -26,7 +26,7 @@
   <record>
     hostname ${(record['kubernetes']['host'] rescue nil) || File.open('/etc/docker-hostname') { |f| f.readline }.rstrip}
     message ${(message rescue nil) || log}
-    pipeline_metadata {"collector":{"version":"0.12.29 1.4.0"}}
+    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-in_tail","name":"fluentd openshift","received_at":"${record['time'].to_s}","version":"0.12.29 1.4.0"}}
   </record>
   remove_keys log,stream
 </filter>

--- a/fluentd/configs.d/openshift/filter-syslog-record-transform.conf
+++ b/fluentd/configs.d/openshift/filter-syslog-record-transform.conf
@@ -2,6 +2,7 @@
   @type record_transformer
   enable_ruby
   <record>
+    systemd {"t":{"PID":"${record['pid']}"},"u":{"SYSLOG_IDENTIFIER":"${record['ident']}"}}
     # if host == 'localhost' do a fqdn lookup
     ## we pull the hostname from the host's /etc/hostname mounted at /etc/docker-hostname to correctly identify the hostname
     hostname ${host.eql?('localhost') ? (begin; File.open('/etc/docker-hostname') { |f| f.readline }.rstrip; rescue; host; end) : host}
@@ -13,9 +14,9 @@
 
 
     #tag ${tag}_.operations_log
-    pipeline_metadata {"collector":{"version":"0.12.29 1.4.0"}}
+    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-in_tail","name":"fluentd openshift","received_at":"${(Time.at(time) > Time.now) ? (Time.new((time.year - 1), time.month, time.day, time.hour, time.min, time.sec, time.utc_offset).to_datetime.to_s) : (time.to_datetime.to_s)}","version":"0.12.29 1.4.0"}}
   </record>
-  remove_keys host
+  remove_keys host,pid,ident
 </filter>
 
 <filter journal.system**>


### PR DESCRIPTION
When using the json-file docker log driver, add support for the
common data model.  Note that there isn't nearly the same amount
of log metadata available with the json-file log driver.