### PR TITLE
Update Elasticsearch DC selection logic in E2E test

### DIFF
--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -28,13 +28,13 @@ fi
 # and keep the cluster rollout test clean.
 # TODO: This will not be necessary when StatefulSets
 # are used to deploy the cluster instead.
-es_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-[a-zA-Z0-9]{8}" )"
+es_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-(data-)?(master|client)-[a-zA-Z0-9]{8}" )"
 if [[ "$( wc -w <<<"${es_dcs}" )" -ne 1 ]]; then
 	os::log::fatal "Expected to find one Elasticsearch DeploymentConfig, got: '${es_dcs:-"<none>"}'"
 fi
 oal_expected_deploymentconfigs+=( ${es_dcs} )
 if [[ $# -eq 1 ]]; then
-	es_ops_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es-ops -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-ops-[a-zA-Z0-9]{8}" )"
+	es_ops_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es-ops -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-ops-(data-)?(master|client)-[a-zA-Z0-9]{8}" )"
 	if [[ "$( wc -w <<<"${es_ops_dcs}" )" -ne 1 ]]; then
 		os::log::fatal "Expected to find one OPS Elasticsearch DeploymentConfig, got: '${es_ops_dcs:-"<none>"}'"
 	fi


### PR DESCRIPTION
Recent refactors in the OpenShift-Ansible installation code for the
Elasticsearch cluster change the name of the `DeploymentConfig`s that
are created. This regex update matches the new changes.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @ewolinetz 

Should follow the merge of https://github.com/openshift/openshift-ansible/pull/3509