### PR TITLE
Update to common data model 1.6.0

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -6,7 +6,8 @@ ENV HOME=/opt/app-root/src \
   PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \
   RUBY_VERSION=2.0 \
   FLUENTD_VERSION=0.12.31 \
-  GEM_HOME=/opt/app-root/src
+  GEM_HOME=/opt/app-root/src \
+  DATA_VERSION=1.6.0
 
 LABEL io.k8s.description="Fluentd container for collecting of docker container logs" \
   io.k8s.display-name="Fluentd ${FLUENTD_VERSION}" \

--- a/fluentd/configs.d/openshift/filter-k8s-record-transform.conf
+++ b/fluentd/configs.d/openshift/filter-k8s-record-transform.conf
@@ -11,13 +11,14 @@
     hostname ${(record['kubernetes']['host'] rescue nil) || File.open('/etc/docker-hostname') { |f| f.readline }.rstrip}
     # log is set if MESSAGE is JSON valued and has err or msg field
     message ${record['message'] || record['MESSAGE'] || log}
-    level ${record['PRIORITY']}
+    level ${["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug", "trace", "unknown"][begin; ('%d' % record['PRIORITY'] || 9).to_i; rescue; 9; end]}
     time ${Time.at((record["_SOURCE_REALTIME_TIMESTAMP"] || record["__REALTIME_TIMESTAMP"]).to_f / 1000000.0).utc.to_datetime.rfc3339(6)}
-    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-systemd","name":"fluentd openshift","received_at":"${Time.at((record['_SOURCE_REALTIME_TIMESTAMP'] || record['__REALTIME_TIMESTAMP']).to_f / 1000000.0).utc.to_datetime.rfc3339(6)}","version":"0.12.29 1.4.0"}}
+    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-systemd","name":"fluentd openshift","received_at":"${Time.at((record['_SOURCE_REALTIME_TIMESTAMP'] || record['__REALTIME_TIMESTAMP']).to_f / 1000000.0).utc.to_datetime.rfc3339(6)}","version":"${ENV['FLUENTD_VERSION'] + ' ' + ENV['DATA_VERSION']}"}}
+    systemd {"t":{"MACHINE_ID":"${record['_MACHINE_ID']}","AUDIT_LOGINUID":"${record['_AUDIT_LOGINUID']}","AUDIT_SESSION":"${record['_AUDIT_SESSION']}","BOOT_ID":"${record['_BOOT_ID']}","CAP_EFFECTIVE":"${record['_CAP_EFFECTIVE']}","CMDLINE":"${record['_CMDLINE']}","COMM":"${record['_COMM']}","EXE":"${record['_EXE']}","GID":"${record['_GID']}","HOSTNAME":"${record['_HOSTNAME']}","PID":"${record['_PID']}","SELINUX_CONTEXT":"${record['_SELINUX_CONTEXT']}","SOURCE_REALTIME_TIMESTAMP":"${record['_SOURCE_REALTIME_TIMESTAMP']}","SYSTEMD_CGROUP":"${record['_SYSTEMD_CGROUP']}","SYSTEMD_OWNER_UID":"${record['_SYSTEMD_OWNER_UID']}","SYSTEMD_SESSION":"${record['_SYSTEMD_SESSION']}","SYSTEMD_SLICE":"${record['_SYSTEMD_SLICE']}","SYSTEMD_UNIT":"${record['_SYSTEMD_UNIT']}","SYSTEMD_USER_UNIT":"${record['_SYSTEMD_USER_UNIT']}","TRANSPORT":"${record['_TRANSPORT']}","UID":"${record['_UID']}"},"u":{"CODE_FILE":"${record['CODE_FILE']}","CODE_FUNCTION":"${record['CODE_FUNCTION']}","CODE_LINE":"${record['CODE_LINE']}","ERRNO":"${record['ERRNO']}","MESSAGE_ID":"${record['MESSAGE_ID']}","RESULT":"${record['RESULT']}","UNIT":"${record['UNIT']}","SYSLOG_FACILITY":"${record['SYSLOG_FACILITY']}","SYSLOG_IDENTIFIER":"${record['SYSLOG_IDENTIFIER']}","SYSLOG_PID":"${record['SYSLOG_PID']}"},"k":{"KERNEL_DEVICE":"${record['_KERNEL_DEVICE']}","KERNEL_SUBSYSTEM":"${record['_KERNEL_SUBSYSTEM']}","UDEV_SYSNAME":"${record['_UDEV_SYSNAME']}","UDEV_DEVNODE":"${record['_UDEV_DEVNODE']}","UDEV_DEVLINK":"${record['_UDEV_DEVLINK']}"}}
   </record>
   # we have to use remove_keys - we can't use renew_record + keep_keys because the
   # k8s meta plugin adds the labels with dynamic names, and we can't keep_keys with wildcards/patterns
-  remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+  remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
 </filter>
 
 <filter kubernetes.var.log.containers**>
@@ -26,8 +27,8 @@
   <record>
     hostname ${(record['kubernetes']['host'] rescue nil) || File.open('/etc/docker-hostname') { |f| f.readline }.rstrip}
     message ${(message rescue nil) || log}
