### PR TITLE
Point build info to redhat ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Origin-Aggregated-Logging [![Build Status](https://travis-ci.org/openshift/origin-aggregated-logging.svg?branch=es2.x)](https://travis-ci.org/openshift/origin-aggregated-logging)
+# Origin-Aggregated-Logging [![Build Status](https://ci.openshift.redhat.com/jenkins/buildStatus/icon?job=test-origin-aggregated-logging)](https://ci.openshift.redhat.com/jenkins/job/test-origin-aggregated-logging)
 
 This repo contains the image definitions of the components of the logging
 stack as well as tools for building and deploying them.


### PR DESCRIPTION
@ewolinetz update the build status to point to the public redhat ci which has meaningful info instead of travis