### PR TITLE
Use Origin image building utility in hack/build-images.sh

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -1,44 +1,21 @@
 #!/bin/bash
 
-set -o errexit
-set -o nounset
-set -o pipefail
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-STARTTIME=$(date +%s)
+function cleanup() {
+    return_code=$?
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
-prefix="${PREFIX:-docker.io/openshift/origin-}"
-version="${OS_TAG:-latest}"
+os::util::ensure::gopath_binary_exists imagebuilder
 
-source_root=$(dirname "${0}")/..
-
-#################################
-declare -A source_for=(
-  [logging-fluentd]=fluentd
-  [logging-elasticsearch]=elasticsearch
-  [logging-kibana]=kibana
-  [logging-curator]=curator
-  [logging-auth-proxy]=kibana-proxy
-  [logging-deployer]=deployer
-  [logging-deployment]=deployer
-)
-for component in ${!source_for[@]} ; do
-  BUILD_STARTTIME=$(date +%s)
-  comp_path=$source_root/${source_for[$component]}
-  docker_tag=${prefix}${component}:${version}
-  echo
-  echo
-  echo "--- Building component '$comp_path' with docker tag '$docker_tag' ---"
-  docker build -t $docker_tag       $comp_path
-  BUILD_ENDTIME=$(date +%s); echo "--- $docker_tag took $(($BUILD_ENDTIME - $BUILD_STARTTIME)) seconds ---"
-  echo
-  echo
-done
-
-echo
-echo
-echo "++ Active images"
-docker images | grep ${prefix}logging | grep ${version} | sort
-echo
-
-
-ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"
+tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
+os::build::image "${tag_prefix}-logging-fluentd"       fluentd
+os::build::image "${tag_prefix}-logging-elasticsearch" elasticsearch
+os::build::image "${tag_prefix}-logging-kibana"        kibana
+os::build::image "${tag_prefix}-logging-curator"       curator
+os::build::image "${tag_prefix}-logging-auth"          kibana-proxy
+os::build::image "${tag_prefix}-logging-deployer"      deployer
+os::build::image "${tag_prefix}-logging-deployment"    deployer


### PR DESCRIPTION
By using the Origin image building utility `os::build::image` we are
able to piggy-back on top of a lot of logic, including the ability to
add a custom tag wtih `$OS_TAG` as before, as well as by default
building with both the `:latest` and `:<git-sha>` tags, to allow CI to
use _specifically_ the images built from `HEAD`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]

/cc @richm I told you the refactor would be nice :)