### PR TITLE
allow logging.sh to be used with pre-deployed openshift + logging

### DIFF
--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$VERBOSE" = true ]; then
+if [ -n "${VERBOSE:-}" ]; then
   set -ex
 else
   set -e

--- a/hack/testing/check-logs.go
+++ b/hack/testing/check-logs.go
@@ -33,7 +33,7 @@ func main() {
 
 	// instead of receiving jsonStream as an Arg, we'll make the call ourselves...
 	proxyHeaders := `-H 'X-Proxy-Remote-User: ` + userName + `' -H 'Authorization: Bearer ` + userToken + `' -H 'X-Forwarded-For: ` + testIP + `'`
-	queryCommand := `oc exec ` + kibana_pod + ` -- curl -s --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert --cacert /etc/kibana/keys/ca ` + proxyHeaders + ` -XGET "https://` + es_svc + `/` + index + `.*/com.redhat.viaq.common/_search?q=hostname:` + hostname + `&fields=message&size=` + querySize + `"`
+	queryCommand := `oc exec ` + kibana_pod + ` -c kibana -- curl -s --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert --cacert /etc/kibana/keys/ca ` + proxyHeaders + ` -XGET "https://` + es_svc + `/` + index + `.*/com.redhat.viaq.common/_search?q=hostname:` + hostname + `&fields=message&size=` + querySize + `"`
 	if verbose {
 		fmt.Printf("Executing command [%s]\n", queryCommand)
 	}

--- a/hack/testing/check-logs.sh
+++ b/hack/testing/check-logs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$VERBOSE" = true ]; then
+if [ -n "${VERBOSE:-}" ]; then
   set -ex
 else
   set -e

--- a/hack/testing/perf-test-operations.sh
+++ b/hack/testing/perf-test-operations.sh
@@ -2,7 +2,7 @@
 # This tests for raw .operations index performance - write a bunch of messages
 # to the system log and see how long it takes all of them to show up in ES
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ] ; then
   set -ex
 else
   set -e
