### PR TITLE
globally remove imagePullPolicy: Always

### DIFF
--- a/deployer/deployer.yaml
+++ b/deployer/deployer.yaml
@@ -125,7 +125,6 @@ items:
     spec:
       containers:
       - image: ${IMAGE_PREFIX}logging-deployment:${IMAGE_VERSION}
-        imagePullPolicy: Always
         name: deployer
         volumeMounts:
         - name: empty

--- a/deployer/templates/curator.yaml
+++ b/deployer/templates/curator.yaml
@@ -60,7 +60,6 @@ objects:
           containers:
           - name: curator
             image: ${IMAGE_PREFIX}logging-curator:${IMAGE_VERSION}
-            imagePullPolicy: Always
             resources:
               limits:
                 cpu: 100m

--- a/deployer/templates/es.yaml
+++ b/deployer/templates/es.yaml
@@ -50,7 +50,6 @@ objects:
             -
               name: "elasticsearch"
               image: ${IMAGE_PREFIX}logging-elasticsearch:${IMAGE_VERSION}
-              imagePullPolicy: Always
               resources:
                 limits:
                   memory: "${INSTANCE_RAM}i"

--- a/deployer/templates/fluentd.yaml
+++ b/deployer/templates/fluentd.yaml
@@ -57,7 +57,6 @@ objects:
           containers:
           - name: fluentd-elasticsearch
             image: ${IMAGE_PREFIX}logging-fluentd:${IMAGE_VERSION}
-            imagePullPolicy: Always
             securityContext:
               privileged: true
             resources:

--- a/deployer/templates/kibana.yaml
+++ b/deployer/templates/kibana.yaml
@@ -61,7 +61,6 @@ objects:
             -
               name: "kibana"
               image: ${IMAGE_PREFIX}logging-kibana:${IMAGE_VERSION}
-              imagePullPolicy: Always
               ports:
               env:
                 - name: "ES_HOST"
@@ -75,7 +74,6 @@ objects:
             -
               name: "kibana-proxy"
               image: ${IMAGE_PREFIX}logging-auth-proxy:${IMAGE_VERSION}
-              imagePullPolicy: Always
               ports:
                 -
                   name: "oaproxy"

--- a/hack/testing/templates/fluentd_dc.yaml
+++ b/hack/testing/templates/fluentd_dc.yaml
@@ -70,7 +70,6 @@ objects:
           containers:
           - name: fluentd-elasticsearch
             image: ${IMAGE_PREFIX}logging-fluentd:${IMAGE_VERSION}
-            imagePullPolicy: Always
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
I'd like "imagePullPolicy: Always" to be removed, on the grounds that it makes development harder, and it should not be needed.  Is it possible?