### PR TITLE
Bug 1396433 - Fluentd pop lots of dump an error event: error_class=NoMethodError error="undefined method `empty?'

### DIFF
--- a/fluentd/filter-common-data-model.rb
+++ b/fluentd/filter-common-data-model.rb
@@ -97,7 +97,7 @@ module Fluent
       end
       # remove the field from record if it is not in the list of fields to keep and
       # it is empty
-      record.delete_if{|k,v| !@keep_empty_fields_hash.key?(k) && (v.nil? || delempty(v).empty? || isempty(v))}
+      record.delete_if{|k,v| !@keep_empty_fields_hash.key?(k) && (v.nil? || isempty(delempty(v)) || isempty(v))}
       # probably shouldn't remove everything . . .
       log.warn("Empty record! tag [#{tag}] time [#{time}]") if record.empty?
       # rename the time field

--- a/hack/testing/test-common-data-model.py
+++ b/hack/testing/test-common-data-model.py
@@ -33,16 +33,24 @@ if check_for_empty and empty(obj):
 
 test2match = {
     "test1": {"undefined1": "undefined1",
+              "undefined11": 1111,
+              "undefined12": True,
               "undefined2": {
-                  "undefined2": "undefined2"
+                  "undefined2": "undefined2",
+                  "undefined22": 2222,
+                  "undefined23": False
               },
               "undefined4": "undefined4",
               "undefined5": "undefined5"
     },
     "test2": {"undefined":
               {"undefined1": "undefined1",
+               "undefined11": 1111,
+               "undefined12": True,
                "undefined2": {
-                   "undefined2": "undefined2"
+                   "undefined2": "undefined2",
+                   "undefined22": 2222,
+                   "undefined23": False
                },
                "undefined4": "undefined4",
                "undefined5": "undefined5"
@@ -50,8 +58,12 @@ test2match = {
     },
     "test3": {"undefined":
               {"undefined1": "undefined1",
+               "undefined11": 1111,
+               "undefined12": True,
                "undefined2": {
-                   "undefined2": "undefined2"
+                   "undefined2": "undefined2",
+                   "undefined22": 2222,
+                   "undefined23": False
                }
               },
               "undefined4": "undefined4",
@@ -59,8 +71,12 @@ test2match = {
     },
     "test4": {"myname":
               {"undefined1": "undefined1",
+               "undefined11": 1111,
+               "undefined12": True,
                "undefined2": {
-                   "undefined2": "undefined2"
+                   "undefined2": "undefined2",
+                   "undefined22": 2222,
+                   "undefined23": False
                }
               },
               "undefined4": "undefined4",
@@ -68,8 +84,12 @@ test2match = {
     },
     "test5": {"myname":
               {"undefined1": "undefined1",
+               "undefined11": 1111,
+               "undefined12": True,
                "undefined2": {
-                   "undefined2": "undefined2"
+                   "undefined2": "undefined2",
+                   "undefined22": 2222,
+                   "undefined23": False
                }
               },
               "undefined4": "undefined4",

--- a/hack/testing/test-common-data-model.sh
+++ b/hack/testing/test-common-data-model.sh
@@ -278,10 +278,14 @@ cfg=`mktemp`
 cat > $cfg <<EOF
 <filter **>
   @type record_transformer
+  enable_ruby
+  auto_typecast
   <record>
     undefined1 undefined1
+    undefined11 \${1111}
+    undefined12 \${true}
     empty1 ""
-    undefined2 {"undefined2":"undefined2","":""}
+    undefined2 {"undefined2":"undefined2","":"","undefined22":2222,"undefined23":false}
     undefined3 {"":""}
     undefined4 undefined4
     undefined5 undefined5


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1396433
Never test a value for `empty?` directly - always use the `isempty`
method which can be safely used.
Added tests to exercise the code with top level values and nested
values that do not have the `empty?` method.