### PR TITLE
Update Bash function for jUnit report to latest master

### DIFF
--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -122,7 +122,7 @@ function cleanup()
         os::log::info "Test Succeeded"
     fi
 
-    os::test::junit::generate_oscmd_report
+    os::test::junit::generate_report
 
     if [ "$DEBUG_FAILURES" = "true" ] ; then
         echo debug failures - when you are finished, 'ps -ef|grep 987654' then kill that sleep process


### PR DESCRIPTION
The Origin Bash functions for generating jUnit reports have changed, so
`os::test::junit::generate_oscmd_report` now is `generate_report` in the
same namespace.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]

/cc @richm 