### PR TITLE
Edit e2e test scripts so they run cleanly on top of new cluster

### DIFF
--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -28,13 +28,13 @@ fi
 # and keep the cluster rollout test clean.
 # TODO: This will not be necessary when StatefulSets
 # are used to deploy the cluster instead.
-es_dcs="$( oc get deploymentconfigs --selector component=es -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-[a-zA-Z0-9]{8}" )"
+es_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-[a-zA-Z0-9]{8}" )"
 if [[ "$( wc -w <<<"${es_dcs}" )" -ne 1 ]]; then
 	os::log::fatal "Expected to find one ElasticSearch DeploymentConfig, got: '${es_dcs:-"<none>"}'"
 fi
 oal_expected_deploymentconfigs+=( ${es_dcs} )
 if [[ $# -eq 1 ]]; then
-	es_ops_dcs="$( oc get deploymentconfigs --selector component=es-ops -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-ops-[a-zA-Z0-9]{8}" )"
+	es_ops_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es-ops -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-ops-[a-zA-Z0-9]{8}" )"
 	if [[ "$( wc -w <<<"${es_ops_dcs}" )" -ne 1 ]]; then
 		os::log::fatal "Expected to find one OPS ElasticSearch DeploymentConfig, got: '${es_ops_dcs:-"<none>"}'"
 	fi

--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-set -o errexit
-set -o nounset
-set -o pipefail
+source "${OS_ROOT}/hack/lib/init.sh"
 
 oal_expected_deploymentconfigs=( "logging-kibana" "logging-curator" )
 oal_expected_routes=( "logging-kibana" )

--- a/hack/testing/check-logs.sh
+++ b/hack/testing/check-logs.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-set -o errexit
-set -o nounset
-set -o pipefail
+source "${OS_ROOT}/hack/lib/init.sh"
 
 docker_uses_journal() {
     # note the unintuitive logic - in this case, a 0 return means true, and a 1

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -32,15 +32,15 @@ test_ip="${OAL_TEST_IP:-"127.0.0.1"}"
 
 os::test::junit::declare_suite_start "test/cluster/functionality"
 
-os::cmd::expect_success "oc project logging"
-
 # We need to use a name and token for logging checks later,
 # so we have to provision a user with a token for this.
 # TODO: Why is this necessary?
 os::cmd::expect_success "oc login --username=${LOG_ADMIN_USER:-admin} --password=${LOG_ADMIN_PW:-admin}"
 test_user="$( oc whoami )"
 test_token="$( oc whoami -t )"
+
 os::cmd::expect_success "oc login --username=system:admin"
+os::cmd::expect_success "oc project logging"
 
 # We can reach the ElasticSearch service at serviceName:apiPort
 elasticsearch_api="$( oc get svc "${OAL_ELASTICSEACH_SERVICE}" -o jsonpath='{ .metadata.name }:{ .spec.ports[?(@.targetPort=="restapi")].port }' )"

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -69,15 +69,15 @@ for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEACH
 	os::log::info "Checking that ElasticSearch pod ${elasticsearch_pod} contains common data model index templates..."
 	os::cmd::expect_success "oc exec ${elasticsearch_pod} -- ls -1 /usr/share/elasticsearch/index_templates"
 	for template in $( oc exec "${elasticsearch_pod}" -- ls -1 /usr/share/elasticsearch/index_templates ); do
-		os::cmd::expect_success_and_text "oc exec ${elasticsearch_pod} -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key -X HEAD -w '%{response_code}' https://localhost:9100/_template/${template}" '100'
+		os::cmd::expect_success_and_text "oc exec ${elasticsearch_pod} -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key -X HEAD -w '%{response_code}' https://localhost:9200/_template/${template}" '100'
 	done
 
 	os::log::info "Checking that ElasticSearch pod ${elasticsearch_pod} has persisted indices created by Fluentd..."
-	os::cmd::try_until_text "oc exec "${elasticsearch_pod}" -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key https://localhost:9100/_cat/indices?h=index" "^(project|\.operations)\." "$(( 10*TIME_MIN ))"
+	os::cmd::try_until_text "oc exec "${elasticsearch_pod}" -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key https://localhost:9200/_cat/indices?h=index" "^(project|\.operations)\." "$(( 10*TIME_MIN ))"
 	# We are interested in indices with one of the following formats:
 	#     .operations.<year>.<month>.<day>
 	#     project.<namespace>.<uuid>.<year>.<month>.<day>
-	for index in $( oc exec "${elasticsearch_pod}" -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key https://localhost:9100/_cat/indices?h=index ); do
+	for index in $( oc exec "${elasticsearch_pod}" -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key https://localhost:9200/_cat/indices?h=index ); do
 		if [[ "${index}" == ".operations"* ]]; then
 			# If this is an operations index, we will be searching
 			# on disk for it

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -69,7 +69,7 @@ for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEACH
 	os::log::info "Checking that ElasticSearch pod ${elasticsearch_pod} contains common data model index templates..."
 	os::cmd::expect_success "oc exec ${elasticsearch_pod} -- ls -1 /usr/share/elasticsearch/index_templates"
 	for template in $( oc exec "${elasticsearch_pod}" -- ls -1 /usr/share/elasticsearch/index_templates ); do
-		os::cmd::expect_success_and_text "oc exec ${elasticsearch_pod} -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key -X HEAD -w '%{response_code}' https://localhost:9200/_template/${template}" '100'
+		os::cmd::expect_success_and_text "oc exec ${elasticsearch_pod} -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key -X HEAD -w '%{response_code}' https://localhost:9200/_template/${template}" '200'
 	done
 
 	os::log::info "Checking that ElasticSearch pod ${elasticsearch_pod} has persisted indices created by Fluentd..."


### PR DESCRIPTION
Add init.sh sources to all test entrypoints

Any script that needs to be able to stand alone as an entrypoint should
source the Origin `hack/lib/init.sh` script. Sourcing this more than
once is handled gracefully, so there is no downside to adding it to many
scripts.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Look for DeploymentConfigs in the right namespace

When we are hacking around the DeploymentConfig search for the e2e test,
we need to make sure we are looking for the ElasticSearch DCs in the
logging namespace.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Switch to logging project before functionality test

When we provision and inspect the logging administrative user in the
functionality test, we need to switch back into the logging project
afterword in order to ensure that the context in which the existing
`system:admin` user is operating doesn't leave us in a different
project.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Wait longer for Kibana and ElasticSearch to start

The previous time-out of 60s was not long enough for the pods containing
the Kibana and/or ElasticSearch containers to start reporting correctly.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
