### PR TITLE
fix get_test_user_token; use openshift_logging_kibana_hostname

### DIFF
--- a/deployer/scripts/util.sh
+++ b/deployer/scripts/util.sh
@@ -375,7 +375,7 @@ function get_latest_pod() {
 # set the test_token, test_name, and test_ip for token auth
 function get_test_user_token() {
     local current_project; current_project="$( oc project -q )"
-    oc login --username=${LOG_ADMIN_USER:-${1:-admin}} --password=${LOG_ADMIN_PW:-${2:-admin}} > /dev/null
+    oc login --username=${1:-${LOG_ADMIN_USER:-admin}} --password=${2:-${LOG_ADMIN_PW:-admin}} > /dev/null
     test_token="$(oc whoami -t)"
     test_name="$(oc whoami)"
     test_ip="127.0.0.1"

--- a/hack/testing/init-log-stack
+++ b/hack/testing/init-log-stack
@@ -43,7 +43,8 @@ deployment_type=origin
 required_packages=[]
 $OS_VERSION_STRING
 
-openshift_hosted_logging_hostname=${KIBANA_HOST:-kibana.127.0.0.1.xip.io}
+openshift_logging_kibana_hostname=${KIBANA_HOST:-kibana.127.0.0.1.xip.io}
+openshift_logging_kibana_ops_hostname=${KIBANA_OPS_HOST:-kibana-ops.127.0.0.1.xip.io}
 openshift_master_logging_public_url=https://${KIBANA_HOST:-kibana.127.0.0.1.xip.io}
 openshift_logging_master_public_url=https://${PUBLIC_MASTER_HOST:-localhost}:8443
 


### PR DESCRIPTION
get_test_user_token always returns the admin credentials, so it always
works.  This makes it use the command line arguments. This also adds tests
to make sure a normal user cannot see a project it is not a member of, and
cannot see .operations index.
This also uses `openshift_logging_kibana_hostname` instead of
`openshift_hosted_logging_hostname` which is not supported by
playbooks/byo/openshift-cluster/openshift-logging.yml
@jcantrill @nhosoi PTAL
[test]