### PR TITLE
Introducing environment variables: MUX_CPU_LIMIT and MUX_MEMORY_LIMIT…

### DIFF
--- a/deployer/templates/fluentd.yaml
+++ b/deployer/templates/fluentd.yaml
@@ -343,4 +343,4 @@ parameters:
 -
   description: 'Fluentd buffer size limit'
   name: BUFFER_SIZE_LIMIT
-  value: "16777216"
+  value: "1048576"

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -22,6 +22,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
       ruby-devel \
       libcurl-devel \
       make \
+      bc \
       iproute && \
     yum clean all
 RUN mkdir -p ${HOME} && \

--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -5,8 +5,11 @@
   shared_key "#{File.open('/etc/fluent/muxkeys/shared_key') do |f| f.readline end.rstrip}"
   secure yes
   ca_cert_path /etc/fluent/muxkeys/ca
-  buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-  buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
+  buffer_type file
+  buffer_path /var/fluentd/file_buffer_mux-client
+  flush_interval 1s
+  buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+  buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
   <server>
     host logging-mux
     port "#{ENV['FORWARD_LISTEN_PORT'] || '24284'}"

--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -5,9 +5,7 @@
   shared_key "#{File.open('/etc/fluent/muxkeys/shared_key') do |f| f.readline end.rstrip}"
   secure yes
   ca_cert_path /etc/fluent/muxkeys/ca
-  buffer_type file
-  buffer_path /var/fluentd/file_buffer_mux-client
-  flush_interval 1s
+  flush_interval 5s
   buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
   buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
   <server>

--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -17,11 +17,9 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 1s
+      flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_type file
-      buffer_path /var/fluentd/file_buffer_es-copy
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -17,9 +17,11 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
+      flush_interval 1s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
+      buffer_type file
+      buffer_path /var/fluentd/file_buffer_es-copy
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -17,11 +17,9 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 1s
+      flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_type file
-      buffer_path /var/fluentd/file_buffer_es-ops-copy
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -17,9 +17,11 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
+      flush_interval 1s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
+      buffer_type file
+      buffer_path /var/fluentd/file_buffer_es-ops-copy
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -17,9 +17,11 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
+      flush_interval 1s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
+      buffer_type file
+      buffer_path /var/fluentd/file_buffer_es
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -17,11 +17,9 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 1s
+      flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_type file
-      buffer_path /var/fluentd/file_buffer_es
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -17,11 +17,9 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 1s
+      flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_type file
-      buffer_path /var/fluentd/file_buffer_es-ops
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -17,9 +17,11 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
+      flush_interval 1s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
+      buffer_type file
+      buffer_path /var/fluentd/file_buffer_es-ops
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -59,7 +59,12 @@ IPADDR6=`/usr/sbin/ip -6 addr show dev eth0 | grep inet6 | sed "s/[ \t]*inet6 \(
 export IPADDR4 IPADDR6
 
 export BUFFER_QUEUE_LIMIT=${BUFFER_QUEUE_LIMIT:-1024}
-export BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-16777216}
+export BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-1048576}
+export MUX_CPU_LIMIT=${MUX_CPU_LIMIT:-500m}
+export MUX_MEMORY_LIMIT=${MUX_MEMORY_LIMIT:-2Gi}
+
+mkdir /var/fluentd
+chmod 0700 /var/fluentd
 
 CFG_DIR=/etc/fluent/configs.d
 if [ "${USE_MUX:-}" = "true" ] ; then

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -58,11 +58,11 @@ IPADDR4=`/usr/sbin/ip -4 addr show dev eth0 | grep inet | sed -e "s/[ \t]*inet \
 IPADDR6=`/usr/sbin/ip -6 addr show dev eth0 | grep inet6 | sed "s/[ \t]*inet6 \([a-f0-9:]*\).*/\1/"`
 export IPADDR4 IPADDR6
 
-export BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-1048576}
-export MUX_CPU_LIMIT=${MUX_CPU_LIMIT:-500m}
-export MUX_MEMORY_LIMIT=${MUX_MEMORY_LIMIT:-2Gi}
-export FLUENTD_CPU_LIMIT=${FLUENTD_CPU_LIMIT:-100m}
-export FLUENTD_MEMORY_LIMIT=${FLUENTD_MEMORY_LIMIT:-512Mi}
+BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-1048576}
+MUX_CPU_LIMIT=${MUX_CPU_LIMIT:-500m}
+MUX_MEMORY_LIMIT=${MUX_MEMORY_LIMIT:-2Gi}
+FLUENTD_CPU_LIMIT=${FLUENTD_CPU_LIMIT:-100m}
+FLUENTD_MEMORY_LIMIT=${FLUENTD_MEMORY_LIMIT:-512Mi}
 
 CFG_DIR=/etc/fluent/configs.d
 if [ "${USE_MUX:-}" = "true" ] ; then

--- a/hack/testing/init-log-stack
+++ b/hack/testing/init-log-stack
@@ -11,6 +11,18 @@ ES_HOSTNAME=${ES_HOST:+openshift_logging_es_hostname=$ES_HOST}
 ES_OPS_ALLOW_EXTERNAL=${ES_OPS_HOST:+openshift_logging_es_ops_allow_external=True}
 ES_OPS_HOSTNAME=${ES_OPS_HOST:+openshift_logging_es_ops_hostname=$ES_OPS_HOST}
 
