### PR TITLE
bug 1457642. Fix SG timeout

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -42,6 +42,7 @@ ADD install.sh ${HOME}/
 RUN ${HOME}/install.sh
 ADD run.sh ${HOME}/
 COPY utils/** /usr/local/bin/
+RUN ln -s /usr/local/bin/logging ${HOME}/logging
 
 WORKDIR ${HOME}
 USER 1000

--- a/elasticsearch/utils/es_seed_acl
+++ b/elasticsearch/utils/es_seed_acl
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+source "logging"
+
+MAX_WAIT_SEED=${MAX_WAIT_SEED:-$((60*60*24*7))} #one week
+
+info "Seeding the searchguard ACL index.  Will wait up to $MAX_WAIT_SEED seconds."
+
+config=/usr/share/elasticsearch/config/elasticsearch.yml
+index=$(python -c "import yaml; print yaml.load(open('/usr/share/elasticsearch/config/elasticsearch.yml'))['searchguard']['config_index_name']" | xargs -i sh -c "echo {}")
+
+now=0
+numretries=0
+loginterval=${SG_ADMIN_LOG_INTERVAL:-100}
+while ! /usr/share/elasticsearch/plugins/openshift-elasticsearch/sgadmin.sh \
+    -cd ${HOME}/sgconfig \
+    -i $index \
+    -ks /etc/elasticsearch/secret/searchguard.key \
+    -kst JKS \
+    -kspass kspass \
+    -ts /etc/elasticsearch/secret/searchguard.truststore \
+    -tst JKS \
+    -tspass tspass \
+    -nhnv \
+    -icl ${DEBUG:+-dg} && [ ${now} -lt ${MAX_WAIT_SEED} ]
+do
+    if ! expr $numretries % $loginterval ; then
+        warn "Error seeding the searchguard ACL index... retrying in 10 seconds - $numretries retries so far"
+        warn "Seeding will continue to fail until the cluster status is YELLOW"
+        info "Remaining red indices: $(QUERY=_cat/indices es_util | grep "^red" | wc -l)"
+    fi
+    numretries=$((numretries+1))
+    sleep 10
+    now=$((now+40)) #wait plus 30s timeout from sgadmin
+done
+
+if [ ${now} -ge ${MAX_WAIT_SEED} ]; then
+    error "Giving up trying to seed ACL"
+    exit 1
+fi
+info "Seeded the searchguard ACL index"

--- a/elasticsearch/utils/es_util
+++ b/elasticsearch/utils/es_util
@@ -6,13 +6,15 @@ source es_util_env
 
 QUERY=${QUERY:-""} 
 INDEX=${INDEX:-"project.*"}
+TYPE=${TYPE:-"_search"}
 SIZE=${SIZE:-10}
 SORT=${SORT:-"@timestamp:desc"}
+OPTIONS=${OPTIONS:-"size=$SIZE&sort=$SORT&pretty"}
 
 ES_BASE=${ES_BASE:-https://localhost:9200}
 
 if [ -z "${QUERY:-}" ]; then
-  QUERY="$ES_BASE/$INDEX/_search?size=$SIZE&sort=$SORT&pretty"
+  QUERY="$INDEX/$TYPE?$OPTIONS"
 fi
 
-curl -s -k --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key $QUERY
+curl -s -k --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key "$ES_BASE/$QUERY"

--- a/elasticsearch/utils/logging
+++ b/elasticsearch/utils/logging
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+
+LOGLEVEL=${LOGLEVEL:-6}
+loglevelint=6
+case $LOGLEVEL in
+    debug) loglevelint=7 ;;
+    info) loglevelint=6 ;;
+    warn) loglevelint=5 ;;
+    error) loglevelint=4 ;;
+    [1-7]) loglevelint=$LOGLEVEL ;;
+    *) echo ERROR: LOGLEVEL must be a number from 1-7
+       echo 7 is DEBUG, 4 is ERROR, default 6 is INFO
+       exit 1 ;;
+esac
+
+log() {
+    lvlint=$1
+    if [ $loglevelint -ge $lvlint ] ; then
+        shift
+        lvl=$1
+        shift
+        printf "[%.23s][%-5s][container.run            ] " "`date -u +'%F %T,%N'`" $lvl
+        echo "$@"
+    fi
+}
+
+debug() {
+    log 7 DEBUG "$@"
+}
+
+info() {
+    log 6 INFO "$@"
+}
+
+warn() {
+    log 5 WARN "$@"
+}
+
+error() {
+    log 4 ERROR "$@"
+}
+


### PR DESCRIPTION
This PR fixes SG timing out when it takes an extended period of time getting to yellow state:

* Adds loop to continue to try and seed
* Adds logging to identify the number of red indicies
* refactors es_util to make it easier to specify alternate queries

This PR overrides #462