### PR TITLE
Add a script to automatically update the hack/lib

### DIFF
--- a/hack/update-lib.sh
+++ b/hack/update-lib.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This script attempts to update the vendored
+# copy of hack/lib from Origin and re-apply all
+# the [carry] commits on top.
+
+for sha in $( git log --pretty='%H' -- hack/lib/ ); do
+	subject="$( git log -n 1 --pretty='%s' "${sha}" )"
+	if [[ "${subject}" =~ ^"Vendor origin/hack/lib at "* ]]; then
+		last_vendor_commit="${sha}"
+		break
+	fi
+done
+
+carry_commits=()
+for sha in $( git log --reverse --pretty='%H' "${last_vendor_commit}..HEAD" -- hack/lib ); do
+	subject="$( git log -n 1 --pretty='%s' "${sha}" )"
+	if [[ "${subject}" =~ ^"[carry]"* ]]; then
+		carry_commits+=( "${sha}" )
+	fi
+done
+
+origin_tmp="$( mktemp -d )"
+git clone --depth 1 git@github.com:openshift/origin.git "${origin_tmp}"
+pushd "${origin_tmp}"
+origin_head="$( git log -n 1 --pretty=%h )"
+popd
+
+rm -rf hack/lib
+cp -r "${origin_tmp}/hack/lib" hack/
+rm -rf "${origin_tmp}"
+git add hack/lib
+git commit --message "Vendor origin/hack/lib at ${origin_head}"
+
+for commit in "${carry_commits[@]}"; do
+	git cherry-pick "${commit}"
+done


### PR DESCRIPTION
We vendor the Origin Bash libraries at hack/lib. We will need to update
that copy every so often while also keep intact the commits we intend to
carry on top. The `hack/update-lib.sh` script aims to automate that
process to some extent.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @richm here is a simple script -- we should not run it until we have https://github.com/openshift/origin/pull/14437 merged