### PR TITLE
Bug 1399388 - Failed to ship logs by "Cannot get new connection from pool." to AWS Elasticsearch after start logging-fluentd pod for a while

### DIFF
--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -13,6 +13,10 @@
 
       type_name com.redhat.viaq.common
 
+      # there is currently a bug in the es plugin + excon - cannot
+      # recreate/reload connections
+      reload_connections false
+      reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -13,6 +13,10 @@
 
       type_name com.redhat.viaq.common
 
+      # there is currently a bug in the es plugin + excon - cannot
+      # recreate/reload connections
+      reload_connections false
+      reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -13,6 +13,10 @@
 
       type_name com.redhat.viaq.common
 
+      # there is currently a bug in the es plugin + excon - cannot
+      # recreate/reload connections
+      reload_connections false
+      reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -13,6 +13,10 @@
 
       type_name com.redhat.viaq.common
 
+      # there is currently a bug in the es plugin + excon - cannot
+      # recreate/reload connections
+      reload_connections false
+      reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1399388
Now that the fluent-plugin-elasticsearch has support for being able to
set `reload_connections false` and `reload_on_failure` false, set these
so that fluentd will not ever attempt to reload connections to
elasticsearch.