### PR TITLE
add utility to make it easier to get stuff from es

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -40,6 +40,7 @@ ADD index_templates/ /usr/share/elasticsearch/index_templates/
 ADD install.sh ${HOME}/
 RUN ${HOME}/install.sh
 ADD run.sh ${HOME}/
+ADD es_util /usr/local/bin
 
 WORKDIR ${HOME}
 USER 1000

--- a/elasticsearch/es_util
+++ b/elasticsearch/es_util
@@ -1,0 +1,17 @@
+#/bin/bash -euxo pipefail
+
+# Utility to grab documents from the ES
+# instance using the admin certs and keys
+
+QUERY=${QUERY:-""} 
+INDEX=${INDEX:-"project.*"}
+SIZE=${SIZE:-10}
+SORT=${SORT:-"@timestamp:desc"}
+
+BASE=${BASE:-https://localhost:9200}
+
+if [ -z "${QUERY:-}" ]; then
+  QUERY="$BASE/$INDEX/_search?size=$SIZE&sort=$SORT"
+fi
+
+curl -s -k --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key $QUERY | python -mjson.tool


### PR DESCRIPTION
Simplifies getting project index data from es. Call like:

`oc exec POD -- bash es_util`

I don't know how to pass ENV vars with the command so the only way to change any of them would be to provide actual args.  Suggestions?