### PR TITLE
Bug 1410705 - Roll over log entries are visible when journal-read-from-head is false

### DIFF
--- a/fluentd/generate_throttle_configs.rb
+++ b/fluentd/generate_throttle_configs.rb
@@ -132,9 +132,16 @@ def create_default_syslog()
   path "#{ENV['JOURNAL_SOURCE'] || '/run/log/journal'}"
   pos_file /var/log/journal.pos
   tag journal
-  read_from_head "#{ENV['JOURNAL_READ_FROM_HEAD'] || 'false'}"
-</source>
     CONF
+      # workaround for https://github.com/reevoo/fluent-plugin-systemd/issues/19
+      if ENV['JOURNAL_READ_FROM_HEAD'] == "true"
+        file.write(<<-CONF2)
+  read_from_head true
+      CONF2
+      end
+      file.write(<<-CONF3)
+</source>
+    CONF3
     }
   else
     File.open(file_name, 'w') { |file|


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1410705
The fluent-plugin-systemd plugin is parsing "false" as a string value, which
always evaluates to boolean true.  The fix is to not set read_from_head
when it is not true, this will use the default false internal value.
See also https://github.com/reevoo/fluent-plugin-systemd/issues/19
Also note that due to
https://github.com/reevoo/fluent-plugin-systemd/issues/20
and
https://github.com/ledbettj/systemd-journal/issues/64
there may be a few old entries read, even if read_from_head is false.