### PR TITLE
add tests and script for multi-tenancy with multi-index /msearch

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -7,7 +7,6 @@ EXPOSE 9300
 USER 0
 
 ENV HOME=/opt/app-root/src \
-  JAVA_VER=1.8.0 \
   ES_VER=2.4.4 \
   ES_CLOUD_K8S_VER=2.4.4 \
   OSE_ES_VER=2.4.4.9 \
@@ -19,6 +18,11 @@ ENV HOME=/opt/app-root/src \
   RECOVER_AFTER_TIME=5m \
   PLUGIN_LOGLEVEL=INFO \
   ES_JAVA_OPTS="-Dmapper.allow_dots_in_name=true"
+
+ARG ES_CLOUD_K8S_VER=2.4.4
+ARG OSE_ES_VER=2.4.4.5
+ARG ES_CLOUD_K8S_URL
+ARG OSE_ES_URL
 
 LABEL io.k8s.description="Elasticsearch container to serve as EFK aggregated logging backend" \
   io.k8s.display-name="Elasticsearch ${ES_VER}" \

--- a/elasticsearch/install.sh
+++ b/elasticsearch/install.sh
@@ -5,8 +5,14 @@ set -ex
 mkdir -p ${HOME}
 ln -s /usr/share/elasticsearch /usr/share/java/elasticsearch
 
-/usr/share/elasticsearch/bin/plugin install io.fabric8/elasticsearch-cloud-kubernetes/${ES_CLOUD_K8S_VER}
-/usr/share/elasticsearch/bin/plugin install io.fabric8.elasticsearch/openshift-elasticsearch-plugin/${OSE_ES_VER}
+if [ -z "${ES_CLOUD_K8S_URL:-}" ] ; then
+    ES_CLOUD_K8S_URL=io.fabric8/elasticsearch-cloud-kubernetes/${ES_CLOUD_K8S_VER}
+fi
+/usr/share/elasticsearch/bin/plugin install ${ES_CLOUD_K8S_URL}
+if [ -z "${OSE_ES_URL:-}" ] ; then
+    OSE_ES_URL=io.fabric8.elasticsearch/openshift-elasticsearch-plugin/${OSE_ES_VER}
+fi
+/usr/share/elasticsearch/bin/plugin install ${OSE_ES_URL}
 
 
 mkdir /elasticsearch