@@ -97,7 +97,7 @@ fi
 # not used now, but in case we need it
 INDEX_PREFIX=
 count_ge_nmessages() {
-    curcount=`oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
+    curcount=`oc exec $kpod -c kibana -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
             https://logging-es${ops}:9200/${INDEX_PREFIX}.operations*/_count\?q=message:$prefix | \
             python -c 'import json, sys; print json.loads(sys.stdin.read())["count"]'`
     # output: time count 
@@ -116,7 +116,7 @@ echo duration `expr $MARKTIME - $STARTTIME`
 
 # search ES and extract the messages
 esmessages=`mktemp`
-oc exec $kpod -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
+oc exec $kpod -c kibana -- curl -s -k --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
    https://logging-es${ops}:9200/${INDEX_PREFIX}.operations*/_search\?q=ident:$prefix\&fields=message\&size=`expr $NMESSAGES + 1` | \
     python -c 'import json, sys; print "\n".join([ii["fields"]["message"][0] for ii in json.loads(sys.stdin.read())["hits"]["hits"]])' | sort -n > $esmessages
 

--- a/hack/testing/setup-and-deploy-logging
+++ b/hack/testing/setup-and-deploy-logging
@@ -1,0 +1,197 @@
+#!/bin/bash
+
+# this must be sourced from logging.sh - it will not work any other way
+
+### create and deploy the logging component pods ###
+masterurlhack="-p MASTER_URL=https://172.30.0.1:443"
+OS_O_A_L_DIR=${OS_O_A_L_DIR:-$OS_ROOT/test/extended/origin-aggregated-logging}
+os::cmd::expect_success "oadm new-project logging --node-selector=''"
+os::cmd::expect_success "oc project logging"
+os::cmd::expect_success "oc create -f $OS_O_A_L_DIR/deployer/deployer.yaml"
+os::cmd::expect_success "oc new-app logging-deployer-account-template"
+os::cmd::expect_success "oadm policy add-cluster-role-to-user oauth-editor system:serviceaccount:logging:logging-deployer"
+deployer_args="--from-literal enable-ops-cluster=${ENABLE_OPS_CLUSTER} \
+    --from-literal use-journal=${USE_JOURNAL:-} \
+    --from-literal journal-source=${JOURNAL_SOURCE:-} \
+    --from-literal journal-read-from-head=${JOURNAL_READ_FROM_HEAD:-false}"
+if [ -n "${PUBLIC_MASTER_HOST:-}" ] ; then
+    deployer_args="$deployer_args --from-literal public-master-url=https://${PUBLIC_MASTER_HOST}:8443"
+fi
+if [ -n "${KIBANA_HOST:-}" ] ; then
+    deployer_args="$deployer_args --from-literal kibana-hostname=$KIBANA_HOST"
+    if getent hosts $KIBANA_HOST > /dev/null 2>&1 ; then
+        echo kibana host $KIBANA_HOST is `getent hosts $KIBANA_HOST` `getent ahostsv4 $KIBANA_HOST`
+    else
+        # does not resolve - add it as an alias for the external IP
+        ip=`getent hosts $PUBLIC_MASTER_HOST | awk '{print $1}'`
+        if grep -q \^$ip /etc/hosts ; then
+            sudo sed -i -e 's/^\('$ip'.*\)$/\1 '$KIBANA_HOST'/' /etc/hosts
+        else
+            echo $ip $KIBANA_HOST | sudo tee -a /etc/hosts
+        fi
+    fi
+    # generate externally facing cert for router
+    openshift admin ca create-server-cert --key=$ARTIFACT_DIR/kibana.key \
+          --cert=$ARTIFACT_DIR/kibana.crt --hostnames=$KIBANA_HOST \
+          --signer-cert=$MASTER_CONFIG_DIR/ca.crt \
+          --signer-key=$MASTER_CONFIG_DIR/ca.key \
+          --signer-serial=$MASTER_CONFIG_DIR/ca.serial.txt
+    deployer_args="$deployer_args \
+                   --from-file=kibana.crt=$ARTIFACT_DIR/kibana.crt \
+                   --from-file=kibana.key=$ARTIFACT_DIR/kibana.key \
+                   --from-file=kibana.ca.crt=$MASTER_CONFIG_DIR/ca.crt"
+fi
+if [ -n "${KIBANA_OPS_HOST:-}" ] ; then
+    deployer_args="$deployer_args --from-literal kibana-ops-hostname=$KIBANA_OPS_HOST"
+    if getent hosts $KIBANA_OPS_HOST > /dev/null 2>&1 ; then
+        echo kibana host $KIBANA_OPS_HOST is `getent hosts $KIBANA_OPS_HOST` `getent ahostsv4 $KIBANA_OPS_HOST`
+    else
+        # does not resolve - add it as an alias for the external IP
+        ip=`getent hosts $PUBLIC_MASTER_HOST | awk '{print $1}'`
+        if grep -q \^$ip /etc/hosts ; then
+            sudo sed -i -e 's/^\('$ip'.*\)$/\1 '$KIBANA_OPS_HOST'/' /etc/hosts
+        else
+            echo $ip $KIBANA_OPS_HOST | sudo tee -a /etc/hosts
+        fi
+    fi
+    # generate externally facing cert for router
+    openshift admin ca create-server-cert --key=$ARTIFACT_DIR/kibana-ops.key \
+          --cert=$ARTIFACT_DIR/kibana-ops.crt --hostnames=$KIBANA_OPS_HOST \
+          --signer-cert=$MASTER_CONFIG_DIR/ca.crt \
+          --signer-key=$MASTER_CONFIG_DIR/ca.key \
+          --signer-serial=$MASTER_CONFIG_DIR/ca.serial.txt
+    deployer_args="$deployer_args \
+                   --from-file=kibana-ops.crt=$ARTIFACT_DIR/kibana-ops.crt \
+                   --from-file=kibana-ops.key=$ARTIFACT_DIR/kibana-ops.key \
+                   --from-file=kibana-ops.ca.crt=$MASTER_CONFIG_DIR/ca.crt"
+fi
+os::cmd::expect_success "oc create configmap logging-deployer $deployer_args"
+
+if [ -n "$USE_LOGGING_DEPLOYER" ] ; then
+    imageprefix="docker.io/openshift/origin-"
+elif [ -n "$USE_LOGGING_DEPLOYER_SCRIPT" ] ; then
+    pushd $OS_O_A_L_DIR/deployer
+    IMAGE_PREFIX="openshift/origin-" PROJECT=logging ./run.sh
+    popd
+    imageprefix=
+else
+    if [ "$USE_LOCAL_SOURCE" = "true" ] ; then
+        build_filter() {
+            # remove all build triggers
+            sed "/triggers/d; /- type: .*Change/d"
+        }
+        post_build() {
+            os::cmd::try_until_success "oc get imagestreamtag origin:latest" "$(( 1 * TIME_MIN ))"
+            for bc in `oc get bc -o jsonpath='{.items[*].metadata.name}'` ; do
+                oc start-build --from-dir $OS_O_A_L_DIR $bc
+            done
+        }
+    else
+        build_filter() {
+            cat
+        }
+        post_build() {
+            :
+        }
+    fi
+
+    os::cmd::expect_success "oc process -o yaml \
+       -f $OS_O_A_L_DIR/hack/templates/dev-builds.yaml \
+       -v LOGGING_FORK_URL=$GIT_URL -v LOGGING_FORK_BRANCH=$GIT_BRANCH \
+       | build_filter | oc create -f -"
+    post_build
+    os::cmd::expect_success "wait_for_builds_complete"
+    imageprefix=`oc get is | awk '$1 == "logging-deployment" {print gensub(/^([^/]*\/logging\/).*$/, "\\\1", 1, $2)}'`
+    sleep 5
+fi
+pvc_params=""
+if [ "$ENABLE_OPS_CLUSTER" = "true" ]; then
+    if [ ! -d $ES_OPS_VOLUME ] ; then
+        sudo mkdir -p $ES_OPS_VOLUME
+        sudo chown 1000:1000 $ES_OPS_VOLUME
+    fi
+    os::cmd::expect_success "oc process -f $OS_O_A_L_DIR/hack/templates/pv-hostmount.yaml -v SIZE=10 -v PATH=${ES_OPS_VOLUME} | oc create -f -"
+    pvc_params="-p ES_OPS_PVC_SIZE=10 -p ES_OPS_PVC_PREFIX=es-ops-pvc-" # deployer will create PVC
+fi
+# TODO: put this back to hostmount-anyuid once we've resolved the SELinux problem with that
+# https://github.com/openshift/origin-aggregated-logging/issues/89
+os::cmd::expect_success "oadm policy add-scc-to-user privileged system:serviceaccount:logging:aggregated-logging-fluentd"
+sleep 5
+os::cmd::expect_success "oadm policy add-cluster-role-to-user cluster-reader \
+                      system:serviceaccount:logging:aggregated-logging-fluentd"
+sleep 5
+os::cmd::expect_success "oadm policy add-cluster-role-to-user rolebinding-reader \
+                      system:serviceaccount:logging:aggregated-logging-elasticsearch"
+sleep 5
+if [ ! -n "$USE_LOGGING_DEPLOYER_SCRIPT" ] ; then
+    os::cmd::expect_success "oc new-app \
+                          logging-deployer-template \
+                          -p IMAGE_PREFIX=$imageprefix \
+                          ${pvc_params} ${masterurlhack}"
+
+    os::cmd::try_until_text "oc describe bc logging-deployment | awk '/^logging-deployment-/ {print \$2}'" "complete"
+    os::cmd::try_until_text "oc get pods -l logging-infra=deployer" "Completed" "$(( 3 * TIME_MIN ))"
+fi
+if [ "$ENABLE_OPS_CLUSTER" = "true" ] ; then
+    # TODO: this shouldn't be necessary once SELinux problems are worked out
+    # leave this at hostmount-anyuid once we've resolved the SELinux problem with that
+    # https://github.com/openshift/origin-aggregated-logging/issues/89
+    os::cmd::expect_success "oadm policy add-scc-to-user privileged \
+         system:serviceaccount:logging:aggregated-logging-elasticsearch"
+    # update the ES_OPS DC to be in the privileged context.
+    # TODO: should not have to do that - should work the same as regular hostmount
+    os::cmd::try_until_text "oc get dc -o name -l component=es-ops" "ops"
+    ops_dc=$(oc get dc -o name -l component=es-ops) || exit 1
+    os::cmd::expect_success "oc patch $ops_dc \
+       -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"elasticsearch\",\"securityContext\":{\"privileged\": true}}]}}}}'"
+
+    os::cmd::try_until_text "oc deploy $ops_dc --latest" "Started" "$(( 3 * TIME_MIN ))"
+fi
+# see if expected pods are running
+os::cmd::try_until_text "oc get pods -l component=es" "Running" "$(( 3 * TIME_MIN ))"
+os::cmd::try_until_text "oc get pods -l component=kibana" "Running" "$(( 3 * TIME_MIN ))"
+os::cmd::try_until_text "oc get pods -l component=curator" "Running" "$(( 3 * TIME_MIN ))"
+if [ "$ENABLE_OPS_CLUSTER" = "true" ] ; then
+    # make sure the expected PVC was created and bound
+    os::cmd::try_until_text "oc get persistentvolumeclaim es-ops-pvc-1" "Bound" "$(( 1 * TIME_MIN ))"
+    # make sure the expected pods are running
+    os::cmd::try_until_text "oc get pods -l component=es-ops" "Running" "$(( 3 * TIME_MIN ))"
+    os::cmd::try_until_text "oc get pods -l component=kibana-ops" "Running" "$(( 3 * TIME_MIN ))"
+    os::cmd::try_until_text "oc get pods -l component=curator-ops" "Running" "$(( 3 * TIME_MIN ))"
+fi
+
+if [ -n "$ES_VOLUME" ] ; then
+    if [ ! -d $ES_VOLUME ] ; then
+        sudo mkdir -p $ES_VOLUME
+        sudo chown 1000:1000 $ES_VOLUME
+    fi
+    # allow es and es-ops to mount volumes from the host
+    os::cmd::expect_success "oadm policy add-scc-to-user hostmount-anyuid \
+         system:serviceaccount:logging:aggregated-logging-elasticsearch"
+    # get es dc
+    esdc=`oc get dc -l component=es -o jsonpath='{.items[0].metadata.name}'`
+    # shutdown es
+    espod=`get_running_pod es`
+    os::cmd::expect_success "oc scale dc $esdc --replicas=0"
+    os::cmd::try_until_failure "oc describe pod $espod > /dev/null" "$(( 3 * TIME_MIN ))"
+    # mount volume manually on ordinary cluster
+    os::cmd::expect_success "oc volume dc/$esdc \
+                             --add --overwrite --name=elasticsearch-storage \
+                             --type=hostPath --path=$ES_VOLUME"
+    # start up es
+    os::cmd::try_until_text "oc deploy $esdc --latest" "Started" "$(( 3 * TIME_MIN ))"
+    os::cmd::expect_success "oc scale dc $esdc --replicas=1"
+    os::cmd::try_until_text "oc get pods -l component=es" "Running" "$(( 3 * TIME_MIN ))"
+fi
+
+# start fluentd
+os::cmd::try_until_success "oc get daemonset logging-fluentd" "$(( 1 * TIME_MIN ))"
+os::cmd::expect_success "oc label node --all logging-infra-fluentd=true"
+
+# the old way with dc's
+# # scale up a fluentd pod
+# os::cmd::try_until_success "oc get dc logging-fluentd"
+# os::cmd::expect_success "oc scale dc logging-fluentd --replicas=1"
+
+os::cmd::try_until_text "oc get pods -l component=fluentd" "Running" "$(( 5 * TIME_MIN ))"
+### logging component pods are now created and deployed ###

--- a/hack/testing/test-common-data-model.sh
+++ b/hack/testing/test-common-data-model.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ]; then
   set -ex
 else
   set -e

--- a/hack/testing/test-datetime-future.sh
+++ b/hack/testing/test-datetime-future.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ] ; then
   set -ex
 else
   set -e
@@ -67,7 +67,7 @@ get_running_pod() {
 # stdout is the JSON output from Elasticsearch
 # stderr is curl errors
 curl_es_from_kibana() {
-    oc exec $1 -- curl --connect-timeout 1 -s -k \
+    oc exec $1 -c kibana -- curl --connect-timeout 1 -s -k \
        --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
        -H "X-Proxy-Remote-User: $test_name" -H "Authorization: Bearer $test_token" -H "X-Forwarded-For: 127.0.0.1" \
        https://${2}:9200/${3}*/${4}\?q=${5}:${6}

--- a/hack/testing/test-es-copy.sh
+++ b/hack/testing/test-es-copy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ] ; then
   set -ex
 else
   set -e
@@ -105,7 +105,7 @@ wait_for_pod_ACTION() {
 # stdout is the JSON output from Elasticsearch
 # stderr is curl errors
 curl_es_from_kibana() {
-    oc exec $1 -- curl --connect-timeout 1 -s -k \
+    oc exec $1 -c kibana -- curl --connect-timeout 1 -s -k \
        --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
        -H "X-Proxy-Remote-User: $test_name" -H "Authorization: Bearer $test_token" -H "X-Forwarded-For: 127.0.0.1" \
        https://${2}:9200/${3}*/${4}\?q=${5}:${6}

--- a/hack/testing/test-fluentd-forward.sh
+++ b/hack/testing/test-fluentd-forward.sh
@@ -5,7 +5,7 @@
 # verify the same way we do now (for ES copy)
 # need to create a custom configmap for both fluentd?
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ]; then
   set -ex
 else
   set -e
@@ -189,7 +189,7 @@ create_forwarding_fluentd() {
 # stdout is the JSON output from Elasticsearch
 # stderr is curl errors
 curl_es_from_kibana() {
-    oc exec $1 -- curl --connect-timeout 1 -s -k \
+    oc exec $1 -c kibana -- curl --connect-timeout 1 -s -k \
        --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
        -H "X-Proxy-Remote-User: $test_name" -H "Authorization: Bearer $test_token" -H "X-Forwarded-For: 127.0.0.1" \
        https://${2}:9200/${3}*/${4}\?q=${5}:${6}

--- a/hack/testing/test-upgrade.sh
+++ b/hack/testing/test-upgrade.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ] ; then
   set -ex
 else
   set -e
@@ -153,7 +153,7 @@ function useFluentdDC() {
   waitFor "[[ -z \"\$(oc get pod \$fluentdpod -o name)\" ]]" "$(( 3 * TIME_MIN ))"
 
   oc process -f templates/fluentd_dc.yaml \
-     -v IMAGE_PREFIX_DEFAULT=$imageprefix,OPS_HOST=$ops_host,OPS_PORT=$ops_port | oc create -f -
+     -v IMAGE_PREFIX_DEFAULT=$imageprefix -v OPS_HOST=$ops_host -v OPS_PORT=$ops_port | oc create -f -
 
   oc new-app logging-fluentd-template
 


### PR DESCRIPTION
@jcantrill @ewolinetz @nhosoi @lukas-vlcek PTAL
These fixes will allow the logging CI tests to be run against an
OpenShift + logging installed via rpm/ansible.
The tests still require that the correct version of both origin and
origin-aggregated-logging are cloned from git:

    mkdir -p /data/src/github.com
    cd /data/src/github.com
    git clone https://github.com/openshift/origin -b release-N.M
    git clone https://github.com/openshift/origin-aggregated-logging -b release-N.M
    oc project logging
    /data/src/github.com/origin-aggregated-logging/hack/testing/logging.sh NOSETUP