### PR TITLE
Allow deployer to use an intermediate CA

### DIFF
--- a/deployer/scripts/util.sh
+++ b/deployer/scripts/util.sh
@@ -68,6 +68,7 @@ function generate_JKS_chain() {
         -keystore $dir/keystore.jks \
         -storepass $ks_pass \
         -noprompt \
+        -trustcacerts \
         -alias $NODE_NAME
 
     echo "Import CA to truststore for validating client certs"
@@ -155,6 +156,7 @@ function generate_JKS_client_cert() {
         -keystore $dir/$NODE_NAME.jks \
         -storepass $ks_pass \
         -noprompt \
+        -trustcacerts \
         -alias $NODE_NAME
 
     echo All done for $NODE_NAME


### PR DESCRIPTION
Deployer is not able to generate all the internal certificates when an Intermediate CA is provided. Keytool will fail with the following error

```
echo 'Import back to keystore (including CA chain)'
/bin/keytool -import -file /etc/deploy/scratch/ca.crt -keystore /etc/deploy/scratch/system.admin.jks -storepass kspass -noprompt -alias sig-ca
Import back to keystore (including CA chain)
Certificate was added to keystore
/bin/keytool -import -file /etc/deploy/scratch/system.admin.crt -keystore /etc/deploy/scratch/system.admin.jks -storepass kspass -noprompt -alias system.admin
keytool error: java.lang.Exception: Failed to establish chain from reply
```