### PR TITLE
add wait_for_fluentd_to_catch_up

### DIFF
--- a/deployer/scripts/util.sh
+++ b/deployer/scripts/util.sh
@@ -318,3 +318,104 @@ function get_latest_pod() {
 
   echo $pod
 }
+
+# $1 - es pod name
+# $2 - es hostname (e.g. logging-es or logging-es-ops)
+# $3 - index name (e.g. project.logging, project.test, .operations, etc.)
+# $4 - _count or _search
+# $5 - field to search
+# $6 - search string
+# stdout is the JSON output from Elasticsearch
+# stderr is curl errors
+function query_es_from_es() {
+    oc exec $1 -- curl --connect-timeout 1 -s -k \
+       --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key \
+       https://${2}:9200/${3}*/${4}\?q=${5}:${6}
+}
+
+function get_count_from_json() {
+    python -c 'import json, sys; print json.loads(sys.stdin.read())["count"]'
+}
+
+# $1 - unique value to search for in es
+function add_test_message() {
+    local kib_pod=`get_running_pod kibana`
+    oc exec $kib_pod -c kibana -- curl --connect-timeout 1 -s \
+       http://localhost:5601/$1 > /dev/null 2>&1
+}
+
+# $1 - shell command or function to call to test if wait is over -
+#      this command/function should return true if the condition
+#      has been met, or false if still waiting for condition to be met
+# $2 - shell command or function to call if we timed out for error handling
+# $3 - timeout in seconds - should be a multiple of $4 (interval)
+# $4 - loop interval in seconds
+function wait_until_cmd_or_err() {
+    let ii=$3
+    local interval=${4:-1}
+    while [ $ii -gt 0 ] ; do
+        $1 && break
+        sleep $interval
+        let ii=ii-$interval
+    done
+    if [ $ii -le 0 ] ; then
+        $2
+        return 1
+    fi
+    return 0
+}
+
+# return true if the actual count matches the expected count, false otherwise
+function test_count_expected() {
+    myfield=${myfield:-message}
+    local nrecs=`query_es_from_es $espod $myhost $myproject _count $myfield $mymessage | \
+           get_count_from_json`
+    test "$nrecs" = $expected
+}
+
+# display an appropriate error message if the expected count did not match
+# the actual count
+function test_count_err() {
+    myfield=${myfield:-message}
+    nrecs=`query_es_from_es $espod $myhost $myproject _count $myfield $mymessage | \
+           get_count_from_json`
+    echo Error: found $nrecs for project $myproject message $mymessage - expected $expected
+    for thetype in _count _search ; do
+        query_es_from_es $espod $myhost $myproject $thetype $myfield $mymessage | python -mjson.tool
+    done
+}
+
+function wait_for_fluentd_to_catch_up() {
+    local es_pod=`get_running_pod es`
+    local es_ops_pod=`get_running_pod es-ops`
+    if [ -z "$es_ops_pod" ] ; then
+        es_ops_pod=$es_pod
+    fi
+    local uuid_es=`uuidgen`
+    local uuid_es_ops=`uuidgen`
+
+    add_test_message $uuid_es
+    logger -i -p local6.info -t $uuid_es_ops $uuid_es_ops
+
+    local rc=0
+
+    # poll for logs to show up
+
+    if espod=$es_pod myhost=logging-es myproject=project.logging mymessage=$uuid_es expected=1 \
+            wait_until_cmd_or_err test_count_expected test_count_err 600 ; then
+        echo good - $FUNCNAME: found 1 record project logging for $uuid_es
+    else
+        echo failed - $FUNCNAME: not found 1 record project logging for $uuid_es
+        rc=1
+    fi
+
+    if espod=$es_ops_pod myhost=logging-es-ops myproject=.operations mymessage=$uuid_es_ops expected=1 myfield=systemd.u.SYSLOG_IDENTIFIER \
+            wait_until_cmd_or_err test_count_expected test_count_err 600 ; then
+        echo good - $FUNCNAME: found 1 record project .operations for $uuid_es_ops
+    else
+        echo failed - $FUNCNAME: not found 1 record project .operations for $uuid_es_ops
+        rc=1
+    fi
+
+    return $rc
+}

--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -320,7 +320,7 @@ os::cmd::try_until_text "oc get pods -l component=fluentd" "Running" "$(( 5 * TI
 function wait_for_app() {
   echo "[INFO] Waiting for app in namespace $1"
   echo "[INFO] Waiting for database pod to start"
-  os::cmd::try_until_text "oc get -n $1 pods -l name=database" 'Running'
+  os::cmd::try_until_text "oc get -n $1 pods -l name=database" 'Running' "$(( 2 * TIME_MIN ))"
 
   echo "[INFO] Waiting for database service to start"
   os::cmd::try_until_text "oc get -n $1 services" 'database' "$(( 2 * TIME_MIN ))"
@@ -374,6 +374,10 @@ if [ "$ENABLE_OPS_CLUSTER" = "true" ] ; then
 else
     USE_CLUSTER=
 fi
+
+# when fluentd starts up it may take a while before it catches up with all of the logs
+# let's wait until that happens
+wait_for_fluentd_to_catch_up
 
 if [ "$TEST_PERF" = "true" ] ; then
     echo "Running performance tests"


### PR DESCRIPTION
There are sporadic test failures in tests that add a log entry
and wait for it to show up in elasticsearch.  One of the issues is
that it may take several minutes for fluentd to catch up with the
current system and container logs, especially when using the journal
as the log source.  I'm not sure why it takes so long, that is an
issue for future investigation.  But doing this "wait" up front before
the other tests should speed up those tests and eliminate some sporadic
test failures.

This also adds some useful testing functions to the shared util.sh
which we can move other tests to use.

It sometimes now (with origin 1.5?) takes 2 minutes for the test app
database to be available.