### PR TITLE
enable console logging for testing

### DIFF
--- a/hack/testing/init-log-stack
+++ b/hack/testing/init-log-stack
@@ -33,6 +33,7 @@ openshift_logging_image_prefix=$imageprefix
 openshift_logging_use_ops=${ENABLE_OPS_CLUSTER:-False}
 openshift_logging_fluentd_use_journal=${USE_JOURNAL:-}
 openshift_logging_fluentd_journal_read_from_head=${JOURNAL_READ_FROM_HEAD:-False}
+openshift_logging_es_log_appenders=['console']
 
 EOL
 


### PR DESCRIPTION
There are several places in the CI test code that expect `oc logs $espod`
will return some value.  In openshift-ansible the default now is to disable
console logging for ES which will make `oc logs $espod` not work.  This
commit enables ES console logging for CI test purposes.

@jcantrill @ewolinetz @nhosoi @portante PTAL
[test]