### PR TITLE
allow use of fluentd monitor and debug agents

### DIFF
--- a/fluentd/configs.d/input-pre-debug.conf
+++ b/fluentd/configs.d/input-pre-debug.conf
@@ -1,0 +1,5 @@
+<source>
+  @type debug_agent
+  port "#{ENV['DEBUG_PORT'] || '24230'}"
+  bind "#{ENV['DEBUG_BIND_ADDR'] || '127.0.0.1'}"
+</source>

--- a/fluentd/configs.d/input-pre-monitor.conf
+++ b/fluentd/configs.d/input-pre-monitor.conf
@@ -1,0 +1,5 @@
+<source>
+  @type monitor_agent
+  bind "#{ENV['MONITOR_BIND_ADDR'] || '0.0.0.0'}"
+  port "#{ENV['MONITOR_PORT'] || '24220'}"
+</source>

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -105,6 +105,28 @@ else
     echo > $CFG_DIR/dynamic/es-ops-copy-config.conf
 fi
 
+# http://docs.fluentd.org/v0.12/articles/monitoring
+if [ "${ENABLE_MONITOR_AGENT:-}" = true ] ; then
+    cp $CFG_DIR/input-pre-monitor.conf $CFG_DIR/openshift
+    # copy any user defined files, possibly overwriting the standard ones
+    if [ -f $CFG_DIR/user/input-pre-monitor.conf ] ; then
+        cp -f $CFG_DIR/user/input-pre-monitor.conf $CFG_DIR/openshift
+    fi
+else
+    rm -f $CFG_DIR/openshift/input-pre-monitor.conf
+fi
+
+# http://docs.fluentd.org/v0.12/articles/monitoring#debug-port
+if [ "${ENABLE_DEBUG_AGENT:-}" = true ] ; then
+    cp $CFG_DIR/input-pre-debug.conf $CFG_DIR/openshift
+    # copy any user defined files, possibly overwriting the standard ones
+    if [ -f $CFG_DIR/user/input-pre-debug.conf ] ; then
+        cp -f $CFG_DIR/user/input-pre-debug.conf $CFG_DIR/openshift
+    fi
+else
+    rm -f $CFG_DIR/openshift/input-pre-debug.conf
+fi
+
 if [[ $DEBUG ]] ; then
     exec fluentd $fluentdargs > /var/log/fluentd.log 2>&1
 else


### PR DESCRIPTION
@jcantrill @ewolinetz @lukas-vlcek @nhosoi @t0ffel ptal
[test]

```
edit daemonset logging-fluentd
add env ENABLE_MONITOR_AGENT true
$ oc exec logging-fluentd-wjm93 -- curl -s http://localhost:24220/api/plugins.json|python -mjson.tool
        {
            "buffer_queue_length": 0,
            "buffer_total_queued_size": 151777,
            "config": {
                "@type": "secure_forward",
...
            }
            "retry_count": 0,
            "type": "secure_forward"
        },
```