### PR TITLE
skip umount in mux mode

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -144,8 +144,12 @@ fi
 
 # bug https://bugzilla.redhat.com/show_bug.cgi?id=1437952
 # pods unable to be terminated because fluentd has them busy
-echo "umounts of dead containers will fail. Ignoring..."
-umount /var/lib/docker/containers/*/shm || :
+if [ "${USE_MUX:-}" = "true" ] ; then
+    : # skip umount
+else
+    echo "umounts of dead containers will fail. Ignoring..."
+    umount /var/lib/docker/containers/*/shm || :
+fi
 
 if [[ $DEBUG ]] ; then
     exec fluentd $fluentdargs > /var/log/fluentd.log 2>&1


### PR DESCRIPTION
mux does not mount anything from the host, so we can skip the umount
@jcantrill @ewolinetz @nhosoi @lukas-vlcek PTAL
[test]