### PR TITLE
Save Kibana metadata in its own namespace; use message

### DIFF
--- a/fluentd/configs.d/openshift/filter-kibana-transform.conf
+++ b/fluentd/configs.d/openshift/filter-kibana-transform.conf
@@ -2,7 +2,9 @@
   @type record_transformer
   enable_ruby
   <record>
-    log ${(err rescue nil) || (msg rescue nil) || record['MESSAGE'] || log}
+    message ${(err rescue nil) || (msg rescue nil) || record['MESSAGE'] || log}
+    kibana {"req":"${record['req']}","res":"${record['res']}","name":"${record['name']}","level":"${record['level']}","v":"${record['v']}","pid":"${record['pid']}"}
   </record>
-  remove_keys req,res,msg,name,level,v,pid,err
+  # remove the keys that have been moved to their new names above.
+  remove_keys msg,MESSAGE,log,err,req,res,name,level,v,pid
 </filter>


### PR DESCRIPTION
Instead of throwing out the metadata in the log entry metadata record,
we move it to its own Kibana namespace.

We also move to using the `message` field instead of using `log`.