### PR TITLE
look for /etc/docker/daemon.json for log-driver

### DIFF
--- a/deployer/templates/fluentd.yaml
+++ b/deployer/templates/fluentd.yaml
@@ -87,6 +87,9 @@ objects:
             - name: dockercfg
               mountPath: /etc/sysconfig/docker
               readOnly: true
+            - name: dockerdaemoncfg
+              mountPath: /etc/docker
+              readOnly: true
             env:
             - name: "K8S_HOST_URL"
               value: ${MASTER_URL}
@@ -175,6 +178,9 @@ objects:
           - name: dockercfg
             hostPath:
               path: /etc/sysconfig/docker
+          - name: dockerdaemoncfg
+            hostPath:
+              path: /etc/docker
 parameters:
 -
   description: "Internal url for reaching the master API to query pod labels"

--- a/hack/testing/build-images
+++ b/hack/testing/build-images
@@ -21,6 +21,9 @@ else
 fi
 
 dev_build_template=dev-builds-wo-deployer.yaml
+oc process -o yaml \
+   -f $OS_O_A_L_DIR/hack/templates/$dev_build_template \
+   -p LOGGING_FORK_URL=$GIT_URL -p LOGGING_FORK_BRANCH=$GIT_BRANCH | build_filter
 
 os::cmd::expect_success "oc process -o yaml \
    -f $OS_O_A_L_DIR/hack/templates/$dev_build_template \

--- a/hack/testing/check-logs.sh
+++ b/hack/testing/check-logs.sh
@@ -17,9 +17,23 @@ TIMES=${TIMES:=10}
 QUERY_SIZE=${QUERY_SIZE:=500}
 
 docker_uses_journal() {
+    # note the unintuitive logic - in this case, a 0 return means true, and a 1
+    # return means false
     # need to be able to handle cases like
     # OPTIONS='--log-driver=json-file ....' # or use --log-driver=journald
-    grep -q "^OPTIONS='[^']*--log-driver=journald" /etc/sysconfig/docker
+    # if "log-driver" is set in /etc/docker/daemon.json, assume that it is
+    # authoritative
+    # otherwise, look for /etc/sysconfig/docker
+    if type -p docker > /dev/null && sudo docker info | grep -q 'Logging Driver: journald' ; then
+        return 0
+    elif grep -q '^[^#].*"log-driver":' /etc/docker/daemon.json 2> /dev/null ; then
+        if grep -q '^[^#].*"log-driver":.*journald' /etc/docker/daemon.json 2> /dev/null ; then
+            return 0
+        fi
+    elif grep -q "^OPTIONS='[^']*--log-driver=journald" /etc/sysconfig/docker 2> /dev/null ; then
+        return 0
+    fi
+    return 1
 }
 
 if [ -z "${USE_JOURNAL:-}" ] ; then

--- a/hack/testing/init-log-stack
+++ b/hack/testing/init-log-stack
@@ -2,6 +2,7 @@
 
 OS_ANSIBLE_VERBOSITY=${OS_ANSIBLE_VERBOSITY:-"vv"}
 OS_VERSION_STRING=${OS_VERSION:+openshift_release=$OS_VERSION}
+USE_JOURNAL_VAR=${USE_JOURNAL:+openshift_logging_fluentd_use_journal=${USE_JOURNAL}}
 
 ANSIBLE_PLAYBOOK_ARGS=${ANSIBLE_PLAYBOOK_ARGS:-""}
 
@@ -31,7 +32,7 @@ openshift_logging_master_public_url=https://${PUBLIC_MASTER_HOST:-localhost}:844
 
 openshift_logging_image_prefix=$imageprefix
 openshift_logging_use_ops=${ENABLE_OPS_CLUSTER:-False}
-openshift_logging_fluentd_use_journal=${USE_JOURNAL:-}
+$USE_JOURNAL_VAR
 openshift_logging_fluentd_journal_read_from_head=${JOURNAL_READ_FROM_HEAD:-False}
 openshift_logging_es_log_appenders=['console']
 openshift_logging_use_mux=${USE_MUX:-false}

--- a/hack/testing/test-datetime-future.sh
+++ b/hack/testing/test-datetime-future.sh
@@ -69,18 +69,6 @@ write_and_verify_logs() {
     return $rc
 }
 
-if [ -z "${USE_JOURNAL:-}" ] ; then
-    docker_uses_journal() {
-        # need to be able to handle cases like
-        # OPTIONS='--log-driver=json-file ....' # or use --log-driver=journald
-        grep -q "^OPTIONS='[^']*--log-driver=journald" /etc/sysconfig/docker
-    }
-else
-    docker_uses_journal() {
-        test $USE_JOURNAL = true
-    }
-fi
-
 TEST_DIVIDER="------------------------------------------"
 
 # make sure the host/node TZ is the same as the fluentd pod


### PR DESCRIPTION
docker now uses /etc/docker/daemon.json or /etc/sysconfig/docker to
configure the log-driver.  Use both of these, preferring daemon.json,
to figure out which log driver docker is using.  The tests can use
`docker info` instead, but this is not available inside the fluentd
container.
This patch relies on https://github.com/openshift/openshift-ansible/pull/4136
to mount /etc/docker inside the fluentd container.
@jcantrill @ewolinetz @skuznets ptal