### PR TITLE
Change startup polling logic to hit APIs and check pod readiness

### DIFF
--- a/deployer/README.md
+++ b/deployer/README.md
@@ -13,7 +13,7 @@
   * [Upgrading your EFK stack](#upgrading-your-efk-stack)
   * [Uninstall and Reinstall](#uninstall-and-reinstall)
 * [Using Kibana](#using-kibana)
-* [Adjusting ElasticSearch After Deployment](#adjusting-elasticsearch-after-deployment)
+* [Adjusting Elasticsearch After Deployment](#adjusting-elasticsearch-after-deployment)
 * [Checking EFK Health](#checking-efk-health)
 * [Troubleshooting](#troubleshooting)
 
@@ -22,7 +22,7 @@
 The deployer pod can enable deploying the full stack of the aggregated
 logging solution with just a few prerequisites:
 
-1. Sufficient volumes defined for ElasticSearch cluster storage.
+1. Sufficient volumes defined for Elasticsearch cluster storage.
 2. A router deployment for serving cluster-defined routes for Kibana.
 
 The deployer generates all the necessary certs/keys/etc for cluster
@@ -101,15 +101,15 @@ but will still precede the corresponding template values within the deployer pod
 You will need to specify the hostname at which Kibana should be
 exposed to client browsers, and also the master URL where client
 browsers will be directed for authenticating to OpenShift. You should
-read the [ElasticSearch](#elasticsearch) section below before choosing
-ElasticSearch parameters for the deployer. These and other parameters
+read the [Elasticsearch](#elasticsearch) section below before choosing
+Elasticsearch parameters for the deployer. These and other parameters
 are available:
 
 * `kibana-hostname`: External hostname where web clients will reach Kibana
 * `public-master-url`: External URL for the master, for OAuth purposes
-* `es-cluster-size`: How many instances of ElasticSearch to deploy. At least 3 are needed for redundancy, and more can be used for scaling.
-* `es-instance-ram`: Amount of RAM to reserve per ElasticSearch instance (e.g. 1024M, 2G). Defaults to 8GiB; must be at least 512M (Ref.: [ElasticSearch documentation](https://www.elastic.co/guide/en/elasticsearch/guide/current/hardware.html#_memory).
-* `es-pvc-size`: Size of the PersistentVolumeClaim to create per ElasticSearch ops instance, e.g. 100G. If empty, no PVCs will be created and emptyDir volumes are used instead.
+* `es-cluster-size`: How many instances of Elasticsearch to deploy. At least 3 are needed for redundancy, and more can be used for scaling.
+* `es-instance-ram`: Amount of RAM to reserve per Elasticsearch instance (e.g. 1024M, 2G). Defaults to 8GiB; must be at least 512M (Ref.: [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/guide/current/hardware.html#_memory).
+* `es-pvc-size`: Size of the PersistentVolumeClaim to create per Elasticsearch ops instance, e.g. 100G. If empty, no PVCs will be created and emptyDir volumes are used instead.
 * `es-pvc-prefix`: Prefix for the names of PersistentVolumeClaims to be created; a number will be appended per instance. If they don't already exist, they will be created with size `es-pvc-size`.
 * `es-pvc-dynamic`: Set to `true` to have created PersistentVolumeClaims annotated such that their backing storage can be dynamically provisioned (if that is available for your cluster).
 * `storage-group`: Number of a supplemental group ID for access to Elasticsearch storage volumes; backing volumes should allow access by this group ID (defaults to 65534).
@@ -234,7 +234,7 @@ deployer creates and how to change them.
 ### Ops cluster
 
 If you set `enable-ops-cluster` to `true` for the deployer, fluentd
-expects to split logs between the main ElasticSearch cluster and another
+expects to split logs between the main Elasticsearch cluster and another
 cluster reserved for operations logs (which are defined as node system
 logs and the projects `default`, `openshift`, and `openshift-infra`). Thus
 a separate Elasticsearch cluster, a separate Kibana, and a separate
@@ -242,20 +242,20 @@ Curator are deployed to index, access, and manage operations logs. These
 deployments are set apart with the `-ops` included in their names. Keep
 these separate deployments in mind while reading the following.
 
-### ElasticSearch
+### Elasticsearch
 
-The deployer creates the number of ElasticSearch instances specified by
-`es-cluster-size`. The nature of ElasticSearch and current Kubernetes
+The deployer creates the number of Elasticsearch instances specified by
+`es-cluster-size`. The nature of Elasticsearch and current Kubernetes
 limitations require that we use a different scaling mechanism than the
 standard Kubernetes scaling.
 
 Scaling a standard deployment (a Kubernetes ReplicationController)
 to multiple pods currently mounts the same volumes on all pods in the
-deployment. However, multiple ElasticSearch instances in a cluster
+deployment. However, multiple Elasticsearch instances in a cluster
 cannot share storage; each pod requires its own storage. Work is under
 way to enable specifying multiple volumes to be allocated individually
 to instances in a deployment, but for now the deployer creates multiple
-deployments in order to scale ElasticSearch to multiple instances. You
+deployments in order to scale Elasticsearch to multiple instances. You
 can view the deployments with:
 
     $ oc get dc --selector logging-infra=elasticsearch
@@ -279,7 +279,7 @@ as directed below.
 By default, the deployer creates an ephemeral deployment in which all
 of a pod's data will be lost any time it is restarted. For production
 use you should specify a persistent storage volume for each deployment
-of ElasticSearch. The deployer parameters with `-pvc-` in the name should
+of Elasticsearch. The deployer parameters with `-pvc-` in the name should
 be used for this. You can either use a pre-existing set of PVCs (specify
 a common prefix for their names and append numbers starting at 1, for
 example with default prefix `logging-es-` supply PVCs `logging-es-1`,
@@ -311,7 +311,7 @@ you would like to use, you can set it with:
 
 #### Node selector
 
-ElasticSearch can be very resource-heavy, particularly in RAM, depending
+Elasticsearch can be very resource-heavy, particularly in RAM, depending
 on the volume of logs your cluster generates. Per Elastic's guidance,
 all members of the cluster should have low latency network connections
 to each other.  You will likely want to direct the instances to dedicated
@@ -342,7 +342,7 @@ oc patch dc/logging-es-{unique name} -p '{"spec":{"template":{"spec":{"nodeSelec
 Recall that the default scheduler algorithm will spread pods to different
 nodes (in the same region, if regions are defined). However this can
 have unexpected consequences in several scenarios and you will most
-likely want to label and specify designated nodes for ElasticSearch.
+likely want to label and specify designated nodes for Elasticsearch.
 
 #### Cluster parameters
 
@@ -362,7 +362,7 @@ should be sufficient, unless you need to scale ES after deployment.
 
 Fluentd is deployed as a DaemonSet that deploys replicas according
 to a node label selector (which you can choose; the default is
-`logging-infra-fluentd`). Once you have ElasticSearch running as
+`logging-infra-fluentd`). Once you have Elasticsearch running as
 desired, label the nodes to deploy Fluentd to in order to feed
 logs into ES. The example below would label a node named
 'ip-172-18-2-170.ec2.internal' using the default Fluentd node selector.
@@ -803,14 +803,14 @@ Here is some information specific to the aggregated logging deployment.
 1. Login is performed via OAuth2, as with the web console. The default certificate
 authentication used for the admin user isn't available, but you can create
 other users and make them cluster admins.
-2. Kibana and ElasticSearch have been customized to display logs only
+2. Kibana and Elasticsearch have been customized to display logs only
 to users that have access to the projects the logs came from. So if you login
 and have no access to anything, be sure your user has access to at least one
 project. Cluster admin users should have access to all project logs as
 well as host logs.
-3. To do anything with ElasticSearch and Kibana, Kibana has to have
+3. To do anything with Elasticsearch and Kibana, Kibana has to have
 defined some index patterns that match indices being recorded in
-ElasticSearch. This should already be done for you, but you should be
+Elasticsearch. This should already be done for you, but you should be
 aware how these work in case you want to customize anything. When logs
 from applications in a project are recorded, they are indexed by project
 name and date in the format `project.name.YYYY-MM-DD`. For matching a project's
@@ -830,16 +830,16 @@ user to be able to view these logs, run `$ oc edit configmap/logging-elasticsear
 change the value of `openshift.operations.allow_cluster_reader` to `true` and
 restart your ES cluster.
 
-# Adjusting ElasticSearch After Deployment
+# Adjusting Elasticsearch After Deployment
 
-If you need to change the ElasticSearch cluster size after deployment,
-DO NOT just scale existing deployments up or down. ElasticSearch cannot
+If you need to change the Elasticsearch cluster size after deployment,
+DO NOT just scale existing deployments up or down. Elasticsearch cannot
 scale by ordinary Kubernetes mechanisms, as explained above. Each instance
 requires its own storage, and thus under current capabilities, its own
 deployment. The deployer defined a template `logging-es-template` which
-can be used to create new ElasticSearch deployments.
+can be used to create new Elasticsearch deployments.
 
-Adjusting the scale of the ElasticSearch cluster
+Adjusting the scale of the Elasticsearch cluster
 typically requires adjusting cluster parameters that
 vary by cluster size. [Elastic documentation discusses these
 issues](https://www.elastic.co/guide/en/elasticsearch/guide/current/_important_configuration_changes.html)
@@ -852,15 +852,15 @@ and existing deployments when changing the cluster size.
 Changing cluster parameters (or any parameters/secrets, really) requires
 re-deploying the instances. In order to minimize resynchronization
 between the instances as they are restarted, we advise halting traffic to
-ElasticSearch and then taking down the entire cluster for maintenance. No
+Elasticsearch and then taking down the entire cluster for maintenance. No
 logs will be lost; Fluentd simply blocks until the cluster returns.
 
-Halting traffic to ElasticSearch requires scaling down Kibana and removing node labels for Fluentd:
+Halting traffic to Elasticsearch requires scaling down Kibana and removing node labels for Fluentd:
 
     $ oc label node --all logging-infra-
     $ oc scale rc/logging-kibana-1 --replicas=0
 
-Next scale all of the ElasticSearch deployments to 0 similarly.
+Next scale all of the Elasticsearch deployments to 0 similarly.
 
     $ oc get rc --selector logging-infra=elasticsearch
     $ oc scale rc/logging-es-... --replicas=0
@@ -1059,7 +1059,7 @@ with a non-zero exit code, and no deployed pods, e.g.:
     NAME                           READY     STATUS             RESTARTS   AGE
     logging-es-2e7ut0iq-1-deploy   1/1       ExitCode:255       0          1m
 
-(In this example, the deployer pod name for an ElasticSearch deployment is shown;
+(In this example, the deployer pod name for an Elasticsearch deployment is shown;
 this is from ReplicationController `logging-es-2e7ut0iq-1` which is a deployment
 of DeploymentConfig `logging-es-2e7ut0iq`.)
 
@@ -1128,7 +1128,7 @@ If everything is deployed but visiting Kibana results in a proxy
 error, then one of the following things is likely to be the issue.
 
 First, Kibana might not actually have any pods that are recognized
-as running. If ElasticSearch is slow in starting up, Kibana may
+as running. If Elasticsearch is slow in starting up, Kibana may
 error out trying to reach it, and won't be considered alive. You can
 check whether the relevant service has any endpoints:
 

--- a/deployer/deployer.yaml
+++ b/deployer/deployer.yaml
@@ -252,15 +252,15 @@ items:
     name: MASTER_URL
     value: "https://kubernetes.default.svc.cluster.local"
   -
-    description: "(Deprecated) How many instances of ElasticSearch to deploy."
+    description: "(Deprecated) How many instances of Elasticsearch to deploy."
     name: ES_CLUSTER_SIZE
     value: "1"
   -
-    description: "(Deprecated) Amount of RAM to reserve per ElasticSearch instance."
+    description: "(Deprecated) Amount of RAM to reserve per Elasticsearch instance."
     name: ES_INSTANCE_RAM
     value: "8G"
   -
-    description: "(Deprecated) Size of the PersistentVolumeClaim to create per ElasticSearch instance, e.g. 100G. If empty, no PVCs will be created and emptyDir volumes are used instead."
+    description: "(Deprecated) Size of the PersistentVolumeClaim to create per Elasticsearch instance, e.g. 100G. If empty, no PVCs will be created and emptyDir volumes are used instead."
     name: ES_PVC_SIZE
   -
     description: "(Deprecated) Prefix for the names of PersistentVolumeClaims to be created; a number will be appended per instance. If they don't already exist, they will be created with size ES_PVC_SIZE."
@@ -283,14 +283,14 @@ items:
     name: ES_RECOVER_AFTER_TIME
     value: "5m"
   -
-    description: "(Deprecated) How many ops instances of ElasticSearch to deploy. By default, ES_CLUSTER_SIZE."
+    description: "(Deprecated) How many ops instances of Elasticsearch to deploy. By default, ES_CLUSTER_SIZE."
     name: ES_OPS_CLUSTER_SIZE
   -
-    description: "(Deprecated) Amount of RAM to reserve per ops ElasticSearch instance."
+    description: "(Deprecated) Amount of RAM to reserve per ops Elasticsearch instance."
     name: ES_OPS_INSTANCE_RAM
     value: "8G"
   -
-    description: "(Deprecated) Size of the PersistentVolumeClaim to create per ElasticSearch ops instance, e.g. 100G. If empty, no PVCs will be created and emptyDir volumes are used instead."
+    description: "(Deprecated) Size of the PersistentVolumeClaim to create per Elasticsearch ops instance, e.g. 100G. If empty, no PVCs will be created and emptyDir volumes are used instead."
     name: ES_OPS_PVC_SIZE
   -
     description: "(Deprecated) Prefix for the names of PersistentVolumeClaims to be created; a number will be appended per instance. If they don't already exist, they will be created with size ES_OPS_PVC_SIZE."

--- a/deployer/scripts/install.sh
+++ b/deployer/scripts/install.sh
@@ -483,7 +483,7 @@ function notify_user() {
 Operations logs:
 ----------------
 You chose to split ops logs to their own ops cluster, which includes an
-ElasticSearch cluster and its own deployment of Kibana. The deployments
+Elasticsearch cluster and its own deployment of Kibana. The deployments
 are set apart by '-ops' in the name. The comments above about configuring
 ES deployments apply equally to the ops cluster.
 "
@@ -497,7 +497,7 @@ The deployer has created secrets, templates, and component deployments
 required for logging. You now have a few more steps to run manually.
 Consult the deployer docs for more detail.
 
-ElasticSearch:
+Elasticsearch:
 --------------
 Clustered instances have been created as individual deployments. View with:
     oc get dc --selector logging-infra=elasticsearch

--- a/deployer/scripts/util.sh
+++ b/deployer/scripts/util.sh
@@ -420,7 +420,7 @@ function curl_es() {
 # stdout is the JSON output from Elasticsearch
 # stderr is curl errors
 function query_es_from_es() {
-    curl_es "$1" "/${2}*/${3}\?q=${4}:${5}" --connect-timeout 1
+    curl_es "$1" "/${2}*/${3}?q=${4}:${5}" --connect-timeout 1
 }
 
 # $1 is es pod

--- a/deployer/scripts/util.sh
+++ b/deployer/scripts/util.sh
@@ -396,6 +396,22 @@ curl_es_from_kibana() {
 }
 
 # $1 - es pod name
+# $2 - es endpoint
+# rest - any args to pass to curl
+function curl_es() {
+    local pod="$1"
+    local endpoint="$2"
+    shift; shift
+    local args=( "${@:-}" )
+
+    local secret_dir="/etc/elasticsearch/secret/"
+    oc exec "${pod}" -- curl --silent --insecure "${args[@]}" \
+                             --key "${secret_dir}admin-key"   \
+                             --cert "${secret_dir}admin-cert" \
+                             "https://localhost:9200${endpoint}"
+}
+
+# $1 - es pod name
 # $2 - es hostname (e.g. logging-es or logging-es-ops)
 # $3 - index name (e.g. project.logging, project.test, .operations, etc.)
 # $4 - _count or _search
@@ -404,9 +420,7 @@ curl_es_from_kibana() {
 # stdout is the JSON output from Elasticsearch
 # stderr is curl errors
 function query_es_from_es() {
-    oc exec $1 -- curl --connect-timeout 1 -s -k \
-       --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key \
-       https://localhost:9200/${2}*/${3}\?q=${4}:${5}
+    curl_es "$1" "/${2}*/${3}\?q=${4}:${5}" --connect-timeout 1
 }
 
 # $1 is es pod

--- a/deployer/templates/curator.yaml
+++ b/deployer/templates/curator.yaml
@@ -113,23 +113,23 @@ parameters:
   name: MASTER_URL
   value: "https://kubernetes.default.svc.cluster.local"
 -
-  description: "Hostname (or IP) for reaching ElasticSearch"
+  description: "Hostname (or IP) for reaching Elasticsearch"
   name: ES_HOST
   value: "logging-es"
 -
-  description: "Port number for reaching ElasticSearch"
+  description: "Port number for reaching Elasticsearch"
   name: ES_PORT
   value: "9200"
 -
-  description: "Location of client certificate for authenticating to ElasticSearch"
+  description: "Location of client certificate for authenticating to Elasticsearch"
   name: ES_CLIENT_CERT
   value: "/etc/curator/keys/cert"
 -
-  description: "Location of client key for authenticating to ElasticSearch"
+  description: "Location of client key for authenticating to Elasticsearch"
   name: ES_CLIENT_KEY
   value: "/etc/curator/keys/key"
 -
-  description: "Location of CA cert for validating connecting to ElasticSearch"
+  description: "Location of CA cert for validating connecting to Elasticsearch"
   name: ES_CA
   value: "/etc/curator/keys/ca"
 -

--- a/deployer/templates/es.yaml
+++ b/deployer/templates/es.yaml
@@ -3,7 +3,7 @@ kind: "Template"
 metadata:
   name: logging-elasticsearch-template-maker
   annotations:
-    description: "Template to create template for deploying ElasticSearch"
+    description: "Template to create template for deploying Elasticsearch"
     tags: "infrastructure"
 objects:
 - apiVersion: "v1"
@@ -11,7 +11,7 @@ objects:
   metadata:
     name: logging-${ES_CLUSTER_NAME}-template
     annotations:
-      description: "Template for deploying ElasticSearch with proxy/plugin for storing and retrieving aggregated cluster logs."
+      description: "Template for deploying Elasticsearch with proxy/plugin for storing and retrieving aggregated cluster logs."
       tags: "infrastructure"
     labels:
       logging-infra: elasticsearch
@@ -117,7 +117,7 @@ objects:
     from: 'logging-${ES_CLUSTER_NAME}-[a-z0-9]{8}'
     generate: expression
   -
-    description: "Amount of RAM to reserve per ElasticSearch instance (e.g. 1024M or 8G)"
+    description: "Amount of RAM to reserve per Elasticsearch instance (e.g. 1024M or 8G)"
     name: INSTANCE_RAM
     value: ${ES_INSTANCE_RAM}
   -

--- a/deployer/templates/fluentd.yaml
+++ b/deployer/templates/fluentd.yaml
@@ -193,43 +193,43 @@ parameters:
   name: MASTER_URL
   value: "https://kubernetes.default.svc.cluster.local"
 -
-  description: "Hostname (or IP) for reaching ElasticSearch to write logs"
+  description: "Hostname (or IP) for reaching Elasticsearch to write logs"
   name: ES_HOST
   value: "logging-es"
 -
-  description: "Port number for reaching ElasticSearch to write logs"
+  description: "Port number for reaching Elasticsearch to write logs"
   name: ES_PORT
   value: "9200"
 -
-  description: "Location of client certificate for authenticating to ElasticSearch to write logs"
+  description: "Location of client certificate for authenticating to Elasticsearch to write logs"
   name: ES_CLIENT_CERT
   value: "/etc/fluent/keys/cert"
 -
-  description: "Location of client key for authenticating to ElasticSearch to write logs"
+  description: "Location of client key for authenticating to Elasticsearch to write logs"
   name: ES_CLIENT_KEY
   value: "/etc/fluent/keys/key"
 -
-  description: "Location of CA cert for validating connection to ElasticSearch to write logs"
+  description: "Location of CA cert for validating connection to Elasticsearch to write logs"
   name: ES_CA
   value: "/etc/fluent/keys/ca"
 -
-  description: "Hostname (or IP) for reaching ElasticSearch to write cluster logs"
+  description: "Hostname (or IP) for reaching Elasticsearch to write cluster logs"
   name: OPS_HOST
   value: "logging-es"
 -
-  description: "Port number for reaching ElasticSearch to write cluster logs"
+  description: "Port number for reaching Elasticsearch to write cluster logs"
   name: OPS_PORT
   value: "9200"
 -
-  description: "Location of client certificate for authenticating to ElasticSearch to write cluster logs"
+  description: "Location of client certificate for authenticating to Elasticsearch to write cluster logs"
   name: OPS_CLIENT_CERT
   value: "/etc/fluent/keys/cert"
 -
-  description: "Location of client key for authenticating to ElasticSearch to write cluster logs"
+  description: "Location of client key for authenticating to Elasticsearch to write cluster logs"
   name: OPS_CLIENT_KEY
   value: "/etc/fluent/keys/key"
 -
-  description: "Location of CA cert for validating connection to ElasticSearch to write cluster logs"
+  description: "Location of CA cert for validating connection to Elasticsearch to write cluster logs"
   name: OPS_CA
   value: "/etc/fluent/keys/ca"
 -
@@ -237,67 +237,67 @@ parameters:
   name: ES_COPY
   value: "false"
 -
-  description: "Hostname (or IP) for additional ElasticSearch"
+  description: "Hostname (or IP) for additional Elasticsearch"
   name: ES_COPY_HOST
   value: ""
 -
-  description: "Port number for additional ElasticSearch"
+  description: "Port number for additional Elasticsearch"
   name: ES_COPY_PORT
   value: ""
 -
-  description: "URL scheme for additional ElasticSearch - http or https - default is https"
+  description: "URL scheme for additional Elasticsearch - http or https - default is https"
   name: ES_COPY_SCHEME
   value: "https"
 -
-  description: "Location of client certificate for authenticating to additional ElasticSearch"
+  description: "Location of client certificate for authenticating to additional Elasticsearch"
   name: ES_COPY_CLIENT_CERT
   value: ""
 -
-  description: "Location of client key for authenticating to additional ElasticSearch"
+  description: "Location of client key for authenticating to additional Elasticsearch"
   name: ES_COPY_CLIENT_KEY
   value: ""
 -
-  description: "Location of CA cert for validating connection to additional ElasticSearch"
+  description: "Location of CA cert for validating connection to additional Elasticsearch"
   name: ES_COPY_CA
   value: ""
 -
-  description: "Username for username/password auth to connection to additional ElasticSearch"
+  description: "Username for username/password auth to connection to additional Elasticsearch"
   name: ES_COPY_USERNAME
   value: ""
 -
-  description: "Password for username/password auth to connection to additional ElasticSearch"
+  description: "Password for username/password auth to connection to additional Elasticsearch"
   name: ES_COPY_PASSWORD
   value: ""
 -
-  description: "Hostname (or IP) for additional ElasticSearch to write cluster logs"
+  description: "Hostname (or IP) for additional Elasticsearch to write cluster logs"
   name: OPS_COPY_HOST
   value: ""
 -
-  description: "Port number for additional ElasticSearch to write cluster logs"
+  description: "Port number for additional Elasticsearch to write cluster logs"
   name: OPS_COPY_PORT
   value: ""
 -
-  description: "URL scheme for additional ElasticSearch to write cluster logs - http or https - default is https"
+  description: "URL scheme for additional Elasticsearch to write cluster logs - http or https - default is https"
   name: OPS_COPY_SCHEME
   value: "https"
 -
-  description: "Location of client certificate for authenticating to additional ElasticSearch to write cluster logs"
+  description: "Location of client certificate for authenticating to additional Elasticsearch to write cluster logs"
   name: OPS_COPY_CLIENT_CERT
   value: ""
 -
-  description: "Location of client key for authenticating to additional ElasticSearch to write cluster logs"
+  description: "Location of client key for authenticating to additional Elasticsearch to write cluster logs"
   name: OPS_COPY_CLIENT_KEY
   value: ""
 -
-  description: "Location of CA cert for validating connectiong to additional ElasticSearch to write cluster logs"
+  description: "Location of CA cert for validating connectiong to additional Elasticsearch to write cluster logs"
   name: OPS_COPY_CA
   value: ""
 -
-  description: "Username for username/password auth to connection to additional ElasticSearch to write cluster logs"
+  description: "Username for username/password auth to connection to additional Elasticsearch to write cluster logs"
   name: OPS_COPY_USERNAME
   value: ""
 -
-  description: "Password for username/password auth to connection to additional ElasticSearch to write cluster logs"
+  description: "Password for username/password auth to connection to additional Elasticsearch to write cluster logs"
   name: OPS_COPY_PASSWORD
   value: ""
 -

--- a/deployer/templates/kibana.yaml
+++ b/deployer/templates/kibana.yaml
@@ -11,7 +11,7 @@ objects:
   metadata:
     name: logging-${KIBANA_DEPLOY_NAME}-template
     annotations:
-      description: "Template for deploying log viewer Kibana connecting to ElasticSearch to visualize aggregated cluster logs."
+      description: "Template for deploying log viewer Kibana connecting to Elasticsearch to visualize aggregated cluster logs."
       tags: "infrastructure"
     labels:
       logging-infra: kibana
@@ -133,11 +133,11 @@ parameters:
   name: OAP_PUBLIC_MASTER_URL
   required: true
 -
-  description: "Hostname/IP for ElasticSearch backend to connect to."
+  description: "Hostname/IP for Elasticsearch backend to connect to."
   name: ES_HOST
   value: "logging-es"
 -
-  description: "Port to connect to for ElasticSearch backend."
+  description: "Port to connect to for Elasticsearch backend."
   name: ES_PORT
   value: "9200"
 -

--- a/hack/templates/pv-hostmount.yaml
+++ b/hack/templates/pv-hostmount.yaml
@@ -3,7 +3,7 @@ kind: "Template"
 metadata:
   name: logging-pv-template
   annotations:
-    description: "Template for deploying a test volume with a host mount for ElasticSearch to use for storage."
+    description: "Template for deploying a test volume with a host mount for Elasticsearch to use for storage."
     tags: "infrastructure"
   labels:
     logging-infra: elasticsearch-pv

--- a/hack/templates/pv-nfs.yaml
+++ b/hack/templates/pv-nfs.yaml
@@ -3,7 +3,7 @@ kind: "Template"
 metadata:
   name: logging-pv-template
   annotations:
-    description: "Template for deploying a test volume with an nfs mount for ElasticSearch to use for storage."
+    description: "Template for deploying a test volume with an nfs mount for Elasticsearch to use for storage."
     tags: "infrastructure"
   labels:
     logging-infra: elasticsearch-pv

--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -20,7 +20,7 @@ if [[ $# -eq 1 ]]; then
 	oal_kibana_components+=( "kibana-ops" )
 fi
 
-# Currently one DeploymentConfig per ElasticSearch
+# Currently one DeploymentConfig per Elasticsearch
 # replica is created, and is therefore given a long
 # unique name that we do not know beforehand. We
 # only know that there should be DCs with the
@@ -30,13 +30,13 @@ fi
 # are used to deploy the cluster instead.
 es_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-[a-zA-Z0-9]{8}" )"
 if [[ "$( wc -w <<<"${es_dcs}" )" -ne 1 ]]; then
-	os::log::fatal "Expected to find one ElasticSearch DeploymentConfig, got: '${es_dcs:-"<none>"}'"
+	os::log::fatal "Expected to find one Elasticsearch DeploymentConfig, got: '${es_dcs:-"<none>"}'"
 fi
 oal_expected_deploymentconfigs+=( ${es_dcs} )
 if [[ $# -eq 1 ]]; then
 	es_ops_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es-ops -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-ops-[a-zA-Z0-9]{8}" )"
 	if [[ "$( wc -w <<<"${es_ops_dcs}" )" -ne 1 ]]; then
-		os::log::fatal "Expected to find one OPS ElasticSearch DeploymentConfig, got: '${es_ops_dcs:-"<none>"}'"
+		os::log::fatal "Expected to find one OPS Elasticsearch DeploymentConfig, got: '${es_ops_dcs:-"<none>"}'"
 	fi
 	oal_expected_deploymentconfigs+=( ${es_ops_dcs} )
 fi

--- a/hack/testing/check-logs.sh
+++ b/hack/testing/check-logs.sh
@@ -31,17 +31,17 @@ if [ -z "${USE_JOURNAL:-}" ] ; then
 fi
 
 USE_JOURNAL="${USE_JOURNAL}"    \
-OAL_ELASTICSEACH_COMPONENT="es" \
+OAL_ELASTICSEARCH_COMPONENT="es" \
 OAL_KIBANA_COMPONENT="kibana"   \
-OAL_ELASTICSEACH_SERVICE="logging-es" \
+OAL_ELASTICSEARCH_SERVICE="logging-es" \
 "${OS_O_A_L_DIR}/test/cluster/functionality.sh"
 
 if [[ $# -eq 1 ]]; then
   # There is an ops cluster set up, so we
   # need to verify it's functionality as well.
   USE_JOURNAL="${USE_JOURNAL}"        \
-  OAL_ELASTICSEACH_COMPONENT="es-ops" \
+  OAL_ELASTICSEARCH_COMPONENT="es-ops" \
   OAL_KIBANA_COMPONENT="kibana-ops"   \
-  OAL_ELASTICSEACH_SERVICE="logging-es-ops" \
+  OAL_ELASTICSEARCH_SERVICE="logging-es-ops" \
   "${OS_O_A_L_DIR}/test/cluster/functionality.sh"
 fi

--- a/hack/testing/templates/fluentd_dc.yaml
+++ b/hack/testing/templates/fluentd_dc.yaml
@@ -135,43 +135,43 @@ parameters:
   name: MASTER_URL
   value: "https://kubernetes.default.svc.cluster.local"
 -
-  description: "Hostname (or IP) for reaching ElasticSearch to write logs"
+  description: "Hostname (or IP) for reaching Elasticsearch to write logs"
   name: ES_HOST
   value: "logging-es"
 -
-  description: "Port number for reaching ElasticSearch to write logs"
+  description: "Port number for reaching Elasticsearch to write logs"
   name: ES_PORT
   value: "9200"
 -
-  description: "Location of client certificate for authenticating to ElasticSearch to write logs"
+  description: "Location of client certificate for authenticating to Elasticsearch to write logs"
   name: ES_CLIENT_CERT
   value: "/etc/fluent/keys/cert"
 -
-  description: "Location of client key for authenticating to ElasticSearch to write logs"
+  description: "Location of client key for authenticating to Elasticsearch to write logs"
   name: ES_CLIENT_KEY
   value: "/etc/fluent/keys/key"
 -
-  description: "Location of CA cert for validating connectiong to ElasticSearch to write logs"
+  description: "Location of CA cert for validating connectiong to Elasticsearch to write logs"
   name: ES_CA
   value: "/etc/fluent/keys/ca"
 -
-  description: "Hostname (or IP) for reaching ElasticSearch to write cluster logs"
+  description: "Hostname (or IP) for reaching Elasticsearch to write cluster logs"
   name: OPS_HOST
   value: "logging-es"
 -
-  description: "Port number for reaching ElasticSearch to write cluster logs"
+  description: "Port number for reaching Elasticsearch to write cluster logs"
   name: OPS_PORT
   value: "9200"
 -
-  description: "Location of client certificate for authenticating to ElasticSearch to write cluster logs"
+  description: "Location of client certificate for authenticating to Elasticsearch to write cluster logs"
   name: OPS_CLIENT_CERT
   value: "/etc/fluent/keys/cert"
 -
-  description: "Location of client key for authenticating to ElasticSearch to write cluster logs"
+  description: "Location of client key for authenticating to Elasticsearch to write cluster logs"
   name: OPS_CLIENT_KEY
   value: "/etc/fluent/keys/key"
 -
-  description: "Location of CA cert for validating connectiong to ElasticSearch to write cluster logs"
+  description: "Location of CA cert for validating connectiong to Elasticsearch to write cluster logs"
   name: OPS_CA
   value: "/etc/fluent/keys/ca"
 -

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -48,14 +48,15 @@ elasticsearch_api="$( oc get svc "${OAL_ELASTICSEACH_SERVICE}" -o jsonpath='{ .m
 
 for kibana_pod in $( oc get pods --selector component="${OAL_KIBANA_COMPONENT}"  -o jsonpath='{ .items[*].metadata.name }' ); do
 	os::log::info "Testing Kibana pod ${kibana_pod} for a successful start..."
-	os::cmd::try_until_text "oc logs ${kibana_pod} -c kibana" "Server running at http://0\.0\.0\.0:5601" "$(( 10*TIME_MIN ))"
-	os::cmd::try_until_text "oc logs ${kibana_pod} -c kibana" "Kibana index ready" "$(( 10*TIME_MIN ))"
+	os::cmd::try_until_text "oc exec ${kibana_pod} -c kibana -- curl -s --request HEAD --write-out '%{response_code}' http://localhost:5601/" "200" "$(( 10*TIME_MIN ))"
+	os::cmd::expect_success_and_text "oc get pod ${kibana_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"kibana\")].ready }'" "true"
+	os::cmd::expect_success_and_text "oc get pod ${kibana_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"kibana-proxy\")].ready }'" "true"
 done
 
 for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEACH_COMPONENT}" -o jsonpath='{ .items[*].metadata.name }' ); do
 	os::log::info "Testing ElasticSearch pod ${elasticsearch_pod} for a successful start..."
-	os::cmd::try_until_text "oc logs ${elasticsearch_pod}" "\[cluster\.service\s*\]" "$(( 10*TIME_MIN ))"
-	os::cmd::try_until_text "oc logs ${elasticsearch_pod}" "\[node\s*\]\s*\[.*\]\s*started" "$(( 10*TIME_MIN ))"
+	os::cmd::try_until_text "oc exec ${elasticsearch_pod} -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key -X HEAD -w '%{response_code}' https://localhost:9200/" '200' "$(( 10*TIME_MIN ))"
+	os::cmd::expect_success_and_text "oc get pod ${elasticsearch_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"elasticsearch\")].ready }'" "true"
 
 	os::log::info "Checking that ElasticSearch pod ${elasticsearch_pod} recovered its indices after starting..."
 	if oc logs "${elasticsearch_pod}" | grep -E "\[cluster\.service\s*\]" | grep -q "new_master"; then

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -12,11 +12,11 @@
 # This script expects the following environment
 # variables:
 #  - OAL_{
-#         ELASTICSEACH,
+#         ELASTICSEARCH,
 #         KIBANA
 #         }_COMPONENT: the component labels that
 #    are used to identify application pods
-#  - OAL_ELASTICSEACH_SERVICE: the service under which
+#  - OAL_ELASTICSEARCH_SERVICE: the service under which
 #    Elasticsearch is exposed
 #  - OAL_QUERY_SIZE: the number of messages to query
 #    for per index
@@ -44,7 +44,7 @@ os::cmd::expect_success "oc login --username=system:admin"
 os::cmd::expect_success "oc project logging"
 
 # We can reach the Elasticsearch service at serviceName:apiPort
-elasticsearch_api="$( oc get svc "${OAL_ELASTICSEACH_SERVICE}" -o jsonpath='{ .metadata.name }:{ .spec.ports[?(@.targetPort=="restapi")].port }' )"
+elasticsearch_api="$( oc get svc "${OAL_ELASTICSEARCH_SERVICE}" -o jsonpath='{ .metadata.name }:{ .spec.ports[?(@.targetPort=="restapi")].port }' )"
 
 for kibana_pod in $( oc get pods --selector component="${OAL_KIBANA_COMPONENT}"  -o jsonpath='{ .items[*].metadata.name }' ); do
 	os::log::info "Testing Kibana pod ${kibana_pod} for a successful start..."
@@ -53,7 +53,7 @@ for kibana_pod in $( oc get pods --selector component="${OAL_KIBANA_COMPONENT}" 
 	os::cmd::expect_success_and_text "oc get pod ${kibana_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"kibana-proxy\")].ready }'" "true"
 done
 
-for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEACH_COMPONENT}" -o jsonpath='{ .items[*].metadata.name }' ); do
+for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARCH_COMPONENT}" -o jsonpath='{ .items[*].metadata.name }' ); do
 	os::log::info "Testing Elasticsearch pod ${elasticsearch_pod} for a successful start..."
 	os::cmd::try_until_text "oc exec ${elasticsearch_pod} -- curl -sk --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key -X HEAD -w '%{response_code}' https://localhost:9200/" '200' "$(( 10*TIME_MIN ))"
 	os::cmd::expect_success_and_text "oc get pod ${elasticsearch_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"elasticsearch\")].ready }'" "true"

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -50,14 +50,14 @@ elasticsearch_api="$( oc get svc "${OAL_ELASTICSEARCH_SERVICE}" -o jsonpath='{ .
 for kibana_pod in $( oc get pods --selector component="${OAL_KIBANA_COMPONENT}"  -o jsonpath='{ .items[*].metadata.name }' ); do
 	os::log::info "Testing Kibana pod ${kibana_pod} for a successful start..."
 	os::cmd::try_until_text "oc exec ${kibana_pod} -c kibana -- curl -s --request HEAD --write-out '%{response_code}' http://localhost:5601/" "200" "$(( 10*TIME_MIN ))"
-	os::cmd::expect_success_and_text "oc get pod ${kibana_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"kibana\")].ready }'" "true"
-	os::cmd::expect_success_and_text "oc get pod ${kibana_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"kibana-proxy\")].ready }'" "true"
+	os::cmd::try_until_text "oc get pod ${kibana_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"kibana\")].ready }'" "true"
+	os::cmd::try_until_text "oc get pod ${kibana_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"kibana-proxy\")].ready }'" "true"
 done
 
 for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARCH_COMPONENT}" -o jsonpath='{ .items[*].metadata.name }' ); do
 	os::log::info "Testing Elasticsearch pod ${elasticsearch_pod} for a successful start..."
 	os::cmd::try_until_text "curl_es '${elasticsearch_pod}' '/' -X HEAD -w '%{response_code}'" '200' "$(( 10*TIME_MIN ))"
-	os::cmd::expect_success_and_text "oc get pod ${elasticsearch_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"elasticsearch\")].ready }'" "true"
+	os::cmd::try_until_text "oc get pod ${elasticsearch_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"elasticsearch\")].ready }'" "true"
 
 	os::log::info "Checking that Elasticsearch pod ${elasticsearch_pod} recovered its indices after starting..."
 	os::cmd::try_until_text "curl_es '${elasticsearch_pod}' '/_cluster/state/master_node' -w '%{response_code}'" "}200$" "$(( 10*TIME_MIN ))"

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -65,7 +65,7 @@ for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARC
 	es_pod_node_id="$( curl_es "${elasticsearch_pod}" "/_nodes/_local" | jq '.nodes' | jq --raw-output 'keys[0]' )"
 	es_detected_master_id="$( curl_es "${elasticsearch_pod}" "/_cat/master?h=id" )"
 	if [[ "${es_master_id}" == "${es_pod_node_id}" ]]; then
-		os::cmd::expect_success_and_text "oc logs ${elasticsearch_pod}" "\[gateway\s*\]\s*\[.*\]\s*recovered\s*\[[0-9]*\]\s*indices into cluster_state"
+		os::log::info "Elasticsearch pod ${elasticsearch_pod} is the master"
 	elif [[ -n "${es_detected_master_id}" ]]; then
 		os::log::info "Elasticsearch pod ${elasticsearch_pod} was able to detect a master"
 	else

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -61,8 +61,8 @@ for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARC
 
 	os::log::info "Checking that Elasticsearch pod ${elasticsearch_pod} recovered its indices after starting..."
 	os::cmd::try_until_text "curl_es '${elasticsearch_pod}' '/_cluster/state/master_node' -w '%{response_code}'" "}200$" "$(( 10*TIME_MIN ))"
-	es_master_id="$( curl_es "${elasticsearch_pod}" "/_cluster/state/master_node" | jq --raw-output '.master_node' )"
-	es_pod_node_id="$( curl_es "${elasticsearch_pod}" "/_nodes/_local" | jq '.nodes' | jq --raw-output 'keys[0]' )"
+	es_master_id="$( curl_es "${elasticsearch_pod}" "/_cluster/state/master_node" | python -c  'import json, sys; print json.load(sys.stdin)["master_node"];' )"
+	es_pod_node_id="$( curl_es "${elasticsearch_pod}" "/_nodes/_local" | python -c  'import json, sys; print json.load(sys.stdin)["nodes"].keys()[0];' )"
 	es_detected_master_id="$( curl_es "${elasticsearch_pod}" "/_cat/master?h=id" )"
 	if [[ "${es_master_id}" == "${es_pod_node_id}" ]]; then
 		os::log::info "Elasticsearch pod ${elasticsearch_pod} is the master"


### PR DESCRIPTION
The current approach of looking through container logs to determine if
the ElasticSearch or Kibana node is a specific state is not only fragile
as there is no compatibility guarantee on the log messages but also not
the most useful as it requires that a cluster is set up to log to the
console, which is not default in production clusters.

Specifically, to query for Kibana and ElasticSearch readiness we should
be able to (in a perfect world) simply wait for the `oc rollout status`
check to succeed, as a full rollout of the `DeploymentConfig` will
require that the containers report a ready state. However, there are two
issues with that approach today:

 - Kibana does not have a readiness probe set
 - the OpenShift-Ansible installer creates `DeploymentConfig`s that set
   the desired replica count to 0, which always causes the rollout to
   succeed as there is no work to do. When these deployments are scaled
   in the future, the rollout is not updated

Both of these issues are being worked on, but in the interim we can
continue checking for Kibana and ElasticSearch readiness in this test
by issuing the same `curl` commands that the `ReadinessProbe` will. This
check can be relaxed as the other changes merge.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]
/cc @richm 