--- a/hack/enable-kibana-msearch-access.sh
+++ b/hack/enable-kibana-msearch-access.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# this grants the given user access to _msearch on the given projects
+# the /sg/roles/0 should look like this:
+#         "hack_for_user_access_loguser": {
+#             "cluster": [],
+#             "indices": {
+#                 "multi-tenancy-1?843a78a0-5ad5-11e7-b47f-0e35fd64a858?*": {
+#                     "*": [
+#                         "indices:admin/validate/query*",
+#                         "indices:admin/get*",
+#                         "indices:admin/mappings/fields/get*",
+#                         "indices:data/read*"
+#                     ]
+#                 },
+#                 "multi-tenancy-2?84f15332-5ad5-11e7-b47f-0e35fd64a858?*": {
+#                     "*": [
+#                         "indices:admin/validate/query*",
+#                         "indices:admin/get*",
+#                         "indices:admin/mappings/fields/get*",
+#                         "indices:data/read*"
+#                     ]
+#                 },
+#                 "project?multi-tenancy-1?843a78a0-5ad5-11e7-b47f-0e35fd64a858?*": {
+#                     "*": [
+#                         "indices:admin/validate/query*",
+#                         "indices:admin/get*",
+#                         "indices:admin/mappings/fields/get*",
+#                         "indices:data/read*"
+#                     ]
+#                 },
+#                 "project?multi-tenancy-2?84f15332-5ad5-11e7-b47f-0e35fd64a858?*": {
+#                     "*": [
+#                         "indices:admin/validate/query*",
+#                         "indices:admin/get*",
+#                         "indices:admin/mappings/fields/get*",
+#                         "indices:data/read*"
+#                     ]
+#                 }
+#             }
+#         }
+
+set -euo pipefail
+
+if [ -n "${DEBUG:-}" ] ; then
+    set -x
+    curl_output() {
+        python -mjson.tool
+    }
+else
+    curl_output() {
+        cat > /dev/null 2>&1
+    }
+fi
+
+LOGGING_PROJECT=${LOGGING_PROJECT:-logging}
+
+# $1 - es pod name
+# $2 - es endpoint
+# rest - any args to pass to curl
+function curl_es() {
+    local pod="$1"
+    local endpoint="$2"
+    shift; shift
+    local args=( "${@:-}" )
+
+    local secret_dir="/etc/elasticsearch/secret/"
+    oc exec -n $LOGGING_PROJECT "${pod}" -- \
+       curl --silent --insecure "${args[@]}" \
+       --key "${secret_dir}admin-key"   \
+       --cert "${secret_dir}admin-cert" \
+       "https://localhost:9200${endpoint}"
+}
+
+# $1 - es pod name
+# $2 - es endpoint
+# rest - any args to pass to curl
+function curl_es_input() {
+    local pod="$1"
+    local endpoint="$2"
+    shift; shift
+    local args=( "${@:-}" )
+
+    local secret_dir="/etc/elasticsearch/secret/"
+    oc exec -i "${pod}" -n $LOGGING_PROJECT -- \
+       curl --silent --insecure "${args[@]}" \
+       --key "${secret_dir}admin-key"   \
+       --cert "${secret_dir}admin-cert" \
+       "https://localhost:9200${endpoint}"
+}
+
+usage() {
+    echo Usage: $0 user-name [project-1 ... project-N]
+    echo If no projects are specified, the msearch access will be removed.
+    echo This script assumes the logging components are in the namespace
+    echo   $LOGGING_PROJECT.  Set the environment variable
+    echo   LOGGING_PROJECT=project-name if the Elasticsearch pods are running
+    echo   in a different namespace.
+}
+
+if [ -z "${1:-}" ] ; then
+    usage
+    exit 1
+fi
+
+if oc get users "$1" > /dev/null 2>&1 ; then
+    echo Using user "$1" . . .
+else
+    echo Error: user "$1" not found
+    usage
+    exit 1
+fi
+
+user="$1" ; shift
+
+for proj in "$@" ; do
+    if oc get project "$proj"  > /dev/null 2>&1 ; then
+        echo Using project "$proj" . . .
+    else
+        echo Error: project "$proj" not found
+        usage
+        exit 1
+    fi
+done
+
+if [ "$#" -gt 0 ] ; then
+    uuids=$( oc get project "$@" -o jsonpath='{.items[*].metadata.uid}' )
+    if [ -z "$uuids" ] ; then
+        echo Error: could not get the project uuids for the given projects "$@"
+        exit 1
+    fi
+fi
+
+espod=$( oc get -n $LOGGING_PROJECT pods --selector component=es -o jsonpath='{ .items[0].metadata.name }' )
+
+if [ -z "$espod" ] ; then
+    echo Error: no Elasticsearch pods found in project \'$LOGGING_PROJECT\'
+    exit 1
+fi
+
+role_name="multi_index_access_for_user_$user"
+
+config_index_name=$( oc exec -n $LOGGING_PROJECT $espod -- python -c "import yaml; print yaml.load(open('/usr/share/elasticsearch/config/elasticsearch.yml'))['searchguard']['config_index_name']" )
+if [ -z "$config_index_name" ] ; then
+    echo Error: could not extract the searchguard index name from $espod /usr/share/elasticsearch/config/elasticsearch.yml
+    exit 1
+fi
+
+sg_index=$( oc exec -n $LOGGING_PROJECT $espod -- bash -c "eval 'echo $config_index_name'" )
+if [ -z "$sg_index" ] ; then
+    echo Error: could not convert "$config_index_name" in $espod to the searchguard index name
+    exit 1
+fi
+
+echo Input looks good - fixing ACLs . . .
+
+curl_es $espod /$sg_index/roles/0 | PROJECTS="$@" UUIDS="${uuids:-}" python -c '
+import json
+import sys
+import os
+role_name = "'"$role_name"'"
+projects = os.environ["PROJECTS"].split()
+uuids = os.environ["UUIDS"].split()
+perm = ["indices:admin/validate/query*", "indices:admin/get*", "indices:admin/mappings/fields/get*", "indices:data/read*"]
+hsh = json.load(sys.stdin)["_source"]
+if not projects:
+    if role_name in hsh:
+        del hsh[role_name]
+else:
+    hsh[role_name] = {"cluster":[],"indices":{}}
+    for proj,uuid in zip(projects,uuids):
+        pat1 = "{}?{}?*".format(proj, uuid)
+        pat2 = "project?{}?{}?*".format(proj, uuid)
+        hsh[role_name]["indices"][pat1] = {"*": perm}
+        hsh[role_name]["indices"][pat2] = {"*": perm}
+json.dump(hsh, sys.stdout)
+' | curl_es_input $espod /$sg_index/roles/0 -XPUT -d@- | \
+        curl_output
+
+curl_es $espod /$sg_index/rolesmapping/0 | PROJECTS="$@" python -c '
+import json
+import sys
+import os
+role_name = "'"$role_name"'"
+user_name = "'"$user"'"
+projects = os.environ["PROJECTS"].split()
+hsh = json.load(sys.stdin)["_source"]
+if not projects:
+    if role_name in hsh:
+        del hsh[role_name]
+else:
+    hsh[role_name] = {"users":[user_name]}
+json.dump(hsh, sys.stdout)
+' | curl_es_input $espod /$sg_index/rolesmapping/0 -XPUT -d@- | \
+        curl_output
+
+echo . . . Done

