### PR TITLE
Allow deployer to use an intermediate CA

### DIFF
--- a/deployer/scripts/util.sh
+++ b/deployer/scripts/util.sh
@@ -77,6 +77,7 @@ function generate_JKS_chain() {
         -file $dir/ca.crt  \
         -keystore $dir/truststore.jks   \
         -storepass $ts_pass  \
+	-trustcacerts \
         -noprompt -alias sig-ca
 
     echo All done for $NODE_NAME


### PR DESCRIPTION
Deployer is not able to generate all the internal certificates when an Intermediate CA is provided. Keytool will fail with the following error
```
+ echo 'Import back to keystore (including CA chain)'
+ /bin/keytool -import -file /etc/deploy/scratch/ca.crt -keystore /etc/deploy/scratch/system.admin.jks -storepass kspass -noprompt -alias sig-ca
Import back to keystore (including CA chain)
Certificate was added to keystore
+ /bin/keytool -import -file /etc/deploy/scratch/system.admin.crt -keystore /etc/deploy/scratch/system.admin.jks -storepass kspass -noprompt -alias system.admin
keytool error: java.lang.Exception: Failed to establish chain from reply
```