### PR TITLE
Add a readiness probe to the Kibana image

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -24,6 +24,7 @@ RUN rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch && \
                 kibana-${KIBANA_VER} && \
     yum clean all
 
+ADD probe/ /usr/share/kibana/probe/
 COPY kibana.yml ${KIBANA_HOME}/config/kibana.yml
 COPY run.sh install.sh ${HOME}/
 RUN sh install.sh

--- a/kibana/probe/readiness.sh
+++ b/kibana/probe/readiness.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+KIBANA_REST_BASEURL=http://localhost:5601
+EXPECTED_RESPONSE_CODE=200
+max_time="${max_time:-4}"
+
+response_code="$(
+    curl --silent                          \
+         --request HEAD                    \
+         --max-time "${max_time}"          \
+         --write-out '%{response_code}'    \
+         "${KIBANA_REST_BASEURL}/"
+)"
+
+if [ "${response_code}" == "${EXPECTED_RESPONSE_CODE}" ]; then
+    exit 0
+else
+    echo "Kibana node is not ready to accept HTTP requests yet [response code: ${response_code}]"
+    exit 1
+fi


### PR DESCRIPTION
In order to ensure that the Kubernetes machinery can determine when the
Kibana Pods are becoming ready, we need to add a readiness probe to the
Containers that make up those pods. The Kibana readiness probe simply
hits the base URL at `http://localhost:5601/` and expects a 200.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @richm @ewolinetz @lukas-vlcek 