### PR TITLE
new-app params cannot be comma delimited

### DIFF
--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin:v1.2.0
+FROM openshift/origin:v1.5.0-alpha.2
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 

--- a/hack/templates/dev-builds.yaml
+++ b/hack/templates/dev-builds.yaml
@@ -61,10 +61,10 @@ objects:
   spec:
     dockerImageRepository: openshift/origin
     tags:
-    - name: v1.2.0
+    - name: v1.5.0-alpha.2
       from:
         kind: DockerImage
-        name: openshift/origin:v1.2.0
+        name: openshift/origin:v1.5.0-alpha.2
 - apiVersion: v1
   kind: BuildConfig
   metadata:
@@ -87,7 +87,7 @@ objects:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: origin:v1.2.0
+          name: origin:v1.5.0-alpha.2
       type: Docker
     triggers:
     - type: ConfigChange


### PR DESCRIPTION
This is the fix for the
```
warning: --param no longer accepts comma-separated lists of values
```
errors.
This also updates the deployer base image to origin v1.5.0-alpha.2, which
uncovered the problem.
@jcantrill @ewolinetz ptal
[test]