### PR TITLE
Removing logic to set reencrypt routes caCert as generated cert

### DIFF
--- a/deployer/scripts/install.sh
+++ b/deployer/scripts/install.sh
@@ -122,22 +122,18 @@ function generate_support_objects() {
 
   oc new-app logging-support-template
   kibana_keys=""; [ -e "$dir/kibana.crt" ] && kibana_keys="--cert=$dir/kibana.crt --key=$dir/kibana.key"
-  # use provided ca cert, if any, otherwise, use the internal ca cert
+  # use provided ca cert, if any
   if [ -e "$dir/kibana.ca.crt" ] ; then
       kibana_keys="$kibana_keys --ca-cert=$dir/kibana.ca.crt"
-  else
-      kibana_keys="$kibana_keys --ca-cert=$dir/ca.crt"
   fi
   oc create route reencrypt --service="logging-kibana" \
                              --hostname="${hostname}" \
                              --dest-ca-cert="$dir/ca.crt" \
                                    $kibana_keys
   kibana_keys=""; [ -e "$dir/kibana-ops.crt" ] && kibana_keys="--cert=$dir/kibana-ops.crt --key=$dir/kibana-ops.key"
-  # use provided ca cert, if any, otherwise, use the internal ca cert
+  # use provided ca cert, if any
   if [ -e "$dir/kibana-ops.ca.crt" ] ; then
       kibana_keys="$kibana_keys --ca-cert=$dir/kibana-ops.ca.crt"
-  else
-      kibana_keys="$kibana_keys --ca-cert=$dir/ca.crt"
   fi
   oc create route reencrypt --service="logging-kibana-ops" \
                              --hostname="${ops_hostname}" \


### PR DESCRIPTION
(cherry picked from commit 2dab911a37b5b1964f73db369c7b3107d987a63c)