### PR TITLE
Revert UTC Patch, Update Elasticsearch DC selection logic in E2E test

### DIFF
--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -28,13 +28,13 @@ fi
 # and keep the cluster rollout test clean.
 # TODO: This will not be necessary when StatefulSets
 # are used to deploy the cluster instead.
-es_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-[a-zA-Z0-9]{8}" )"
+es_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-(data-)?(master|client)-[a-zA-Z0-9]{8}" )"
 if [[ "$( wc -w <<<"${es_dcs}" )" -ne 1 ]]; then
 	os::log::fatal "Expected to find one Elasticsearch DeploymentConfig, got: '${es_dcs:-"<none>"}'"
 fi
 oal_expected_deploymentconfigs+=( ${es_dcs} )
 if [[ $# -eq 1 ]]; then
-	es_ops_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es-ops -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-ops-[a-zA-Z0-9]{8}" )"
+	es_ops_dcs="$( oc get deploymentconfigs --namespace logging --selector component=es-ops -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-es-ops-(data-)?(master|client)-[a-zA-Z0-9]{8}" )"
 	if [[ "$( wc -w <<<"${es_ops_dcs}" )" -ne 1 ]]; then
 		os::log::fatal "Expected to find one OPS Elasticsearch DeploymentConfig, got: '${es_ops_dcs:-"<none>"}'"
 	fi

--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -112,31 +112,21 @@ os::log::info "Starting logging tests at `date`"
 
 cd "${OS_ROOT}"
 
-function cleanup()
-{
-    out=$?
-    echo
-    if [ $out -ne 0 ]; then
-        echo "[FAIL] !!!!! Test Failed !!!!"
-    else
-        os::log::info "Test Succeeded"
-    fi
-
-    os::test::junit::generate_report
-
+function cleanup() {
+    return_code=$?
     if [ "$DEBUG_FAILURES" = "true" ] ; then
         echo debug failures - when you are finished, 'ps -ef|grep 987654' then kill that sleep process
         sleep 987654 || echo debugging done - continuing
     fi
-    if [ "$DO_CLEANUP" = "true" ] ; then
-        cleanup_openshift
-    fi
-    os::log::info "Exiting at `date`"
-    ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"
-    return $out
-}
 
-trap "exit" INT TERM
+    if [ "$DO_CLEANUP" = "true" ] ; then
+        os::cleanup::all "${return_code}"
+    else
+        os::util::describe_return_code "${return_code}"
+    fi
+
+    exit "${return_code}"
+}
 trap "cleanup" EXIT
 
 # override LOG_DIR and ARTIFACTS_DIR

--- a/hack/testing/test-curator.sh
+++ b/hack/testing/test-curator.sh
@@ -340,7 +340,12 @@ basictest() {
     # see what the current time and timezone are in the curator pod
     oc exec $curpod -- date
     # calculate the runhour and runminute to run 5 minutes from now
-    tz=`timedatectl | awk '/Time zone:/ {print $3}'`
+    # There is apparently a bug in el7 - this doesn't work:
+    # date +%H --date="TZ=\"Region/City\" 5 minutes hence"
+    ## date: invalid date ‘TZ="Region/City" 5 minutes hence’
+    # so for now, just use UTC
+    #tz=`timedatectl | awk '/Time zone:/ {print $3}'`
+    tz=UTC
     runhour=`TZ=$tz date +%H --date="TZ=\"$tz\" $sleeptime seconds hence"`
     runminute=`TZ=$tz date +%M --date="TZ=\"$tz\" $sleeptime seconds hence"`
     cat > $curtest <<EOF

--- a/hack/testing/test-curator.sh
+++ b/hack/testing/test-curator.sh
@@ -11,7 +11,7 @@ set -o nounset
 set -o pipefail
 
 if ! type get_running_pod > /dev/null 2>&1 ; then
-    . ${OS_O_A_L_DIR:-../..}/deployer/scripts/util.sh
+    . ${OS_O_A_L_DIR:-../..}/deployer/scripts/util.sh1
 fi
 
 if [[ $# -ne 1 || "$1" = "false" ]]; then
@@ -374,6 +374,18 @@ project3-qe:
   delete:
     days: 7
 EOF
+
+    echo "[DEBUG] \$today=${today}"
+    echo "[DEBUG] \$yesterday=${yesterday}"
+    echo "[DEBUG] \$lastweek=${lastweek}"
+    echo "[DEBUG] \$fourweeksago=${fourweeksago}"
+    echo "[DEBUG] \$thirtyonedaysago=${thirtyonedaysago}"
+    echo "[DEBUG] \$twomonthsago=${twomonthsago}"
+    echo "[DEBUG] \$pod_time=$( oc exec $curpod -- date -u +"$tf" )"
+    echo "[DEBUG] \$runhour=${runhour}"
+    echo "[DEBUG] \$runminute=${runminute}"
+    echo "[DEBUG] config yaml: $( cat "${curtest}" )"
+
     update_config_and_restart $curtest
     # wait for curator run 1 to finish
     wait_for_curator_run $curpod 1


### PR DESCRIPTION
Revert "Merge pull request #433 from stevekuznetsov/skuznets/timezone-update"

This reverts commit 9135ff014fb20ea4ecb2c2f86638ff300f37b2e7, reversing
changes made to ae9dff631fb6a25cbdc1c7545771c50553437bf2.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Update Elasticsearch DC selection logic in E2E test

Recent refactors in the OpenShift-Ansible installation code for the
Elasticsearch cluster change the name of the `DeploymentConfig`s that
are created. This regex update matches the new changes.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


[test]