### PR TITLE
Point OPS_HOST to the default elasticsearch ops cluster

### DIFF
--- a/deployer/templates/fluentd.yaml
+++ b/deployer/templates/fluentd.yaml
@@ -203,7 +203,7 @@ parameters:
 -
   description: "Hostname (or IP) for reaching ElasticSearch to write cluster logs"
   name: OPS_HOST
-  value: "logging-es"
+  value: "logging-es-ops"
 -
   description: "Port number for reaching ElasticSearch to write cluster logs"
   name: OPS_PORT


### PR DESCRIPTION
Proposed fix for issue #437 

Targets OpenShift 3.4, specifically the set-up of the EFK stack after installation of the cluster.

This PR supersedes https://github.com/openshift/origin-aggregated-logging/pull/438 to target the release-1.4 branch instead of the master branch.