### PR TITLE
bug 1465464. Kibana memory use underscore instead of dash

### DIFF
--- a/kibana/run.sh
+++ b/kibana/run.sh
@@ -29,7 +29,7 @@ if [[ "${KIBANA_MEMORY_LIMIT:-}" =~ $regex ]]; then
         ((num = $DEFAULT_MIN))
     fi
 
-    export NODE_OPTIONS="--max-old-space-size=$((num / ${BYTES_PER_MEG}))"
+    export NODE_OPTIONS="--max_old_space_size=$((num / ${BYTES_PER_MEG}))"
 
 else
     echo "Unable to process the KIBANA_MEMORY_LIMIT: '${KIBANA_MEMORY_LIMIT}'.  It must be in the format of: /${regex}/"


### PR DESCRIPTION
Modifies the memory switch to use underscores instead of dashes per:

[1] https://github.com/nodejs/node/issues/7937
[2] https://github.com/elastic/kibana/issues/9006