### PR TITLE
Update fluentd.yaml

### DIFF
--- a/deployer/templates/fluentd.yaml
+++ b/deployer/templates/fluentd.yaml
@@ -63,6 +63,7 @@ objects:
             resources:
               limits:
                 cpu: 100m
+                memory: 512Mi
             volumeMounts:
             - name: runlogjournal
               mountPath: /run/log/journal


### PR DESCRIPTION
Right now you do not set a memory limit on the Pods, which means they can grow exponentially since the project default is not set to have any limits (as per documentation). I am going with 512MB mostly by guessing based on what I have seen it consume on average in production environment