--- a/hack/testing/test-multi-tenancy.sh
+++ b/hack/testing/test-multi-tenancy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/multi_tenancy.sh

--- a/test/multi_tenancy.sh
+++ b/test/multi_tenancy.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+# Test various aspects of multi tenancy
+# Test that regular users can view indices of
+# projects they are members of
+# Test that regular users cannot view indices
+# of projects they are not members of
+# Test multi-project searches e.g.
+# {"index":["project.a.*","project.b.*"]}
+# {"query" : {"match_all" : {}}}
+# cat msearch.json | curl https://localhost:9200/_msearch -XPOST --data-binary @-
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/deployer/scripts/util.sh"
+trap os::test::junit::reconcile_output EXIT
+os::util::environment::use_sudo
+
+os::test::junit::declare_suite_start "test/multi_tenancy"
+
+espod=$( oc get pods --selector component=es -o jsonpath='{ .items[*].metadata.name }' )
+esopspod=$( oc get pods --selector component=es-ops -o jsonpath='{ .items[*].metadata.name }' )
+esopspod=${esopspod:-$espod}
+
+# HACK HACK HACK
+# remove this once we have real multi-tenancy, multi-index support
+function hack_msearch_access() {
+    LOGGING_PROJECT=logging ${OS_O_A_L_DIR}/hack/enable-kibana-msearch-access.sh "$@"
+}
+
+delete_users=""
+cleanup_msearch_access=""
+
+function cleanup() {
+    set +e
+    for user in $cleanup_msearch_access ; do
+        hack_msearch_access $user
+    done
+    for user in $delete_users ; do
+        oc delete user $user
+    done
+    if [ -n "${espod:-}" ] ; then
+        curl_es $espod /project.multi-tenancy-* -XDELETE > /dev/null
+    fi
+    for proj in multi-tenancy-1 multi-tenancy-2 multi-tenancy-3 ; do
+        oc delete project $proj
+    done
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+}
+
+trap cleanup EXIT
+
+function create_user_and_assign_to_projects() {
+    local current_project; current_project="$( oc project -q )"
+    local user=$1; shift
+    local pw=$1; shift
+    if oc get users $user > /dev/null 2>&1 ; then
+        os::log::info Using existing user $user
+    else
+        os::log::info Creating user $user with password $pw
+        os::log::debug "$( oc login --username=$user --password=$pw 2>&1 )"
+        delete_users="$delete_users $user"
+    fi
+    os::log::debug "$( oc login --username=system:admin 2>&1 )"
+    os::log::info Assigning user to projects "$@"
+    while [ -n "${1:-}" ] ; do
+        os::log::debug "$( oc project $1 2>&1 )"
+        os::log::debug "$( oadm policy add-role-to-user view $user 2>&1 )"
+        shift
+    done
+    oc project "${current_project}" > /dev/null
+}
+
+function add_message_to_index() {
+    # project is $1
+    # message is $2
+    # espod is $3
+    local project_uuid=$( oc get project $1 -o jsonpath='{ .metadata.uid }' )
+    local index="project.$1.$project_uuid.$(date -u +'%Y.%m.%d')"
+    os::log::debug $( curl_es "$3" "/$index/multi-tenancy-test/" -XPOST -d '{"message":"'${2:-"multi-tenancy message"}'"}' | python -mjson.tool 2>&1 )
+}
+
+function test_user_has_proper_access() {
+    local user=$1; shift
+    local pw=$1; shift
+    local indices="["
+    local comma=""
+    # rest - indices to which access should be granted
+    for proj in "$@" ; do
+        os::log::info See if user $user can read /project.$proj.*
+        get_test_user_token $user $pw
+        nrecs=$( curl_es_with_token $espod "/project.$proj.*/_count" $test_name $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = 1" ; then
+            os::log::error $user cannot access project.$proj.* indices
+            curl_es_with_token $espod "/project.$proj.*/_count" $test_name $test_token | python -mjson.tool
+            exit 1
+        fi
+        indices="${indices}${comma}"'"'"project.$proj.*"'"'
+        comma=,
+    done
+    indices="${indices}]"
+
+    # test user has access for msearch for multiple indices
+    os::log::info See if user $user can _msearch "$indices"
+    get_test_user_token $user $pw
+    nrecs=$( { echo '{"index":'"${indices}"'}'; echo '{"size":0,"query":{"match_all":{}}}'; } | \
+                     curl_es_with_token_and_input $espod "/_msearch" $test_name $test_token -XPOST --data-binary @- | \
+                     get_count_from_json_from_search )
+    if ! os::cmd::expect_success "test $nrecs = 2" ; then
+        os::log::error $user cannot access "$indices" indices with _msearch
+        {
+            echo '{"index":'"${indices}"'}'
+            echo '{"query" : {"match_all" : {}}}'
+        } | curl_es_with_token_and_input $espod "/_msearch" $test_name $test_token -XPOST --data-binary @- | \
+            python -mjson.tool
+        exit 1
+    fi
+
+    # verify normal user has no access to default indices
+    os::log::info See if user $user is denied /project.default.*
+    get_test_user_token $user $pw
+    nrecs=$( curl_es_with_token $espod "/project.default.*/_count" $test_name $test_token | \
+                 get_count_from_json )
+    if ! os::cmd::expect_success "test $nrecs = 0" ; then
+        os::log::error $LOG_NORMAL_USER has improper access to project.default.* indices
+        curl_es_with_token $espod "/project.default.*/_count" $test_name $test_token | python -mjson.tool
+        exit 1
+    fi
+
+    # verify normal user has no access to .operations
+    os::log::info See if user $user is denied /.operations.*
+    get_test_user_token $user $pw
+    nrecs=$( curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | \
+                 get_count_from_json )
+    if ! os::cmd::expect_success "test $nrecs = 0" ; then
+        os::log::error $LOG_NORMAL_USER has improper access to .operations.* indices
+        curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | python -mjson.tool
+        exit 1
+    fi
+}
+
+curl_es $espod /project.multi-tenancy-* -XDELETE > /dev/null
+
+for proj in multi-tenancy-1 multi-tenancy-2 multi-tenancy-3 ; do
+    os::log::info Creating project $proj
+    os::log::debug "$( oadm new-project $proj --node-selector='' 2>&1 )"
+    os::log::info Creating test index and entry for $proj
+    add_message_to_index $proj "" $espod
+done
+
+LOG_NORMAL_USER=${LOG_NORMAL_USER:-loguser}
+LOG_NORMAL_PW=${LOG_NORMAL_PW:-loguser}
+
+LOG_USER2=${LOG_USER2:-loguser2}
+LOG_PW2=${LOG_PW2:-loguser2}
+
+create_user_and_assign_to_projects $LOG_NORMAL_USER $LOG_NORMAL_PW multi-tenancy-1 multi-tenancy-2
+create_user_and_assign_to_projects $LOG_USER2 $LOG_PW2 multi-tenancy-2 multi-tenancy-3
+
+hack_msearch_access $LOG_NORMAL_USER multi-tenancy-1 multi-tenancy-2
+cleanup_msearch_access="$cleanup_msearch_access $LOG_NORMAL_USER"
+hack_msearch_access $LOG_USER2 multi-tenancy-2 multi-tenancy-3
+cleanup_msearch_access="$cleanup_msearch_access $LOG_USER2"
+
+oc login --username=system:admin > /dev/null
+oc project logging > /dev/null
+
+test_user_has_proper_access $LOG_NORMAL_USER $LOG_NORMAL_PW multi-tenancy-1 multi-tenancy-2
+test_user_has_proper_access $LOG_USER2 $LOG_PW2 multi-tenancy-2 multi-tenancy-3
+


### PR DESCRIPTION
Add a script `hack/enable-kibana-msearch-access.sh` which can be
used to add permission for users to perform /_msearch queries of
Elasticsearch, in the manner of Kibana.
Added tests for multi-tenancy including testing for this script
to make sure it works.
This commit also changes Elasticsearch so that it has the ability
to pass in different plugins at build time for testing.
@jcantrill @portante PTAL
[test]