### PR TITLE
Don't require imagebuilder for hack/build-images.sh

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -15,5 +15,3 @@ os::build::image "${tag_prefix}-logging-elasticsearch" elasticsearch
 os::build::image "${tag_prefix}-logging-kibana"        kibana
 os::build::image "${tag_prefix}-logging-curator"       curator
 os::build::image "${tag_prefix}-logging-auth"          kibana-proxy
-os::build::image "${tag_prefix}-logging-deployer"      deployer
-os::build::image "${tag_prefix}-logging-deployment"    deployer

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -9,8 +9,6 @@ function cleanup() {
 }
 trap "cleanup" EXIT
 
-os::util::ensure::gopath_binary_exists imagebuilder
-
 tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
 os::build::image "${tag_prefix}-logging-fluentd"       fluentd
 os::build::image "${tag_prefix}-logging-elasticsearch" elasticsearch


### PR DESCRIPTION
None of the Logging images require the functionality that is provided by
`imagebuilder`, so we do not need to require it. The Origin image build
utilities should be able to fall back to `docker build` as normal.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]

/cc @richm sorry, this was a mistake on my end in the script on the first pass