### PR TITLE
allow tests to run against released software with NOSETUP flag to logging.sh

### DIFF
--- a/deployer/scripts/util.sh
+++ b/deployer/scripts/util.sh
@@ -326,7 +326,7 @@ wait_for_pod_ACTION() {
     fi
     while [ $ii -gt 0 ] ; do
         if [ $1 = stop ] && oc describe pod/$curpod > /dev/null 2>&1 ; then
-            if [ -n "$VERBOSE" ] ; then
+            if [ -n "${VERBOSE:-}" ] ; then
                 echo pod $curpod still running
             fi
         elif [ $1 = start ] && [ -z "$curpod" ] ; then
@@ -336,7 +336,7 @@ wait_for_pod_ACTION() {
                     return 1
                 fi
             fi
-            if [ -n "$VERBOSE" ] ; then
+            if [ -n "${VERBOSE:-}" ] ; then
                 echo pod for component=$2 not running yet
             fi
         else
@@ -493,7 +493,7 @@ function wait_for_fluentd_to_catch_up() {
     local starttime=`date +%s`
     echo START wait_for_fluentd_to_catch_up at `date -u --rfc-3339=ns`
     local es_pod=`get_running_pod es`
-    local es_ops_pod=`get_running_pod es-ops`
+    local es_ops_pod=`get_running_pod es-ops 2> /dev/null`
     if [ -z "$es_ops_pod" ] ; then
         es_ops_pod=$es_pod
     fi

--- a/hack/testing/README.md
+++ b/hack/testing/README.md
@@ -38,7 +38,47 @@ to have been created (based on the logs of the Elasticsearch pods).
 This Go script will query the appropriate ES pod (if an OPS cluster was used)
 and check the local log files for the each result message.
 
-## check-curator.sh
+## Environment values for testing
+
+In addition to providing the argument `true` to `e2e-test.sh` to indicate that
+an OPS cluster is used, the following environment values can be used to
+change behavior of the scripts.
+
+The format for the following would be
+`ENV_VAR1=value [ENV_VAR2=value2] ./e2e-test.sh`
+
+```
+VERBOSE                 | If set, the scripts will print out each command as executed | default: "" (unset)
+KIBANA_CLUSTER_SIZE     | The num of Kibana pod replicas | default: 1
+KIBANA_OPS_CLUSTER_SIZE | The num of Kibana Ops pod replicas if OPS cluster is used | default: 1
+ES_CLUSTER_SIZE         | The num of Elasticsearch pod replicas | default: 1
+ES_OPS_CLUSTER_SIZE     | The num of Elasticsearch Ops pod replicas if OPS cluster is used | default: 1
+TIMES                   | The maximum number of attempts to try for checking if ES is ready for queries | default: 10
+QUERY_SIZE              | The maximum number of query results returned for an index | default: 500
+```
+
+# logging.sh
+The script logging.sh is the main CI test driver.  There are a number of
+environment variables that can control its behavior.  In addition, giving the
+`NOSETUP` argument to the script will cause it to not set up OpenShift and the
+logging components.  Instead, it will assume these have already been set up,
+and will just configure the environment to run the tests, then run the tests.
+```
+USE_JOURNAL             | If set to "true" or "false", explicitly enable or disable using the journald as the logging source | default: unset - fluentd will use whatever is configured for the system
+GIT_URL                 | The full URL of the location of the code | default: https://github.com/openshift/origin-aggregated-logging
+GIT_BRANCH              | The GIT_URL branch to use | default: master
+ENABLE_OPS_CLUSTER      | If "true", enable the ops components kibana-ops, etc. | default: "false"
+DEBUG_FAILURES          | If "true", leave the system running to allow logging in to investigate issues | default: "false"
+DO_CLEANUP              | If "false", do not teardown OpenShift, leave it running | default: "true"
+USE_LOCAL_SOURCE        | If "true", use the logging code on the local file systeme to build the images from source | default: "false"
+ES_VOLUME               | Path to the local disk location to use for Elasticsearch storage | default: "/var/lib/es"
+ES_OPS_VOLUME           | Path to the local disk location to use for Elasticsearch OPS storage | default: "/var/lib/es-ops"
+MUX_ALLOW_EXTERNAL      | If "true", configure mux to accept external connections | default: "false"
+USE_MUX_CLIENT          | If "true", configure the node agent fluentd to send raw logs to mux | default: "false"
+USE_MUX                 | If "true", use mux to accept log records from local fluentd node agents | default: "false"
+```
+
+# test-curator.sh
 
 The purpose of this script is to verify the curator pod is working.  It will
 add curator configs for the following projects and trimming parameters:
@@ -62,25 +102,6 @@ The script will then use the curator credentials to run curator to list the
 indices afterwards, and verify that the indices created for "today" are still
 present, and the indices created outside of the time window for each project
 have been removed.
-
-## Environment values for testing
-
-In addition to providing the argument `true` to `e2e-test.sh` to indicate that
-an OPS cluster is used, the following environment values can be used to
-change behavior of the scripts.
-
-The format for the following would be
-`ENV_VAR1=value [ENV_VAR2=value2] ./e2e-test.sh`
-
-```
-VERBOSE                 | If "true", the scripts will print out each command as executed | default: "false"
-KIBANA_CLUSTER_SIZE     | The num of Kibana pod replicas | default: 1
-KIBANA_OPS_CLUSTER_SIZE | The num of Kibana Ops pod replicas if OPS cluster is used | default: 1
-ES_CLUSTER_SIZE         | The num of Elasticsearch pod replicas | default: 1
-ES_OPS_CLUSTER_SIZE     | The num of Elasticsearch Ops pod replicas if OPS cluster is used | default: 1
-TIMES                   | The maximum number of attempts to try for checking if ES is ready for queries | default: 10
-QUERY_SIZE              | The maximum number of query results returned for an index | default: 500
-```
 
 # About the performance testing
 

--- a/hack/testing/e2e-test.sh
+++ b/hack/testing/e2e-test.sh
@@ -2,7 +2,7 @@
 
 if [[ $# -ne 1 ]]; then
   # assuming not using OPS cluster
-  CLUSTER="false"
+  CLUSTER=""
 else
   CLUSTER="$1"
 fi
@@ -13,11 +13,11 @@ ES_CLUSTER_SIZE=${ES_CLUSTER_SIZE:=1}
 ES_OPS_CLUSTER_SIZE=${ES_OPS_CLUSTER_SIZE:=1}
 
 echo "Checking installation of the EFK stack..."
-KIBANA_CLUSTER_SIZE=$KIBANA_CLUSTER_SIZE KIBANA_OPS_CLUSTER_SIZE=$KIBANA_OPS_CLUSTER_SIZE ES_CLUSTER_SIZE=$ES_CLUSTER_SIZE ES_OPS_CLUSTER_SIZE=$ES_OPS_CLUSTER_SIZE ./check-EFK-running.sh "$CLUSTER"
+KIBANA_CLUSTER_SIZE=$KIBANA_CLUSTER_SIZE KIBANA_OPS_CLUSTER_SIZE=$KIBANA_OPS_CLUSTER_SIZE ES_CLUSTER_SIZE=$ES_CLUSTER_SIZE ES_OPS_CLUSTER_SIZE=$ES_OPS_CLUSTER_SIZE ./check-EFK-running.sh $CLUSTER
 
 if [[ $? -eq 0 ]]; then
   echo "Checking for log entry matches between ES and their sources..."
-  ./check-logs.sh "$CLUSTER"
+  ./check-logs.sh $CLUSTER
 else
   echo "Errors found when checking installation of the EFK stack -- not checking log entry matches. Please resolve errors and retest."
   exit 1

--- a/hack/testing/perf-test-operations.sh
+++ b/hack/testing/perf-test-operations.sh
@@ -2,7 +2,7 @@
 # This tests for raw .operations index performance - write a bunch of messages
 # to the system log and see how long it takes all of them to show up in ES
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ] ; then
   set -ex
 else
   set -e

--- a/hack/testing/test-curator.sh
+++ b/hack/testing/test-curator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${VERBOSE:-false}" = "true" ] ; then
+if [ -n "${VERBOSE:-}" ] ; then
   set -ex
 else
   set -e

--- a/hack/testing/test-datetime-future.sh
+++ b/hack/testing/test-datetime-future.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ] ; then
   set -ex
 else
   set -e

--- a/hack/testing/test-es-copy.sh
+++ b/hack/testing/test-es-copy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ]; then
   set -ex
 else
   set -e

--- a/hack/testing/test-fluentd-forward.sh
+++ b/hack/testing/test-fluentd-forward.sh
@@ -5,7 +5,7 @@
 # verify the same way we do now (for ES copy)
 # need to create a custom configmap for both fluentd?
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ]; then
   set -ex
 else
   set -e

--- a/hack/testing/test-json-parsing.sh
+++ b/hack/testing/test-json-parsing.sh
@@ -4,7 +4,7 @@
 # embedded JSON into its component fields, and use the
 # original message field in the embedded JSON
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ]; then
   set -ex
 else
   set -e

