### PR TITLE
some Elasticsearch run.sh improvements and logging.sh improvements

### DIFF
--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -255,6 +255,7 @@ rm -f $lfds
 
 # when fluentd starts up it may take a while before it catches up with all of the logs
 # let's wait until that happens
+wait_for_fluentd_ready
 wait_for_fluentd_to_catch_up
 
 # add admin user and normal user for kibana and token auth testing


### PR DESCRIPTION
It was very difficult to read the Elasticsearch logs with the `.`
characters from the http check interspersed with messages from ES
itself.  This commit makes the ES run.sh logging compatible with
the output from ES itself.  You can look for "container.run" to
see only the logs from the run.sh script.  This also allows for
using a DEBUG option to see the details from the various checks, and
using an ERROR level to hide most of the noise.
One interesting problem I found is that if wait_for_fluentd_to_catch_up
ran before fluentd was fully reading from the log sources, that
test could add entries that _fluentd would never read_.  The solution
is to look for the position files before writing something that you
expect fluentd to read.
@jcantrill @ewolinetz @nhosoi @lukas-vlcek @stevekuznetzov
[test]