### PR TITLE
use version 2.x of the elasticsearch libraries

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -28,8 +28,11 @@ RUN mkdir -p ${HOME} && \
     gem install -N --conservative --minimal-deps \
       fluentd:${FLUENTD_VERSION} \
       'activesupport:<5' \
+      'elasticsearch-transport:<5' \
+      'elasticsearch-api:<5' \
+      'elasticsearch:<5' \
       fluent-plugin-kubernetes_metadata_filter \
-      fluent-plugin-elasticsearch \
+      'fluent-plugin-elasticsearch:>1.9.2' \
       'fluent-plugin-systemd:<0.1.0' \
       systemd-journal \
       fluent-plugin-rewrite-tag-filter \


### PR DESCRIPTION
Work around gem dependency issues in the elasticsearch libraries so
that we can use the 2.x versions of the libraries.
@jcantrill @portante PTAL
[test]