### PR TITLE
Ensure jUnit XML is generated on failure

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -105,6 +105,8 @@ function os::util::environment::update_path_var() {
     local prefix
     if os::util::find::system_binary 'go' >/dev/null 2>&1; then
         prefix+="${OS_OUTPUT_BINPATH}/$(os::util::host_platform):"
+        # add in the Origin output as well
+        prefix+="${OS_ROOT}/../origin/${OS_OUTPUT_SUBPATH}/bin/$(os::util::host_platform):"
     fi
     if [[ -n "${GOPATH:-}" ]]; then
         prefix+="${GOPATH}/bin:"

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -16,6 +16,7 @@
 #    run. Test suite entrypoints exist under hack/testing/
 #    with the test- prefix. The regex in $SUITE is a simple
 #    filter.
+#  - JUNIT_REPORT: generate a jUnit XML report for tests
 
 source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
 source "${OS_O_A_L_DIR}/deployer/scripts/util.sh"
@@ -31,6 +32,10 @@ if [[ -z "${TEST_ONLY:-}" ]]; then
 	"${OS_O_A_L_DIR}/hack/testing/setup.sh"
 elif [[ -z "${KUBECONFIG:-}" ]]; then
 	os::log::fatal "A \$KUBECONFIG must be specified with \$TEST_ONLY."
+fi
+
+if [[ -n "${JUNIT_REPORT:-}" ]]; then
+	export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
 fi
 
 expected_failures=(

--- a/test/cluster/rollout.sh
+++ b/test/cluster/rollout.sh
@@ -14,6 +14,7 @@
 #                  }: $IFS-delimited lists of
 #    OpenShift ojects that are expected to exist
 source "$(dirname "${BASH_SOURCE[0]}" )/../../hack/lib/init.sh"
+trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "test/cluster/rollout"
 


### PR DESCRIPTION
If `os::test::junit::reconcile_output` is not trapped on `EXIT`, we will
not generate valid jUnit XML on a test failure as the output file will
be in a corrupt state.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]

/cc @richm @jcantrill this is why we were not getting jUnit output and why it was hard to tell what failed in logging tests sometimes -- with this it will be much quicker to tell.