### PR TITLE
Make local ES node REST point URL configurable

### DIFF
--- a/elasticsearch/probe/readiness.sh
+++ b/elasticsearch/probe/readiness.sh
@@ -17,7 +17,7 @@
 #
 
 # TODO: try re-use code from ./run.sh
-ES_REST_BASEURL=https://localhost:9200
+ES_REST_BASEURL=${ES_REST_BASEURL:-https://logging-es:9200}
 EXPECTED_RESPONSE_CODE=200
 secret_dir=/etc/elasticsearch/secret
 max_time=${max_time:-4}
@@ -33,6 +33,6 @@ response_code=$(curl -s -X HEAD \
 if [ ${response_code} == ${EXPECTED_RESPONSE_CODE} ]; then
   exit 0
 else
-  echo "Elasticsearch node is not ready to accept HTTP requests yet [response code: ${response_code}]"
+  echo "Elasticsearch node is not ready to accept HTTP requests at ${ES_REST_BASEURL} [response code: ${response_code}]"
   exit 1
 fi


### PR DESCRIPTION
This PR makes the readiness probe URL configurable and one can override it using `${ES_REST_BASEURL}` env var. The default value is newly set to `https://logging-es:9200`.

In general, if cURL command is run against invalid URL (or the DNS is not working correctly) then we can get `${response code} == "000"`.

See example:
````bash
$ cat test.sh
#!/bin/bash
URL=$1
response_code=$(curl -s -v -X HEAD \
    --max-time 1 \
    -w '%{response_code}' \
    "${URL}") 
echo Response code: ${response_code}
````
````bash
# Invalid URL
# ===============================
$ ./test.sh https://dummy
* Rebuilt URL to: https://dummy/
* Could not resolve host: dummy
* Closing connection 0
Response code: 000

# Valid URL
# ===============================
$ ./test.sh  https://www.google.com
* Rebuilt URL to: https://www.google.com/
*   Trying 2a00:1450:400e:809::2004...
* connect to 2a00:1450:400e:809::2004 port 443 failed: Connection refused
*   Trying 216.58.211.100...
* Connected to www.google.com (216.58.211.100) port 443 (#0)

(... truncated ...)

* Operation timed out after 282 milliseconds with 0 out of 259 bytes received
* Closing connection 0
Response code: 302
````

@richm @jcantrill @ewolinetz PTAL, general questions for you below:

- Does the default value `https://logging-es:9200` represent the local ES node in this context?
- Shall we change the name `${ES_REST_BASEURL}` of the env var to something better?
- I would like to add `-v` to the cURL call so that we can see in the logs (`oc describe pod ...`) possible reason why readiness probe fails, but I am afraid this can be expensive change (if I am not mistaken readiness probe get called every few sec according to configuration, it is not stopped after first successful pass, or is it? //cc @rhcarvalho), other option is to print verbose info only if the test fails, but that seem to be more complicated in bash.