### PR TITLE
use openshift/origin:v1.5.1 as base for deployer

### DIFF
--- a/deployer/Dockerfile
+++ b/deployer/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin:v1.5.0-alpha.2
+FROM openshift/origin:v1.5.1
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 


### PR DESCRIPTION
the oc in openshift/origin:v1.5.0-alpha.2 does not work against origin master (oc deploy --latest fails).  released/non-alpha oc 1.4.1, 1.5.0 and 1.5.1 are all good - use the latest.