### PR TITLE
1. Introducing following environment variables with the initial value…

### DIFF
--- a/deployer/templates/fluentd.yaml
+++ b/deployer/templates/fluentd.yaml
@@ -343,4 +343,4 @@ parameters:
 -
   description: 'Fluentd buffer size limit'
   name: BUFFER_SIZE_LIMIT
-  value: "16777216"
+  value: "1048576"

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -23,6 +23,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
       ruby-devel \
       libcurl-devel \
       make \
+      bc \
       iproute && \
     yum clean all
 RUN mkdir -p ${HOME} && \

--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -5,8 +5,9 @@
   shared_key "#{File.open('/etc/fluent/muxkeys/shared_key') do |f| f.readline end.rstrip}"
   secure yes
   ca_cert_path /etc/fluent/muxkeys/ca
-  buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-  buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
+  flush_interval 5s
+  buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+  buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
   <server>
     host logging-mux
     port "#{ENV['FORWARD_LISTEN_PORT'] || '24284'}"

--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -20,6 +20,6 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -20,6 +20,6 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -20,6 +20,6 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -20,6 +20,6 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT']}"
-      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT']}"
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -58,8 +58,11 @@ IPADDR4=`/usr/sbin/ip -4 addr show dev eth0 | grep inet | sed -e "s/[ \t]*inet \
 IPADDR6=`/usr/sbin/ip -6 addr show dev eth0 | grep inet6 | sed "s/[ \t]*inet6 \([a-f0-9:]*\).*/\1/"`
 export IPADDR4 IPADDR6
 
-export BUFFER_QUEUE_LIMIT=${BUFFER_QUEUE_LIMIT:-1024}
-export BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-16777216}
+BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-1048576}
+MUX_CPU_LIMIT=${MUX_CPU_LIMIT:-500m}
+MUX_MEMORY_LIMIT=${MUX_MEMORY_LIMIT:-2Gi}
+FLUENTD_CPU_LIMIT=${FLUENTD_CPU_LIMIT:-100m}
+FLUENTD_MEMORY_LIMIT=${FLUENTD_MEMORY_LIMIT:-512Mi}
 
 CFG_DIR=/etc/fluent/configs.d
 if [ "${USE_MUX:-}" = "true" ] ; then
@@ -100,6 +103,33 @@ if [ "${USE_MUX_CLIENT:-}" = "true" ] ; then
 else
     rm -f $CFG_DIR/openshift/filter-pre-mux-client.conf
 fi
+
+if [ "${USE_MUX:-}" = "true" ] ; then
+    TOTAL_MEMORY_LIMIT=`echo $MUX_MEMORY_LIMIT |  sed -e "s/[Kk]/*1024/g;s/[Mm]/*1024*1024/g;s/[Gg]/*1024*1024*1024/g;s/i//g" | bc`
+else
+    TOTAL_MEMORY_LIMIT=`echo $FLUENTD_MEMORY_LIMIT |  sed -e "s/[Kk]/*1024/g;s/[Mm]/*1024*1024/g;s/[Gg]/*1024*1024*1024/g;s/i//g" | bc`
+fi
+BUFFER_SIZE_LIMIT=`echo $BUFFER_SIZE_LIMIT |  sed -e "s/[Kk]/*1024/g;s/[Mm]/*1024*1024/g;s/[Gg]/*1024*1024*1024/g;s/i//g" | bc`
+if [ $BUFFER_SIZE_LIMIT -eq 0 ]; then
+    BUFFER_SIZE_LIMIT=1048576
+fi
+
+DIV=1
+if [ "$ES_HOST" != "$OPS_HOST" ] || [ "$ES_PORT" != "$OPS_PORT" ] ; then
+    # using ops cluster
+    DIV=`expr $DIV \* 2`
+fi
+if [ "${USE_MUX_CLIENT:-}" = "true" ] ; then
+    DIV=`expr $DIV \* 2`
+fi
+
+# MEMORY_LIMIT per buffer
+MEMORY_LIMIT=`expr $TOTAL_MEMORY_LIMIT / $DIV`
+BUFFER_QUEUE_LIMIT=`expr $MEMORY_LIMIT / $BUFFER_SIZE_LIMIT`
+if [ $BUFFER_QUEUE_LIMIT -eq 0 ]; then
+    BUFFER_QUEUE_LIMIT=1024
+fi
+export BUFFER_QUEUE_LIMIT BUFFER_SIZE_LIMIT
 
 OPS_COPY_HOST="${OPS_COPY_HOST:-$ES_COPY_HOST}"
 OPS_COPY_PORT="${OPS_COPY_PORT:-$ES_COPY_PORT}"

--- a/hack/testing/init-log-stack
+++ b/hack/testing/init-log-stack
@@ -11,6 +11,18 @@ ES_HOSTNAME=${ES_HOST:+openshift_logging_es_hostname=$ES_HOST}
 ES_OPS_ALLOW_EXTERNAL=${ES_OPS_HOST:+openshift_logging_es_ops_allow_external=True}
 ES_OPS_HOSTNAME=${ES_OPS_HOST:+openshift_logging_es_ops_hostname=$ES_OPS_HOST}
 
+if [ "$MUX_ALLOW_EXTERNAL" = true ] ; then
+    SET_MUX_CPU_LIMIT="openshift_logging_mux_cpu_limit=${MUX_CPU_LIMIT:-500m}"
+    SET_MUX_MEMORY_LIMIT="openshift_logging_mux_memory_limit=${MUX_MEMORY_LIMIT:-2Gi}"
+    SET_MUX_BUFFER_QUEUE_LIMIT="openshift_logging_mux_buffer_queue_limit=${MUX_BUFFER_QUEUE_LIMIT:-1024}"
+    SET_MUX_BUFFER_SIZE_LIMIT="openshift_logging_mux_buffer_size_limit=${MUX_BUFFER_SIZE_LIMIT:-1048576}"
+else
+    SET_MUX_CPU_LIMIT=""
+    SET_MUX_MEMORY_LIMIT=""
+    SET_MUX_BUFFER_QUEUE_LIMIT=""
+    SET_MUX_BUFFER_SIZE_LIMIT=""
+fi
+
 source $OS_O_A_L_DIR/hack/testing/build-images
 
 # init inventory file
@@ -47,6 +59,10 @@ $ES_ALLOW_EXTERNAL
 $ES_HOSTNAME
 $ES_OPS_ALLOW_EXTERNAL
 $ES_OPS_HOSTNAME
+$SET_MUX_CPU_LIMIT
+$SET_MUX_MEMORY_LIMIT
+$SET_MUX_BUFFER_QUEUE_LIMIT
+$SET_MUX_BUFFER_SIZE_LIMIT
 
 EOL
 


### PR DESCRIPTION
… for fluentd.

  MUX_CPU_LIMIT: 500m
  MUX_MEMORY_LIMIT: 2Gi
  FLUENTD_CPU_LIMIT: 100m
  FLUENTD_MEMORY_LIMIT: 512Mi
They are configurable by openshift-ansible, as well.
  openshift_logging_fluentd_cpu_limit: 500m
  openshift_logging_fluentd_memory_limit: 2Gi
  openshift_logging_mux_cpu_limit: 500m
  openshift_logging_mux_memory_limit: 2Gi

2. Introducing an environment variable BUFFER_SIZE_LIMIT for the fluentd buffer_chunk_limit.
   Using the given BUFFER_SIZE_LIMIT, the available RAM size and number of output,
   BUFFER_QUEUE_LIMIT is calculated.
   The BUFFER_SIZE_LIMIT value and the BUFFER_QUEUE_LIMIT value are set to buffer_chunk_limit
   and buffer_queue_limit, respectively.

Note: replacement for pr #461