### PR TITLE
Bug 1439504 - Kibana show raw json in "message" field for pods messages in json format

### DIFF
--- a/fluentd/configs.d/openshift/filter-k8s-record-transform.conf
+++ b/fluentd/configs.d/openshift/filter-k8s-record-transform.conf
@@ -10,7 +10,7 @@
     # Plus we'd better avoid the file IO.
     hostname ${(record['kubernetes']['host'] rescue nil) || File.open('/etc/docker-hostname') { |f| f.readline }.rstrip}
     # log is set if MESSAGE is JSON valued and has err or msg field
-    message ${record['MESSAGE'] || log}
+    message ${record['message'] || record['MESSAGE'] || log}
     level ${record['PRIORITY']}
     time ${Time.at((record["_SOURCE_REALTIME_TIMESTAMP"] || record["__REALTIME_TIMESTAMP"]).to_f / 1000000.0).utc.to_datetime.rfc3339(6)}
     pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-systemd","name":"fluentd openshift","received_at":"${Time.at((record['_SOURCE_REALTIME_TIMESTAMP'] || record['__REALTIME_TIMESTAMP']).to_f / 1000000.0).utc.to_datetime.rfc3339(6)}","version":"0.12.29 1.4.0"}}

--- a/hack/testing/init-log-stack
+++ b/hack/testing/init-log-stack
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 OS_ANSIBLE_VERBOSITY=${OS_ANSIBLE_VERBOSITY:-"vv"}
-OS_VERSION=${OS_VERSION:-v1.5.0-alpha.2}
+OS_VERSION_STRING=${OS_VERSION:+openshift_release=$OS_VERSION}
 
 ANSIBLE_PLAYBOOK_ARGS=${ANSIBLE_PLAYBOOK_ARGS:-""}
 
@@ -23,7 +23,7 @@ docker_protect_installed_version=true
 openshift_deployment_type=origin
 deployment_type=origin
 required_packages=[]
-openshift_release=${OS_VERSION}
+$OS_VERSION_STRING
 
 openshift_hosted_logging_hostname=${KIBANA_HOST:-kibana.127.0.0.1.xip.io}
 openshift_master_logging_public_url=https://${KIBANA_HOST:-kibana.127.0.0.1.xip.io}

--- a/hack/testing/test-json-parsing.py
+++ b/hack/testing/test-json-parsing.py
@@ -1,0 +1,31 @@
+import sys
+import json
+
+obj = json.loads(sys.stdin.read())
+
+uuid = sys.argv[1]
+
+matchfieldsvalues = {
+    'statusCode': 404,
+    'type': 'response',
+    'method': 'get'
+}
+
+for dd in obj['hits']['hits']:
+    if dd['_score'] < 1.0:
+        print "ignoring spurious hit"
+        continue
+    match = 'GET /%s 404 ' % uuid
+    if not dd['_source']['message'].startswith(match):
+        print 'Error: message field does not start with [%s]: [%s]' % (match, dd['_source']['message'])
+        sys.exit(1)
+    for field,value in matchfieldsvalues.iteritems():
+        if not field in dd['_source']:
+            print 'Error: %s field not in record: [%s]' % (field, json.dumps(dd['_source']))
+            sys.exit(1)
+        if not dd['_source'][field] == value:
+            print 'Error: field %s does not have expected %s value: [%s]' % (field, str(value), str(dd['_source'][field]))
+            sys.exit(1)
+
+print 'Success: record contains all of the expected fields/values'
+sys.exit(0)

--- a/hack/testing/test-json-parsing.sh
+++ b/hack/testing/test-json-parsing.sh
@@ -1,0 +1,57 @@
+#! /bin/bash
+
+# test that logging will parse the message field containing
+# embedded JSON into its component fields, and use the
+# original message field in the embedded JSON
+
+if [[ $VERBOSE ]]; then
+  set -ex
+else
+  set -e
+  VERBOSE=
+fi
+set -o nounset
+set -o pipefail
+
+if ! type get_running_pod > /dev/null 2>&1 ; then
+    . ${OS_O_A_L_DIR:-../..}/deployer/scripts/util.sh
+fi
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-${TMPDIR:-/tmp}/origin-aggregated-logging}
+if [ ! -d $ARTIFACT_DIR ] ; then
+    mkdir -p $ARTIFACT_DIR
+fi
+
+# generate a log message in the Kibana logs - Kibana log messages are in JSON format:
+# {"type":"response","@timestamp":"2017-04-07T02:03:37Z","tags":[],"pid":1,"method":"get","statusCode":404,"req":{"url":"/ca30cead-d470-4db8-a2a2-bb71439987e2","method":"get","headers":{"user-agent":"curl/7.29.0","host":"localhost:5601","accept":"*/*"},"remoteAddress":"127.0.0.1","userAgent":"127.0.0.1"},"res":{"statusCode":404,"responseTime":3,"contentLength":9},"message":"GET /ca30cead-d470-4db8-a2a2-bb71439987e2 404 3ms - 9.0B"}
+# logging should parse this and make "type", "tags", "statusCode", etc. as top level fields
+# the "message" field should contain only the embedded message and not the entire JSON blob
+
+es_pod=`get_running_pod es`
+uuid_es=`uuidgen`
+echo Adding test message $uuid_es to Kibana . . .
+add_test_message $uuid_es
+rc=0
+timeout=600
+echo Waiting $timeout seconds for $uuid_es to show up in Elasticsearch . . .
+if espod=$es_pod myproject=project.logging. mymessage=$uuid_es expected=1 \
+    wait_until_cmd_or_err test_count_expected test_count_err $timeout ; then
+    echo good - $0: found 1 record project logging for $uuid_es
+else
+    echo failed - $0: not found 1 record project logging for $uuid_es after $timeout seconds
+    echo "Checking journal for $uuid_es..."
+    if journalctl | grep $uuid_es ; then
+        echo "Found $uuid_es in journal"
+    else
+        echo "Unable to find $uuid_es in journal"
+    fi
+
+    exit 1
+fi
+
+echo Testing if record is in correct format . . .
+query_es_from_es $es_pod project.logging. _search message $uuid_es | \
+    python test-json-parsing.py $uuid_es
+
+echo Success: $0 passed
+exit 0


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1439504
The problem is that the k8s record transformer filter was wiping
out the "message" field added by the k8s meta filter when reading
logs from the journal.  The fix is to preserve that field if present.

Do not set openshift_release in CI test if OS_VERSION is unset.
Instead, let ansible figure out the version from the installed software.

(cherry picked from commit 9a6274451d850c4d3e42ba35781b607659255c02)
@jcantrill @ewolinetz PTAL backport to release-1.5