### PR TITLE
Point OPS_HOST to the default elasticsearch ops cluster

### DIFF
--- a/deployer/templates/fluentd.yaml
+++ b/deployer/templates/fluentd.yaml
@@ -219,7 +219,7 @@ parameters:
 -
   description: "Hostname (or IP) for reaching Elasticsearch to write cluster logs"
   name: OPS_HOST
-  value: "logging-es"
+  value: "logging-es-ops"
 -
   description: "Port number for reaching Elasticsearch to write cluster logs"
   name: OPS_PORT


### PR DESCRIPTION
Proposed fix for issue #437 