### PR TITLE
disable k8s meta plugin for mux client

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -94,6 +94,9 @@ if [ "${USE_MUX_CLIENT:-}" = "true" ] ; then
     if [ -f $CFG_DIR/user/filter-pre-mux-client.conf ] ; then
         cp -f $CFG_DIR/user/filter-pre-mux-client.conf $CFG_DIR/openshift
     fi
+    # rm k8s meta plugin - do not hit the API server
+    rm $CFG_DIR/openshift/filter-k8s-meta.conf
+    touch $CFG_DIR/openshift/filter-k8s-meta.conf
 else
     rm -f $CFG_DIR/openshift/filter-pre-mux-client.conf
 fi


### PR DESCRIPTION
One of the reasons for using fluentd as a mux client is to avoid
hitting the API server - this patch makes sure that the fluentd k8s
meta plugin is explicitly disabled.