### PR TITLE
Parameterizing fluentd buffer_queue_limit and buffer_size_limit; increasing the default values

### DIFF
--- a/deployer/templates/fluentd.yaml
+++ b/deployer/templates/fluentd.yaml
@@ -159,6 +159,10 @@ objects:
               value: ${USE_MUX_CLIENT}
             - name: "MUX_ALLOW_EXTERNAL"
               value: ${MUX_ALLOW_EXTERNAL}
+            - name: "BUFFER_QUEUE_LIMIT"
+              value: ${BUFFER_QUEUE_LIMIT}
+            - name: "BUFFER_SIZE_LIMIT"
+              value: ${BUFFER_SIZE_LIMIT}
           volumes:
           - name: runlogjournal
             hostPath:
@@ -332,3 +336,11 @@ parameters:
   description: 'Configure MUX SERVER (false|true).'
   name: MUX_ALLOW_EXTERNAL
   value: "false"
+-
+  description: 'Fluentd buffer queue limit (0.12 only)'
+  name: BUFFER_QUEUE_LIMIT
+  value: "1024"
+-
+  description: 'Fluentd buffer size limit'
+  name: BUFFER_SIZE_LIMIT
+  value: "16777216"

--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -5,6 +5,8 @@
   shared_key "#{File.open('/etc/fluent/muxkeys/shared_key') do |f| f.readline end.rstrip}"
   secure yes
   ca_cert_path /etc/fluent/muxkeys/ca
+  buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
+  buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
   <server>
     host logging-mux
     port "#{ENV['FORWARD_LISTEN_PORT'] || '24284'}"

--- a/fluentd/configs.d/mux-post-input-filter-tag.conf
+++ b/fluentd/configs.d/mux-post-input-filter-tag.conf
@@ -15,8 +15,6 @@
 <match **>
   @type rewrite_tag_filter
   @label @INGRESS
-  buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-  buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
   rewriterule1 mux_need_k8s_meta ^false$ mux
   rewriterule2 mux_namespace_name (.+) kubernetes.mux.var.log.containers.mux-mux.mux-mux_$1_mux-0123456789012345678901234567890123456789012345678901234567890123.log
 </match>

--- a/fluentd/configs.d/mux-post-input-filter-tag.conf
+++ b/fluentd/configs.d/mux-post-input-filter-tag.conf
@@ -15,6 +15,8 @@
 <match **>
   @type rewrite_tag_filter
   @label @INGRESS
+  buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
+  buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
   rewriterule1 mux_need_k8s_meta ^false$ mux
   rewriterule2 mux_namespace_name (.+) kubernetes.mux.var.log.containers.mux-mux.mux-mux_$1_mux-0123456789012345678901234567890123456789012345678901234567890123.log
 </match>

--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -19,5 +19,7 @@
       reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
-      disable_retry_limit
+      disable_retry_limit true
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
     </store>

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -19,5 +19,7 @@
       reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
-      disable_retry_limit
+      disable_retry_limit true
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
     </store>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -19,5 +19,7 @@
       reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
-      disable_retry_limit
+      disable_retry_limit true
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
     </store>

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -19,5 +19,7 @@
       reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
-      disable_retry_limit
+      disable_retry_limit true
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
     </store>

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -58,6 +58,9 @@ IPADDR4=`/usr/sbin/ip -4 addr show dev eth0 | grep inet | sed -e "s/[ \t]*inet \
 IPADDR6=`/usr/sbin/ip -6 addr show dev eth0 | grep inet6 | sed "s/[ \t]*inet6 \([a-f0-9:]*\).*/\1/"`
 export IPADDR4 IPADDR6
 
+export BUFFER_QUEUE_LIMIT=${BUFFER_QUEUE_LIMIT:-1024}
+export BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-16777216}
+
 CFG_DIR=/etc/fluent/configs.d
 if [ "${USE_MUX:-}" = "true" ] ; then
     # copy our standard mux configs to the openshift dir

--- a/hack/testing/test-fluentd-forward.sh
+++ b/hack/testing/test-fluentd-forward.sh
@@ -96,8 +96,8 @@ update_current_fluentd() {
   self_hostname forwarding-${HOSTNAME}\n\
   shared_key aggregated_logging_ci_testing\n\
   secure no\n\
-  buffer_queue_limit \"#{ENV['BUFFER_QUEUE_LIMIT']}\"\n\
-  buffer_chunk_limit \"#{ENV['BUFFER_SIZE_LIMIT']}\"\n\
+  buffer_queue_limit \"#{ENV['"'BUFFER_QUEUE_LIMIT'"']}\"\n\
+  buffer_chunk_limit \"#{ENV['"'BUFFER_SIZE_LIMIT'"']}\"\n\
   <server>\n\
    host '${FLUENTD_FORWARD}'\n\
    port 24284\n\
@@ -166,6 +166,9 @@ fpod=`get_running_pod fluentd`
 
 # run test to make sure fluentd is working normally - no forwarding
 write_and_verify_logs 1 || {
+    oc logs $fpod > $ARTIFACT_DIR/test-fluentd-forward.fluentd.log
+    ffpod=`get_running_pod forward-fluentd`
+    oc logs $ffpod > $ARTIFACT_DIR/test-fluentd-forward.forward-fluentd.log
     oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1
     exit 1
 }
@@ -181,6 +184,9 @@ create_forwarding_fluentd
 update_current_fluentd
 
 write_and_verify_logs 1 || {
+    oc logs $fpod > $ARTIFACT_DIR/test-fluentd-forward.fluentd.log
+    ffpod=`get_running_pod forward-fluentd`
+    oc logs $ffpod > $ARTIFACT_DIR/test-fluentd-forward.forward-fluentd.log
     oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1
     exit 1
 }
@@ -189,6 +195,9 @@ write_and_verify_logs 1 || {
 cleanup
 
 write_and_verify_logs 1 || {
+    oc logs $fpod > $ARTIFACT_DIR/test-fluentd-forward.fluentd.log
+    ffpod=`get_running_pod forward-fluentd`
+    oc logs $ffpod > $ARTIFACT_DIR/test-fluentd-forward.forward-fluentd.log
     oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1
     exit 1
 }

--- a/hack/testing/test-fluentd-forward.sh
+++ b/hack/testing/test-fluentd-forward.sh
@@ -96,6 +96,8 @@ update_current_fluentd() {
   self_hostname forwarding-${HOSTNAME}\n\
   shared_key aggregated_logging_ci_testing\n\
   secure no\n\
+  buffer_queue_limit \"#{ENV['BUFFER_QUEUE_LIMIT']}\"\n\
+  buffer_chunk_limit \"#{ENV['BUFFER_SIZE_LIMIT']}\"\n\
   <server>\n\
    host '${FLUENTD_FORWARD}'\n\
    port 24284\n\


### PR DESCRIPTION
Introducing environment variables: BUFFER_QUEUE_LIMIT, BUFFER_SIZE_LIMIT

They are set to these parameters:
      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
    
Default values are increased as follows:
      BUFFER_QUEUE_LIMIT: 256 -> 1024
      BUFFER_SIZE_LIMIT: 8388608 -> 16777216