### PR TITLE
Reformat cluster end-to-end test to use Bash helpers

### DIFF
--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -1,352 +1,51 @@
 #!/bin/bash
 
-if [ "$VERBOSE" = true ]; then
-  set -ex
-else
-  set -e
+set -o errexit
+set -o nounset
+set -o pipefail
+
+oal_expected_deploymentconfigs=( "logging-kibana" "logging-curator" )
+oal_expected_routes=( "logging-kibana" )
+oal_expected_services=( "logging-es" "logging-es-cluster" "logging-kibana" )
+oal_expected_oauthclients=( "kibana-proxy" )
+oal_expected_daemonsets=( "logging-fluentd" )
+oal_elasticseach_components=( "es" )
+oal_kibana_components=( "kibana" )
+
+if [[ $# -eq 1 ]]; then
+	# There is an ops cluster set up, so we
+	# need to expect to see more objects.
+	oal_expected_deploymentconfigs+=( "logging-kibana-ops" "logging-curator-ops" )
+	oal_expected_routes+=( "logging-kibana-ops" )
+	oal_expected_services+=( "logging-es-ops" "logging-es-ops-cluster" "logging-kibana-ops" )
+	oal_elasticseach_components+=( "es-ops" )
+	oal_kibana_components+=( "kibana-ops" )
 fi
 
-TIMES=300
-
-function waitFor() {
-
-  local statement=$1
-  for (( i=1; i<=$TIMES; i++ )); do
-    eval "$statement" && return 0
-    sleep 1
-  done
-  return 1
-}
-
-function waitForValue() {
-
-  local value=$1
-
-  if waitFor "[[ -n \$($value) ]]"; then
-    eval $value
-    return 0
-  fi
-  echo "$value not found within $TIMES seconds"
-  return 1
-}
-
-function checkESStarted() {
-
-  local pod=$1
-  local cluster_service
-
-  if ! cluster_service=$(waitForValue "oc logs $pod | grep '\[cluster\.service[[:space:]]*\]'"); then
-    echo "Unable to find log message from cluster.service for pod $pod within $TIMES seconds"
-    return 1
-  fi
-
-  # If this instance detects a different master, it won't recover its own indices
-  #  check for output from "[cluster.service " with "] detected_master ["
-  local non_master=$(echo $cluster_service | grep "detected_master")
-# OR
-  # instance is the master if logs have this:
-  #  check for output from "[cluster.service " with "] new_master ["
-  local master=$(echo $cluster_service | grep "new_master")
-
-  # Check that instance started.
-  #  check for output from "[node " with "] started"
-
-  if ! waitFor "[[ -n \"\$(oc logs $pod | grep '\[node[[:space:]]*\][[:space:]]*\[.*\][[:space:]]*started')\" ]]"; then
-    echo "Unable to find log message from node that ES pod $pod started within $TIMES seconds"
-    return 1
-  fi
-
-  # Check that it recovered its indices after starting if a master
-  #  check for output from "[gateway" with "] recovered[:num:] indices into cluster state"
-  if [[ -n "$master" ]]; then
-    if ! waitFor "[[ -n \"\$(oc logs $pod | grep '\[gateway[[:space:]]*\][[:space:]]*\[.*\][[:space:]]*recovered[[:space:]]*\[[[:digit:]]*\][[:space:]]*indices into cluster_state')\" ]]"; then
-      echo "Unable to find log message from gateway that ES pod $pod recovered its indices within $TIMES seconds"
-      return 1
-    fi
-  else
-    # if we aren't master we should be started by now and should have detected a master
-    if [[ -z "$non_master" ]]; then
-      echo "For ES pod $pod - node isn't master and was unable to detect master"
-      return 1
-    fi
-  fi
-}
-
-function checkKibanaStarted() {
-
-  local pod=$1
-
-  if ! waitFor "[[ -n \$(oc logs $pod -c kibana | grep 'Server running at http://0.0.0.0:5601') ]]"; then
-    echo "Kibana pod $pod was not able to start up within $TIMES seconds"
-    return 1
-  fi
-
-  if ! waitFor "[[ -n \$(oc logs $pod -c kibana | grep 'Kibana index ready') ]]"; then
-    echo "Kibana pod $pod was not able to start up within $TIMES seconds"
-    return 1
-  fi
-}
-
-function checkESContainsIndexTemplates() {
-
-  local pod=$1
-  local template_files
-  local secret_dir=/etc/elasticsearch/secret/
- 
-  if ! template_files=$(waitForValue "oc exec $pod -- ls -1 /usr/share/elasticsearch/index_templates"); then
-    echo "No index template files found"
-    return 1
-  fi
-
-  echo "Checking presence of index templates: ${template_files}"
-  for template in $template_files; do
-    echo "  - verify ${template}"
-    if ! response_code=$(waitForValue "oc exec $pod -- curl -s -k -X HEAD -w '%{response_code}' --cert ${secret_dir}admin-cert --key ${secret_dir}admin-key https://localhost:9200/_template/$template") || test "$response_code" != "200" ; then
-      echo "Could not find index template https://localhost:9200/_template/$template - $response_code"
-      return 1
-    fi
-  done
-
-}
-
-# add one since fluentd will be deployed via a daemonset
-# keeping as -2 + 1 for readibilty
-ADDITIONAL_PODS=$((KIBANA_CLUSTER_SIZE + ES_CLUSTER_SIZE - 2 + 1))
-
-EXIT_CODE=0
-
-if [[ $# -ne 1 ]]; then
-  # assuming not using OPS cluster
-  CLUSTER="false"
-else
-  CLUSTER="$1"
-  ADDITIONAL_PODS=$((ADDITIONAL_PODS + KIBANA_OPS_CLUSTER_SIZE + ES_OPS_CLUSTER_SIZE - 2))
+# Currently one DeploymentConfig per ElasticSearch
+# replica is created, and is therefore given a long
+# unique name that we do not know beforehand. We
+# only know that there should be DCs with the
+# logging-es- prefix, so we cheat now to look it up
+# and keep the cluster rollout test clean.
+# TODO: This will not be necessary when StatefulSets
+# are used to deploy the cluster instead.
+es_dcs="$( oc get deploymentconfigs --selector component=es -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-[a-zA-Z0-9]{8}" )"
+if [[ "$( wc -w <<<"${es_dcs}" )" -ne 1 ]]; then
+	os::log::fatal "Expected to find one ElasticSearch DeploymentConfig, got: '${es_dcs:-"<none>"}'"
+fi
+oal_expected_deploymentconfigs+=( ${es_dcs} )
+if [[ $# -eq 1 ]]; then
+	es_ops_dcs="$( oc get deploymentconfigs --selector component=es-ops -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-ops-[a-zA-Z0-9]{8}" )"
+	if [[ "$( wc -w <<<"${es_ops_dcs}" )" -ne 1 ]]; then
+		os::log::fatal "Expected to find one OPS ElasticSearch DeploymentConfig, got: '${es_ops_dcs:-"<none>"}'"
+	fi
+	oal_expected_deploymentconfigs+=( ${es_ops_dcs} )
 fi
 
-if [[ "$CLUSTER" == "true" ]]; then
-  NEEDED_COMPONENTS=("logging-es-[a-ZA-Z0-9]+?0" "logging-kibana0" "logging-curator0" "logging-es-ops-[a-zA-Z0-9]+?0" "logging-kibana-ops0" "logging-curator-ops0")
-else
-  NEEDED_COMPONENTS=("logging-es-[a-zA-Z0-9]+?0" "logging-kibana0" "logging-curator0")
-fi
-
-if [ "${USE_MUX:-}" = true ] ; then
-    NEEDED_COMPONENTS=(${NEEDED_COMPONENTS[@]} "logging-mux0")
-fi
-
-TEST_DIVIDER="-------------------------------------------------------"
-COMPONENTS_COUNT=${#NEEDED_COMPONENTS[@]}
-
-echo "Checking component installation and if pods are running:"
-echo $TEST_DIVIDER
-# Check that we have DC
-
-FOUND_DC=(`oc get dc -l logging-infra -o jsonpath='{.items[*].metadata.labels.component}' | xargs -n1 | sort -u | xargs`)
-DC_COUNT=${#FOUND_DC[@]}
-DC_MESSAGE="[$DC_COUNT/$COMPONENTS_COUNT] deployment configs found."
-
-if [[ $DC_COUNT -ne $COMPONENTS_COUNT ]]; then
-  echo "Error - $DC_MESSAGE"
-  EXIT_CODE=1
-
-  # check which DC are missing
-  for dc in "${NEEDED_COMPONENTS[@]}"; do
-    if [[ ! ( ${FOUND_DC[@]} =~ $dc ) ]]; then
-
-      PRINTED_DC=`echo $dc | cut -d"[" -f 1 | rev | cut -c 2- | rev`
-      echo " ! deployment config for $PRINTED_DC is missing..."
-    fi
-  done
-
-  echo "* Please rerun the deployer to generate missing deployment configs."
-else
-  echo "Success - $DC_MESSAGE"
-fi
-
-echo $TEST_DIVIDER
-# Check that we have RC
-
-FOUND_RC=(`oc get rc -l logging-infra -o jsonpath='{.items[*].metadata.labels.component}' | xargs -n1 | sort -u | xargs`)
-RC_COUNT=${#FOUND_RC[@]}
-RC_MESSAGE="[$RC_COUNT/$COMPONENTS_COUNT] unique replication controllers found."
-
-if [[ $RC_COUNT -ne $COMPONENTS_COUNT ]]; then
-  echo "Error - $RC_MESSAGE"
-  EXIT_CODE=1
-
-  # check which RC are missing
-  for rc in "${NEEDED_COMPONENTS[@]}"; do
-    if [[ ! ( ${FOUND_RC[@]} =~ $rc ) ]]; then
-      PRINTED_RC=`echo $rc | cut -d"[" -f 1 | rev | cut -c 2- | rev`
-      echo " ! unique replication controller for $PRINTED_RC is missing..."
-    fi
-  done
-
-  #TODO: there is another way to generate the RC from a DC... update message to use that *'if able, otherwise'
-  echo "* Please rerun the deployer or redeploy the appropriate DC to generate missing replication controllers."
-else
-  echo "Success - $RC_MESSAGE"
-fi
-
-echo $TEST_DIVIDER
-# Check that we have Routes
-
-# we add a '0' to deal with false positives of 'kibana' matching 'kibana' and 'kibana-ops' when checking what is found
-NEEDED_ROUTES=("kibana0")
-if [[ "$CLUSTER" = true ]] ; then
-    NEEDED_ROUTES=(${NEEDED_ROUTES[@]} "kibana-ops0")
-fi
-if [ -n "${ES_HOST:-}" ] ; then
-    NEEDED_ROUTES=(${NEEDED_ROUTES[@]} "logging-es")
-fi
-if [ -n "${ES_OPS_HOST:-}" ] ; then
-    NEEDED_ROUTES=(${NEEDED_ROUTES[@]} "logging-es-ops")
-fi
-FOUND_ROUTES=(`oc get routes -l logging-infra=support -o jsonpath='{.items[*].metadata.name}'`)
-ROUTE_COUNT=${#FOUND_ROUTES[@]}
-NEEDED_ROUTE_COUNT=${#NEEDED_ROUTES[@]}
-ROUTE_MESSAGE="[$ROUTE_COUNT/$NEEDED_ROUTE_COUNT] routes found."
-
-if [[ $ROUTE_COUNT -ne $NEEDED_ROUTE_COUNT ]]; then
-  echo "Error - $ROUTE_MESSAGE"
-  EXIT_CODE=1
-
-  for route in "${NEEDED_ROUTES[@]}"; do
-    if [[ ! ( ${FOUND_ROUTES[@]} =~ $route ) ]]; then
-      echo " ! route ${route%0} is missing..."
-    fi
-  done
-
-  echo "* Please rerun \`oc process logging-support-template | oc create -f -\` to generate missing routes."
-else
-  echo "Success - $ROUTE_MESSAGE"
-fi
-
-echo $TEST_DIVIDER
-# Check that we have Services
-
-# we add a '0' to deal with false positives of when checking what is found, similar to what we do for routes
-NEEDED_SERVICE=("logging-es0" "logging-es-cluster0" "logging-kibana0")
-if [[ "$CLUSTER" = true ]] ; then
-    NEEDED_SERVICE=(${NEEDED_SERVICE[@]} "logging-es-ops0" "logging-es-ops-cluster0" "logging-kibana-ops0")
-fi
-if [ "${MUX_ALLOW_EXTERNAL:-}" = true ] ; then
-    NEEDED_SERVICE=(${NEEDED_SERVICE[@]} "logging-mux0")
-fi
-FOUND_SERVICE=(`oc get svc -l logging-infra=support -o jsonpath='{.items[*].metadata.name}'`)
-SERVICE_COUNT=${#FOUND_SERVICE[@]}
-NEEDED_SERVICE_COUNT=${#NEEDED_SERVICE[@]}
-SERVICE_MESSAGE="[$SERVICE_COUNT/$NEEDED_SERVICE_COUNT] services found."
-
-if [[ $SERVICE_COUNT -ne $NEEDED_SERVICE_COUNT ]]; then
-  echo "Error - $SERVICE_MESSAGE"
-  EXIT_CODE=1
-
-  for svc in "${NEEDED_SERVICE[@]}"; do
-    if [[ ! ( ${FOUND_SERVICE[@]} =~ $svc ) ]]; then
-      echo " ! service ${svc%0} is missing..."
-    fi
-  done
-
-  echo "* Please rerun \`oc process logging-support-template | oc create -f -\` to generate missing routes."
-else
-  echo "Success - $SERVICE_MESSAGE"
-fi
-
-echo $TEST_DIVIDER
-# Check that we have Oauth Client
-
-FOUND_OAUTH=(`oc get oauthclient -l logging-infra=support -o jsonpath='{.items[*].metadata.name}'`)
-OAUTH_COUNT=${#FOUND_OAUTH[@]}
-NEEDED_OAUTH_COUNT=1
-OAUTH_MESSAGE="[$OAUTH_COUNT/$NEEDED_OAUTH_COUNT] oauth clients found."
-
-if [[ $OAUTH_COUNT -ne $NEEDED_OAUTH_COUNT ]]; then
-  echo "Error - $OAUTH_MESSAGE"
-  echo " ! oauth client kibana-proxy is missing..."
-  EXIT_CODE=1
-
-  echo "* Please rerun \`oc process logging-support-template | oc create -f -\` to generate missing oauth client."
-else
-  echo "Success - $OAUTH_MESSAGE"
-fi
-
-echo $TEST_DIVIDER
-# Check that we have the fluentd DaemonSet
-
-FOUND_DAEMONSET=(`oc get daemonset -l logging-infra=fluentd -o jsonpath='{.items[*].metadata.name}'`)
-DAEMONSET_COUNT=${#FOUND_DAEMONSET[@]}
-NEEDED_DAEMONSET_COUNT=1
-DAEMONSET_MESSAGE="[$DAEMONSET_COUNT/$NEEDED_DAEMONSET_COUNT] daemonsets found."
-
-if [[ $DAEMONSET_COUNT -ne $NEEDED_DAEMONSET_COUNT ]]; then
-  echo "Error - $DAEMONSET_MESSAGE"
-  echo " ! daemonset logging-fluentd is missing..."
-  EXIT_CODE=1
-
-  echo "* Please rerun \`oc process logging-fluentd-template | oc create -f -\` to generate missing daemonset."
-else
-  echo "Success - $DAEMONSET_MESSAGE"
-fi
-
-echo $TEST_DIVIDER
-# Check that Pods are running
-# we want to only look for currently running pods
-waitFor "[[ ${#NEEDED_COMPONENTS[@]} -eq \$(oc get pods -o jsonpath='{.items[*].metadata.labels.deployment}' | wc -w) ]]"
-if [[ $? -ne 0 ]]; then
-  echo "Timed out waiting for triggered deployments to complete..."
-  # should this exit?
-fi
-
-NEEDED_PODS=("${NEEDED_COMPONENTS[@]}" logging-fluentd)
-FOUND_PODS=(`oc get pods -l component,provider=openshift -o jsonpath='{.items[?(.status.phase=="Running")].metadata.name}'`)
-POD_COUNT=${#FOUND_PODS[@]}
-POD_MESSAGE="[$POD_COUNT/$((COMPONENTS_COUNT + ADDITIONAL_PODS))] running pods found."
-
-if [[ $POD_COUNT -ne $((COMPONENTS_COUNT + ADDITIONAL_PODS)) ]]; then
-  echo "Error - $POD_MESSAGE"
-  EXIT_CODE=1
-
-  # check which pods are missing
-  for pod in "${NEEDED_PODS[@]}"; do
-    if [[ ! ( ${FOUND_PODS[@]} =~ $pod ) ]]; then
-      PRINTED_POD=`echo $pod | cut -d"[" -f 1 | rev | cut -c 2- | rev`
-      echo " ! pod for $PRINTED_POD is not currently running..."
-    fi
-  done
-
-  echo "* Please ensure the number of replicas for your DC and RC are at least 1."
-  echo "* If the fluentd pod is missing, please ensure your node is tagged appropriately."
-else
-  echo "Success - $POD_MESSAGE"
-fi
-
-echo $TEST_DIVIDER
-echo "Checking for ES and Kibana successful starts"
-## Add check to Kibana and ES that they started up correctly
-for pod in $(oc get pods -l component=es -o name); do
-  checkESStarted "$pod" || EXIT_CODE=1
-done
-for pod in $(oc get pods -l component=es-ops -o name); do
-  checkESStarted "$pod" || EXIT_CODE=1
-done
-
-for pod in $(oc get pods -l component=kibana -o name); do
-  checkKibanaStarted "$pod" || EXIT_CODE=1
-done
-for pod in $(oc get pods -l component=kibana-ops -o name); do
-  checkKibanaStarted "$pod" || EXIT_CODE=1
-done
-
-echo $TEST_DIVIDER
-echo "Checking if ES contains common data model index templates"
-for pod in $(oc get pods -l component=es -o jsonpath='{.items[*].metadata.name}'); do
-  checkESContainsIndexTemplates "$pod" || EXIT_CODE=1
-done
-if [[ "$CLUSTER" == "true" ]]; then
-  for pod in $(oc get pods -l component=es-ops -o jsonpath='{.items[*].metadata.name}'); do
-    checkESContainsIndexTemplates "$pod" || EXIT_CODE=1
-  done
-fi
-
-echo $TEST_DIVIDER
-exit $EXIT_CODE
+OAL_EXPECTED_DEPLOYMENTCONFIGS="${oal_expected_deploymentconfigs[*]}" \
+OAL_EXPECTED_ROUTES="${oal_expected_routes[*]}"                       \
+OAL_EXPECTED_SERVICES="${oal_expected_services[*]}"                   \
+OAL_EXPECTED_OAUTHCLIENTS="${oal_expected_oauthclients[*]}"           \
+OAL_EXPECTED_DAEMONSETS="${oal_expected_daemonsets[*]}"               \
+"${OS_O_A_L_DIR}/test/cluster/rollout.sh"

--- a/hack/testing/check-logs.go
+++ b/hack/testing/check-logs.go
@@ -129,13 +129,11 @@ func main() {
 	if foundEntries == totalEntries {
 		if totalEntries == 0 {
 			fmt.Printf("Failure - no log entries found in Elasticsearch %s for index %s\n", es_svc, index)
-			os.Exit(1)
 		} else {
 			fmt.Printf("Success - [%v/%v] log entries found in %s\n", foundEntries, totalEntries, filePath)
 		}
 	} else {
 		fmt.Printf("Failure - [%v/%v] log entries found in %s\n%s", foundEntries, totalEntries, filePath, missesBuffer.String())
-		os.Exit(1)
 	}
 
 }

--- a/hack/testing/check-logs.go
+++ b/hack/testing/check-logs.go
@@ -33,7 +33,7 @@ func main() {
 
 	// instead of receiving jsonStream as an Arg, we'll make the call ourselves...
 	proxyHeaders := `-H 'X-Proxy-Remote-User: ` + userName + `' -H 'Authorization: Bearer ` + userToken + `' -H 'X-Forwarded-For: ` + testIP + `'`
-	queryCommand := `oc exec ` + kibana_pod + ` -- curl -s --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert --cacert /etc/kibana/keys/ca ` + proxyHeaders + ` -XGET "https://` + es_svc + `/` + index + `.*/com.redhat.viaq.common/_search?q=hostname:` + hostname + `&fields=message&size=` + querySize + `"`
+	queryCommand := `oc exec ` + kibana_pod + ` -- curl -s --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert --cacert /etc/kibana/keys/ca ` + proxyHeaders + ` -XGET "https://` + es_svc + `/` + index + `.*/_search?q=hostname:` + hostname + `&fields=message&size=` + querySize + `"`
 	if verbose {
 		fmt.Printf("Executing command [%s]\n", queryCommand)
 	}
@@ -129,11 +129,13 @@ func main() {
 	if foundEntries == totalEntries {
 		if totalEntries == 0 {
 			fmt.Printf("Failure - no log entries found in Elasticsearch %s for index %s\n", es_svc, index)
+			os.Exit(1)
 		} else {
 			fmt.Printf("Success - [%v/%v] log entries found in %s\n", foundEntries, totalEntries, filePath)
 		}
 	} else {
 		fmt.Printf("Failure - [%v/%v] log entries found in %s\n%s", foundEntries, totalEntries, filePath, missesBuffer.String())
+		os.Exit(1)
 	}
 
 }

--- a/hack/testing/check-logs.sh
+++ b/hack/testing/check-logs.sh
@@ -1,20 +1,8 @@
 #!/bin/bash
 
-if [ "$VERBOSE" = true ]; then
-  set -ex
-else
-  set -e
-fi
-
-if [[ $# -ne 1 ]]; then
-  # assuming not using OPS cluster
-  CLUSTER="false"
-else
-  CLUSTER="$1"
-fi
-
-TIMES=${TIMES:=10}
-QUERY_SIZE=${QUERY_SIZE:=500}
+set -o errexit
+set -o nounset
+set -o pipefail
 
 docker_uses_journal() {
     # note the unintuitive logic - in this case, a 0 return means true, and a 1
@@ -44,98 +32,18 @@ if [ -z "${USE_JOURNAL:-}" ] ; then
     fi
 fi
 
-oc login --username=${LOG_ADMIN_USER:-admin} --password=${LOG_ADMIN_PW:-admin} > /dev/null
-test_token="$(oc whoami -t)"
-test_name="$(oc whoami)"
-test_ip="127.0.0.1"
-oc login --username=system:admin > /dev/null
-oc project logging
+USE_JOURNAL="${USE_JOURNAL}"    \
+OAL_ELASTICSEACH_COMPONENT="es" \
+OAL_KIBANA_COMPONENT="kibana"   \
+OAL_ELASTICSEACH_SERVICE="logging-es" \
+"${OS_O_A_L_DIR}/test/cluster/functionality.sh"
 
-TEST_DIVIDER="------------------------------------------"
-# in case we need an index prefix
-INDEX_PREFIX=
-
-# we need logic for ES_OPS
-KIBANA_POD=`oc get pods | grep 'logging-kibana-[0-9]' | grep -v -- "-build" | grep -v -- "-deploy" | cut -d" " -f 1`
-KIBANA_OPS_POD=`oc get pods | grep 'logging-kibana-ops-[0-9]' | cut -d" " -f 1`
-ES_SVC=`oc get svc | grep '^logging-es ' | awk '{print $1 ":" $4}' | rev | cut -c 5- | rev`
-ES_OPS_SVC=`oc get svc | grep '^logging-es-ops ' | awk '{print $1 ":" $4}' | rev | cut -c 5- | rev`
-
-# get names of the ES pods to check their logs
-PODS=(`oc get pods | grep 'logging-es-' | grep 'Running' | cut -d" " -f 1`)
-
-# check each container's logs for indices created by fluentd
-for pod in "${PODS[@]}"; do
-  INDEX_COUNT=0
-  for i in $(seq 1 $TIMES); do
-    INDICES=(`oc logs $pod | grep 'update_mapping \[com.redhat.viaq.common\]' | cut -d"[" -f 6 | cut -d"]" -f 1 | rev | cut -d"." -f 4- | rev | sort | uniq`)
-    INDEX_COUNT=${#INDICES[@]}
-    if [[ $INDEX_COUNT -eq 0 ]]; then
-      sleep 1
-    else
-      break
-    fi
-  done
-  if [[ $INDEX_COUNT -eq 0 ]]; then
-    # if we have no indices created -- we have nothing to check
-    echo " ! no log indices found"
-  else
-    # indexes were created -- we should check logs here
-    echo "   found $INDEX_COUNT index(es) [${INDICES[@]}]"
-    echo $TEST_DIVIDER
-
-    for index in "${INDICES[@]}"; do
-      # if index is ".operations.*" then we check syslog
-      if [[ "$index" == "${INDEX_PREFIX}.operations" ]]; then
-        # search /var/log/messages*
-        FILE_PATH="/var/log/messages*"
-
-        if [[ "$CLUSTER" == "true" ]]; then
-          ES="$ES_OPS_SVC"
-          KIBANA="$KIBANA_OPS_POD"
-        else
-          ES="$ES_SVC"
-          KIBANA="$KIBANA_POD"
-        fi
-
-      else
-        # if index is anything else, then we check container logs (where namespace is index)
-        # need to parse out the uuid from the index name
-        fp_index=$(echo $index | sed 's/\..*//g')
-        FILE_PATH="/var/log/containers/*_${fp_index}_*.log"
-        ES="$ES_SVC"
-        KIBANA="$KIBANA_POD"
-      fi
-
-      KIBANA=`echo $KIBANA | cut -d" " -f 1`
-      ES=`echo $ES | cut -d" " -f 1`
-      ES_NAME=$(oc get svc | grep `echo $ES | cut -d":" -f 1` | cut -d" " -f 1)
-
-      READY=0
-      # Before we try to get logs from $KIBANA we should make sure it has properly started up e.g. it has connected to ES successfully -> ES is up
-      for i in $(seq 1 $TIMES); do
-        if [[ ! -z `oc logs $KIBANA -c kibana | grep 'Server running at http://0.0.0.0:5601'` ]]; then
-          if [[ ! -z `oc logs $KIBANA -c kibana | grep 'Kibana index ready'` ]]; then
-            READY=1
-            break
-          fi
-        fi
-
-        sleep 1
-        echo "Waiting for $ES_NAME to be ready to query..."
-      done
-
-      if [[ $READY -eq 1 ]]; then
-        # this needs to read from the system log files, so use sudo, and use -E and set PATH
-        # because it needs to use the oc commands
-        sudo -E env USE_JOURNAL=$USE_JOURNAL PATH=$PATH VERBOSE=$VERBOSE go run check-logs.go "$KIBANA" "$ES" "$index" "$FILE_PATH" "$QUERY_SIZE" "$test_name" "$test_token" "$test_ip"
-        echo $TEST_DIVIDER
-      else
-        echo "$ES_NAME not ready to be queried within $TIMES attempts..."
-      fi
-
-    done
-
-  fi
-
-done
+if [[ $# -eq 1 ]]; then
+  # There is an ops cluster set up, so we
+  # need to verify it's functionality as well.
+  USE_JOURNAL="${USE_JOURNAL}"        \
+  OAL_ELASTICSEACH_COMPONENT="es-ops" \
+  OAL_KIBANA_COMPONENT="kibana-ops"   \
+  OAL_ELASTICSEACH_SERVICE="logging-es-ops" \
+  "${OS_O_A_L_DIR}/test/cluster/functionality.sh"
+fi

--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -27,6 +27,7 @@ OS_O_A_L_DIR=${OS_O_A_L_DIR:-$(dirname "${BASH_SOURCE}")/../..}
 # use absolute path
 pushd $OS_O_A_L_DIR
 OS_O_A_L_DIR=`pwd`
+export OS_O_A_L_DIR
 popd
 USE_LOGGING_DEPLOYER=
 USE_LOGGING_DEPLOYER_SCRIPT=

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# This functionality test ensures that:
+#  - ElasticSearch and Kibana pods have started
+#    successfully
+#  - ElasticSearch is reachable from Kibana
+#  - the Kibana-proxy is working
+#  - the Kibana cert and key are functional
+#  - indices have been successfully created by Fluentd
+#    in ElasticSearch
+#
+# This script expects the following environment
+# variables:
+#  - OAL_{
+#         ELASTICSEACH,
+#         KIBANA
+#         }_COMPONENT: the component labels that
+#    are used to identify application pods
+#  - OAL_ELASTICSEACH_SERVICE: the service under which
+#    ElasticSearch is exposed
+#  - OAL_QUERY_SIZE: the number of messages to query
+#    for per index
+#  - OAL_TEST_IP: the IP address to test forwarding for
+#  - LOG_ADMIN_{
+#               USER
+#               PW
+#               }: credentials for the admin user
+source "${OS_ROOT}/hack/lib/init.sh"
+
+query_size="${OAL_QUERY_SIZE:-"500"}"
+test_ip="${OAL_TEST_IP:-"127.0.0.1"}"
+
+os::test::junit::declare_suite_start "test/cluster/functionality"
+
+os::cmd::expect_success "oc project logging"
+
+# We need to use a name and token for logging checks later,
+# so we have to provision a user with a token for this.
+# TODO: Why is this necessary?
+os::cmd::expect_success "oc login --username=${LOG_ADMIN_USER:-admin} --password=${LOG_ADMIN_PW:-admin}"
+test_user="$( oc whoami )"
+test_token="$( oc whoami -t )"
+os::cmd::expect_success "oc login --username=system:admin"
+
+# We can reach the ElasticSearch service at serviceName:apiPort
+elasticsearch_api="$( oc get svc "${OAL_ELASTICSEACH_SERVICE}" -o jsonpath='{ .metadata.name }:{ .spec.ports[?(@.targetPort=="restapi")].port }' )"
+
+for kibana_pod in $( oc get pods --selector component="${OAL_KIBANA_COMPONENT}"  -o jsonpath='{ .items[*].metadata.name }' ); do
+	os::log::info "Testing Kibana pod ${kibana_pod} for a successful start..."
+	os::cmd::try_until_text "oc logs ${kibana_pod} -c kibana" "Server running at http://0\.0\.0\.0:5601"
+	os::cmd::try_until_text "oc logs ${kibana_pod} -c kibana" "Kibana index ready"
+done
+
+for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEACH_COMPONENT}" -o jsonpath='{ .items[*].metadata.name }' ); do
+	os::log::info "Testing ElasticSearch pod ${elasticsearch_pod} for a successful start..."
+	os::cmd::try_until_text "oc logs ${elasticsearch_pod}" "\[cluster\.service\s*\]"
+	os::cmd::try_until_text "oc logs ${elasticsearch_pod}" "\[node\s*\]\s*\[.*\]\s*started"
+
+	os::log::info "Checking that ElasticSearch pod ${elasticsearch_pod} recovered its indices after starting..."
+	if oc logs "${elasticsearch_pod}" | grep -E "\[cluster\.service\s*\]" | grep -q "new_master"; then
+		os::cmd::expect_success_and_text "oc logs ${elasticsearch_pod}" "\[gateway\s*\]\s*\[.*\]\s*recovered\s*\[[0-9]*\]\s*indices into cluster_state"
+	elif oc logs "${elasticsearch_pod}" | grep -E "\[cluster\.service\s*\]" | grep -q "detected_master"; then
+		os::log::info "ElasticSearch pod ${elasticsearch_pod} was able to detect a master"
+	else
+		os::log::fatal "ElasticSearch pod ${elasticsearch_pod} isn't master and was unable to detect a master"
+	fi
+
+	os::log::info "Checking that ElasticSearch pod ${elasticsearch_pod} contains common data model index templates..."
+	os::cmd::expect_success "oc exec ${elasticsearch_pod} -- ls -1 /usr/share/elasticsearch/index_templates"
+	for template in $( oc exec "${elasticsearch_pod}" -- ls -1 /usr/share/elasticsearch/index_templates ); do
+		os::cmd::expect_success_and_text "oc exec ${elasticsearch_pod} -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key -X HEAD -w '%{response_code}' https://localhost:9200/_template/${template}" '200'
+	done
+
+	os::log::info "Checking that ElasticSearch pod ${elasticsearch_pod} has persisted indices created by Fluentd..."
+	os::cmd::try_until_text "oc logs ${elasticsearch_pod}" "update_mapping \[com\.redhat\.viaq\.common\]"
+	# We are interested in indices with one of the following formats:
+	#     .operations.<year>.<month>.<day>
+	#     project.<namespace>.<uuid>.<year>.<month>.<day>
+	for index in $( oc exec "${elasticsearch_pod}" -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key https://localhost:9200/_cat/indices?h=index ); do
+		if [[ "${index}" == ".operations"* ]]; then
+			# If this is an operations index, we will be searching
+			# on disk for it
+			index_search_path="/var/log/messages"
+		elif [[ "${index}" == "project."* ]]; then
+			# Otherwise, we will find it in the container log, which
+			# we can identify with the UUID
+			uuid="$( cut -d '.' -f 3 <<<"${index}" )"
+			index_search_path="/var/log/containers/*_${uuid}_*.log"
+		else
+			continue
+		fi
+
+		# We don't care about the date in the index
+		index="$( rev <<<"${index}" | cut -d"." -f 4- | rev )"
+
+		for kibana_pod in $( oc get pods --selector component="${OAL_KIBANA_COMPONENT}"  -o jsonpath='{ .items[*].metadata.name }' ); do
+			os::log::info "Cheking for index ${index} with Kibana pod ${kibana_pod}..."
+			# As we're checking system log files, we need to use `sudo`
+			os::cmd::expect_success "sudo -E VERBOSE=true go run '${OS_O_A_L_DIR}/hack/testing/check-logs.go' '${kibana_pod}' '${elasticsearch_api}' '${index}' '${index_search_path}' '${query_size}' '${test_user}' '${test_token}' '${test_ip}'"
+		done
+	done
+done
+
+os::test::junit::declare_suite_end

--- a/test/cluster/rollout.sh
+++ b/test/cluster/rollout.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This rollout test ensures that the DeploymentConfigs
+# that are specified have been created and deployed
+# successfully onto the cluster. This script expects
+# the following environment variables:
+#
+#  - OAL_EXPECTED_{
+#                  DEPLOYMENTCONFIGS,
+#                  OAUTHCLIENTS,
+#                  DAEMONSETS,
+#                  SERVICES,
+#                  ROUTES
+#                  }: $IFS-delimited lists of
+#    OpenShift ojects that are expected to exist
+source "${OS_ROOT}/hack/lib/init.sh"
+
+os::test::junit::declare_suite_start "test/cluster/rollout"
+
+os::cmd::expect_success "oc project logging"
+
+os::log::info "Checking for DeploymentConfigurations..."
+for deploymentconfig in ${OAL_EXPECTED_DEPLOYMENTCONFIGS}; do
+	os::cmd::expect_success "oc get deploymentconfig ${deploymentconfig}"
+	os::cmd::expect_success "oc rollout status deploymentconfig/${deploymentconfig}"
+done
+
+os::log::info "Checking for Routes..."
+for route in ${OAL_EXPECTED_ROUTES}; do
+	os::cmd::expect_success "oc get route ${route}"
+done
+
+os::log::info "Checking for Services..."
+for service in ${OAL_EXPECTED_SERVICES}; do
+	os::cmd::expect_success "oc get service ${service}"
+done
+
+os::log::info "Checking for OAuthClients..."
+for oauthclient in ${OAL_EXPECTED_OAUTHCLIENTS}; do
+	os::cmd::expect_success "oc get oauthclient ${oauthclient}"
+done
+
+os::log::info "Checking for DaemonSets..."
+for daemonset in ${OAL_EXPECTED_DAEMONSETS}; do
+	os::cmd::expect_success "oc get daemonset ${daemonset}"
+	desired_number="$( oc get daemonset "${daemonset}" -o jsonpath='{ .status.desiredNumberScheduled }' )"
+	os::cmd::try_until_text "oc get daemonset ${daemonset} -o jsonpath='{ .status.numberReady }'" "${desired_number}"
+done
+
+os::test::junit::declare_suite_end


### PR DESCRIPTION
Reformat cluster end-to-end test to use Bash helpers

Much of the work being done by the cluster end-to-end test can be
simplified by using the `os::cmd` suite of Bash helpers from Origin as
well as the `oc rollout status` command.

Of note -- in `test/cluster/rollout.sh` we are dropping the explicit
tests for ReplicationControllers and Pods as we can assume that the
OpenShift platform will function correctly at this point, and we are
not deploying any ReplicationControllers or Pods directly.

In `test/cluster/functionality.sh` we are getting the list of indices
in ElasticSearch by using the `/_cat/indices` REST endpoint, not by
looking through the pod log. We are also checking each Kibana pod, not
just one.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
