### PR TITLE
fixes for test env vars and paths

### DIFF
--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -71,8 +71,13 @@ fi
 # use a few tools from the deployer
 source "$OS_O_A_L_DIR/deployer/scripts/util.sh"
 
+# have to set these here so setup_tmpdir_vars will not give them bogus values
+export LOG_DIR=${LOG_DIR:-${TMPDIR:-/tmp}/origin-aggregated-logging/logs}
+export ARTIFACT_DIR=${ARTIFACT_DIR:-${TMPDIR:-/tmp}/origin-aggregated-logging/artifacts}
 # include all the origin test libs we need
 if [ -f ${OS_ROOT}/hack/lib/init.sh ] ; then
+    # disallow init.sh from calling setup_tmpdir_vars
+    export OS_TMP_ENV_SET=origin-aggregated-logging
     source ${OS_ROOT}/hack/lib/init.sh # one stop shopping
     os::util::environment::setup_tmpdir_vars origin-aggregated-logging
 else
@@ -119,10 +124,8 @@ trap "exit" INT TERM
 trap "cleanup" EXIT
 
 # override LOG_DIR and ARTIFACTS_DIR
-export LOG_DIR=${LOG_DIR:-${TMPDIR:-/tmp}/origin-aggregated-logging/logs}
-export ARTIFACT_DIR=${ARTIFACT_DIR:-${TMPDIR:-/tmp}/origin-aggregated-logging/artifacts}
 os::util::environment::use_sudo
-os::util::environment::setup_all_server_vars "origin-aggregated-logging/"
+os::util::environment::setup_all_server_vars
 os::util::environment::setup_time_vars
 
 os::log::system::start
@@ -142,7 +145,6 @@ openshift ex config patch ${SERVER_CONFIG_DIR}/master/master-config.orig.yaml \
           --patch="{\"networkConfig\": {\"externalIPNetworkCIDRs\": [\"0.0.0.0/0\"]}}" > \
           ${SERVER_CONFIG_DIR}/master/master-config.yaml
 os::start::server
-
 export KUBECONFIG="${ADMIN_KUBECONFIG}"
 
 os::test::junit::declare_suite_start "logging"


### PR DESCRIPTION
There have been some changes to the test init procedure which was
wiping out our env. vars.
@jcantrill @ewolinetz @nhosoi @lukas-vlcek PTAL
[test]