### PR TITLE
create external routes for ES; allow kibtest user ES _cluster access

### DIFF
--- a/elasticsearch/install.sh
+++ b/elasticsearch/install.sh
@@ -9,7 +9,7 @@ ln -s /usr/share/elasticsearch /usr/share/java/elasticsearch
 /usr/share/elasticsearch/bin/plugin install -b com.floragunn/search-guard-2/${SG_VER}
 /usr/share/elasticsearch/bin/plugin install io.fabric8/elasticsearch-cloud-kubernetes/${ES_CLOUD_K8S_VER}
 #/usr/share/elasticsearch/bin/plugin install io.fabric8.elasticsearch/openshift-elasticsearch-plugin/${OSE_ES_VER}
-/usr/share/elasticsearch/bin/plugin -i io.fabric8.elasticsearch/openshift-elasticsearch-plugin/${OSE_ES_VER} -url https://rmeggins.fedorapeople.org/openshift-elasticsearch-plugin-${OSE_ES_VER}.zip
+/usr/share/elasticsearch/bin/plugin install -b -v https://rmeggins.fedorapeople.org/openshift-elasticsearch-plugin-${OSE_ES_VER}.zip
 
 
 mkdir /elasticsearch

--- a/elasticsearch/install.sh
+++ b/elasticsearch/install.sh
@@ -8,7 +8,9 @@ ln -s /usr/share/elasticsearch /usr/share/java/elasticsearch
 /usr/share/elasticsearch/bin/plugin install -b com.floragunn/search-guard-ssl/${SG_SSL_VER}
 /usr/share/elasticsearch/bin/plugin install -b com.floragunn/search-guard-2/${SG_VER}
 /usr/share/elasticsearch/bin/plugin install io.fabric8/elasticsearch-cloud-kubernetes/${ES_CLOUD_K8S_VER}
-/usr/share/elasticsearch/bin/plugin install io.fabric8.elasticsearch/openshift-elasticsearch-plugin/${OSE_ES_VER}
+#/usr/share/elasticsearch/bin/plugin install io.fabric8.elasticsearch/openshift-elasticsearch-plugin/${OSE_ES_VER}
+/usr/share/elasticsearch/bin/plugin -i io.fabric8.elasticsearch/openshift-elasticsearch-plugin/${OSE_ES_VER} -url https://rmeggins.fedorapeople.org/openshift-elasticsearch-plugin-${OSE_ES_VER}.zip
+
 
 mkdir /elasticsearch
 mkdir -p $ES_CONF


### PR DESCRIPTION
* create external reencrypt routes for Elasticsearch - this will allow
username/token access from outside of the cluster
* add the kibtest user to the sg_role_admin to allow it to access the
  /_cluster/health and other monitoring endpoints
* increase the test app timeouts to avoid spurious test failures

These patches allow external monitoring tools (e.g.viaq/watches-cli) to
monitor ES.