### PR TITLE
kibana CA cert must be provided with kibana route cert

### DIFF
--- a/deployer/README.md
+++ b/deployer/README.md
@@ -201,8 +201,12 @@ in the `logging-deployer` secret:
 
 * `kibana.crt` - A browser-facing certificate for the Kibana route. If not supplied, the route is secured with the default router cert.
 * `kibana.key` - A key to be used with the Kibana certificate.
+* `kibana.ca.crt` - The CA cert for the CA that issued `kibana.crt`, if needed
+  * if not present, the CA cert for the the internal Kibana service will be used
 * `kibana-ops.crt` - A browser-facing certificate for the Ops Kibana route. If not supplied, the route is secured with the default router cert.
 * `kibana-ops.key` - A key to be used with the Ops Kibana certificate.
+* `kibana-ops.ca.crt` - The CA cert for the CA that issued `kibana-ops.crt`, if needed
+  * if not present, the CA cert for the the internal Kibana service will be used
 * `kibana-internal.crt` - An internal certificate for the Kibana server.
 * `kibana-internal.key` - A key to be used with the internal Kibana certificate.
 * `server-tls.json` - JSON TLS options to override the internal Kibana TLS defaults; refer to
@@ -216,7 +220,8 @@ An invocation supplying a properly signed Kibana cert might be:
 
     $ oc create secret generic logging-deployer \
        --from-file kibana.crt=/path/to/cert \
-       --from-file kibana.key=/path/to/key
+       --from-file kibana.key=/path/to/key \
+       --from-file kibana.ca.crt=/path/to/ca.crt
 
 ### Choose Template Parameters
 

--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -177,7 +177,8 @@ if [ -n "${KIBANA_HOST:-}" ] ; then
           --signer-serial=$MASTER_CONFIG_DIR/ca.serial.txt
     deployer_args="$deployer_args \
                    --from-file=kibana.crt=$ARTIFACT_DIR/kibana.crt \
-                   --from-file=kibana.key=$ARTIFACT_DIR/kibana.key"
+                   --from-file=kibana.key=$ARTIFACT_DIR/kibana.key \
+                   --from-file=kibana.ca.crt=$MASTER_CONFIG_DIR/ca.crt"
 fi
 if [ -n "${KIBANA_OPS_HOST:-}" ] ; then
     deployer_args="$deployer_args --from-literal kibana-ops-hostname=$KIBANA_OPS_HOST"
@@ -200,7 +201,8 @@ if [ -n "${KIBANA_OPS_HOST:-}" ] ; then
           --signer-serial=$MASTER_CONFIG_DIR/ca.serial.txt
     deployer_args="$deployer_args \
                    --from-file=kibana-ops.crt=$ARTIFACT_DIR/kibana-ops.crt \
-                   --from-file=kibana-ops.key=$ARTIFACT_DIR/kibana-ops.key"
+                   --from-file=kibana-ops.key=$ARTIFACT_DIR/kibana-ops.key \
+                   --from-file=kibana-ops.ca.crt=$MASTER_CONFIG_DIR/ca.crt"
 fi
 os::cmd::expect_success "oc create configmap logging-deployer $deployer_args"
 


### PR DESCRIPTION
When creating the kibana route using an external cert provided by
the user, the route will be in a error state if it cannot validate
the given cert with a CA.  This allows specifying the CA cert file
to use for the route `--ca-cert`.