--- a/hack/testing/test-mux.sh
+++ b/hack/testing/test-mux.sh
@@ -3,7 +3,7 @@
 # test the mux route and service
 # - can accept secure_forward from a "client" fluentd
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ]; then
   set -ex
 else
   set -e
@@ -29,7 +29,7 @@ fi
 oadm new-project testproj --node-selector=''
 
 print_message() {
-    if [ "${VERBOSE:-false}" = true ] ; then
+    if [ -n "${VERBOSE:-}" ] ; then
         query_es_from_es $espod $myproject _search $myfield $mymessage >> $MUXDEBUG
 
         local es_pod=`get_running_pod es`
@@ -203,7 +203,7 @@ write_and_verify_logs() {
 
     local rc=0
 
-    if [ "${VERBOSE:-false}" = true ] ; then
+    if [ -n "${VERBOSE:-}" ] ; then
         MUXDEBUG=$ARTIFACT_DIR/mux-test-ext.$is_testproj.$no_container_vals.$mismatch_namespace.$no_project_tag.log
     else
         MUXDEBUG="/dev/null"

--- a/hack/testing/test-upgrade.sh
+++ b/hack/testing/test-upgrade.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ]; then
   set -ex
 else
   set -e

--- a/hack/testing/test-viaq-data-model.sh
+++ b/hack/testing/test-viaq-data-model.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $VERBOSE ]]; then
+if [ -n "${VERBOSE:-}" ]; then
   set -ex
 else
   set -e


### PR DESCRIPTION
If logging.sh is run with the NOSETUP argument, it will skip the set up
of OpenShift and logging components, and will assume they are already
present.
In addition, clean up and make consistent the use of the VERBOSE and CLUSTER
environment variables, and document the current logging.sh variables.
@jcantrill @stevekuznetsov @nhosoi @lukas-vlcek PTAL
[test]