-    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-in_tail","name":"fluentd openshift","received_at":"${record['time'].to_s}","version":"0.12.29 1.4.0"}}
-    level ${record['stream'] == 'stdout' ? 6 : 3}
+    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-in_tail","name":"fluentd openshift","received_at":"${record['time'].to_s}","version":"${ENV['FLUENTD_VERSION'] + ' ' + ENV['DATA_VERSION']}"}}
+    level ${record['stream'] == 'stdout' ? 'info' : 'err'}
     time ${time.utc.to_datetime.rfc3339(6)}
   </record>
   remove_keys log,stream

--- a/fluentd/configs.d/openshift/filter-syslog-record-transform.conf
+++ b/fluentd/configs.d/openshift/filter-syslog-record-transform.conf
@@ -14,7 +14,7 @@
 
 
     #tag ${tag}_.operations_log
-    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-in_tail","name":"fluentd openshift","received_at":"${(Time.at(time) > Time.now) ? (Time.new((time.year - 1), time.month, time.day, time.hour, time.min, time.sec, time.utc_offset).utc.to_datetime.rfc3339(6)) : (time.utc.to_datetime.rfc3339(6))}","version":"0.12.29 1.4.0"}}
+    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-in_tail","name":"fluentd openshift","received_at":"${(Time.at(time) > Time.now) ? (Time.new((time.year - 1), time.month, time.day, time.hour, time.min, time.sec, time.utc_offset).utc.to_datetime.rfc3339(6)) : (time.utc.to_datetime.rfc3339(6))}","version":"${ENV['FLUENTD_VERSION'] + ' ' + ENV['DATA_VERSION']}"}}
   </record>
   remove_keys host,pid,ident
 </filter>
@@ -37,9 +37,11 @@
     # Plus we'd better avoid the file IO.
     hostname ${_HOSTNAME.eql?('localhost') ? (begin; File.open('/etc/docker-hostname') { |f| f.readline }.rstrip; rescue; _HOSTNAME; end) : _HOSTNAME}
     message ${record["MESSAGE"]}
-    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-systemd","name":"fluentd openshift","received_at":"${(record['_SOURCE_REALTIME_TIMESTAMP'] || record['__REALTIME_TIMESTAMP']) ? Time.at((record['_SOURCE_REALTIME_TIMESTAMP'] || record['__REALTIME_TIMESTAMP']).to_f / 1000000.0).utc.to_datetime.rfc3339(6) : time.utc.to_datetime.rfc3339(6)}","version":"0.12.29 1.4.0"}}
+    pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-systemd","name":"fluentd openshift","received_at":"${(record['_SOURCE_REALTIME_TIMESTAMP'] || record['__REALTIME_TIMESTAMP']) ? Time.at((record['_SOURCE_REALTIME_TIMESTAMP'] || record['__REALTIME_TIMESTAMP']).to_f / 1000000.0).utc.to_datetime.rfc3339(6) : time.utc.to_datetime.rfc3339(6)}","version":"${ENV['FLUENTD_VERSION'] + ' ' + ENV['DATA_VERSION']}"}}
     # if the field name begins with an uppercase letter, or might not exist, you have to use the record["FIELDNAME"] style
     time ${(record["_SOURCE_REALTIME_TIMESTAMP"] || record["__REALTIME_TIMESTAMP"]) ? Time.at((record["_SOURCE_REALTIME_TIMESTAMP"] || record["__REALTIME_TIMESTAMP"]).to_f / 1000000.0).utc.to_datetime.rfc3339(6) : time.utc.to_datetime.rfc3339(6)}
+    # map PRIORITY number to level string
+    level ${["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug", "trace", "unknown"][begin; ('%d' % record['PRIORITY'] || 9).to_i; rescue; 9; end]}
     # if field is optional you have to use record[name] or (name rescue nil) or something like that
   </record>
   remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID

--- a/fluentd/configs.d/openshift/filter-viaq-data-model.conf
+++ b/fluentd/configs.d/openshift/filter-viaq-data-model.conf
@@ -1,6 +1,6 @@
 <filter **>
   @type viaq_data_model
-  default_keep_fields CEE,docker,file,geoip,hostname,kubernetes,level,message,offset,pid,pipeline_metadata,rsyslog,service,systemd,tags,time
+  default_keep_fields CEE,docker,file,geoip,hostname,kubernetes,level,message,offset,pid,pipeline_metadata,rsyslog,service,systemd,tags,time,ovirt,collectd,tlog,aushape,namespace_name,namespace_uuid
   extra_keep_fields "#{ENV['CDM_EXTRA_KEEP_FIELDS'] || ''}"
   keep_empty_fields "#{ENV['CDM_KEEP_EMPTY_FIELDS'] || 'message'}"
   use_undefined "#{ENV['CDM_USE_UNDEFINED'] || false}"


### PR DESCRIPTION
Make sure the `level` field uses `notice`, `err`, `info`, etc. string
values rather than numbers or any other value.  If the value to be
mapped is unknown, the value of `unknown` will be used as the level
field value.
Add `DATA_VERSION=1.6.0` env. var.
Use FLUENTD_VERSION + DATA_VERSION to construct the version used in
the pipeline_metadata.
Add the `systemd` fields to container records read from journald.
Add new common data model fields and namespaces to viaq plugin.
@jcantrill @lukas-vlcek @nhosoi @portante PTAL
[test]