+if [ "$MUX_ALLOW_EXTERNAL" = true ] ; then
+    SET_MUX_CPU_LIMIT="openshift_logging_mux_cpu_limit=${MUX_CPU_LIMIT:-500m}"
+    SET_MUX_MEMORY_LIMIT="openshift_logging_mux_memory_limit=${MUX_MEMORY_LIMIT:-2Gi}"
+    SET_MUX_BUFFER_QUEUE_LIMIT="openshift_logging_mux_buffer_queue_limit=${MUX_BUFFER_QUEUE_LIMIT:-1024}"
+    SET_MUX_BUFFER_SIZE_LIMIT="openshift_logging_mux_buffer_size_limit=${MUX_BUFFER_SIZE_LIMIT:-1048576}"
+else
+    SET_MUX_CPU_LIMIT=""
+    SET_MUX_MEMORY_LIMIT=""
+    SET_MUX_BUFFER_QUEUE_LIMIT=""
+    SET_MUX_BUFFER_SIZE_LIMIT=""
+fi
+
 source $OS_O_A_L_DIR/hack/testing/build-images
 
 # init inventory file
@@ -43,14 +55,14 @@ openshift_logging_es_log_appenders=['console']
 openshift_logging_use_mux=${USE_MUX:-false}
 openshift_logging_mux_allow_external=${MUX_ALLOW_EXTERNAL:-false}
 openshift_logging_use_mux_client=${USE_MUX_CLIENT:-false}
-$SET_MUX_CPU_LIMIT
-$SET_MUX_MEMORY_LIMIT
-$SET_MUX_BUFFER_QUEUE_LIMIT
-$SET_MUX_BUFFER_SIZE_LIMIT
 $ES_ALLOW_EXTERNAL
 $ES_HOSTNAME
 $ES_OPS_ALLOW_EXTERNAL
 $ES_OPS_HOSTNAME
+$SET_MUX_CPU_LIMIT
+$SET_MUX_MEMORY_LIMIT
+$SET_MUX_BUFFER_QUEUE_LIMIT
+$SET_MUX_BUFFER_SIZE_LIMIT
 
 EOL
 

--- a/hack/testing/init-log-stack
+++ b/hack/testing/init-log-stack
@@ -43,6 +43,10 @@ openshift_logging_es_log_appenders=['console']
 openshift_logging_use_mux=${USE_MUX:-false}
 openshift_logging_mux_allow_external=${MUX_ALLOW_EXTERNAL:-false}
 openshift_logging_use_mux_client=${USE_MUX_CLIENT:-false}
+$SET_MUX_CPU_LIMIT
+$SET_MUX_MEMORY_LIMIT
+$SET_MUX_BUFFER_QUEUE_LIMIT
+$SET_MUX_BUFFER_SIZE_LIMIT
 $ES_ALLOW_EXTERNAL
 $ES_HOSTNAME
 $ES_OPS_ALLOW_EXTERNAL

--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -44,6 +44,12 @@ export USE_MUX=${USE_MUX:-false}
 if [ "$MUX_ALLOW_EXTERNAL" = true -o "$USE_MUX_CLIENT" = true ] ; then
     export USE_MUX=true
 fi
+if [ "$MUX_ALLOW_EXTERNAL" = true ] ; then
+    export SET_MUX_CPU_LIMIT="openshift_logging_mux_cpu_limit=${MUX_CPU_LIMIT:-500m}"
+    export SET_MUX_MEMORY_LIMIT="openshift_logging_mux_memory_limit=${MUX_MEMORY_LIMIT:-2Gi}"
+    export SET_MUX_BUFFER_QUEUE_LIMIT="openshift_logging_mux_buffer_queue_limit=${MUX_BUFFER_QUEUE_LIMIT:-1024}"
+    export SET_MUX_BUFFER_SIZE_LIMIT="openshift_logging_mux_buffer_size_limit=${MUX_BUFFER_SIZE_LIMIT:-1048576}"
+fi
 
 # use a few tools from the deployer
 source "$OS_O_A_L_DIR/deployer/scripts/util.sh"

--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -44,12 +44,6 @@ export USE_MUX=${USE_MUX:-false}
 if [ "$MUX_ALLOW_EXTERNAL" = true -o "$USE_MUX_CLIENT" = true ] ; then
     export USE_MUX=true
 fi
-if [ "$MUX_ALLOW_EXTERNAL" = true ] ; then
-    export SET_MUX_CPU_LIMIT="openshift_logging_mux_cpu_limit=${MUX_CPU_LIMIT:-500m}"
-    export SET_MUX_MEMORY_LIMIT="openshift_logging_mux_memory_limit=${MUX_MEMORY_LIMIT:-2Gi}"
-    export SET_MUX_BUFFER_QUEUE_LIMIT="openshift_logging_mux_buffer_queue_limit=${MUX_BUFFER_QUEUE_LIMIT:-1024}"
-    export SET_MUX_BUFFER_SIZE_LIMIT="openshift_logging_mux_buffer_size_limit=${MUX_BUFFER_SIZE_LIMIT:-1048576}"
-fi
 
 # use a few tools from the deployer
 source "$OS_O_A_L_DIR/deployer/scripts/util.sh"


### PR DESCRIPTION
… with the default value set {500m, 2Gi}.

Setting them to openshift_logging_mux_cpu_limit and openshift_logging_mux_memory_limit
in the inventory file, respectively.

Setting BUFFER_QUEUE_LIMIT and BUFFER_SIZE_LIMIT to openshift_logging_mux_buffer_queue_limit
and openshift_logging_mux_buffer_size_limit, as well.

Switching to buffer_type file
buffer_path /var/fluentd/file_buffer_*
buffer_chunk_limit 1m
buffer_queue_limit 1024
flush_interval 1s