### PR TITLE
Fluentd,Mux: make buffer_type configurable; By default, buffer_type file

### DIFF
--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -20,7 +20,8 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_type "#{ENV['BUFFER_TYPE']}"
+      buffer_type "#{ENV['BUFFER_TYPE'] || 'memory'}"
+      buffer_path "#{ENV['FILE_BUFFER_PATH_ES_COPY'] || '/dev/null'}"
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -20,6 +20,7 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
+      buffer_type "#{ENV['BUFFER_TYPE']}"
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -20,6 +20,7 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
+      buffer_type "#{ENV['BUFFER_TYPE']}"
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -20,7 +20,8 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_type "#{ENV['BUFFER_TYPE']}"
+      buffer_type "#{ENV['BUFFER_TYPE'] || 'memory'}"
+      buffer_path "#{ENV['FILE_BUFFER_PATH_ESOPS_COPY'] || '/dev/null'}"
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -20,6 +20,7 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
+      buffer_type "#{ENV['BUFFER_TYPE']}"
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -20,7 +20,8 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_type "#{ENV['BUFFER_TYPE']}"
+      buffer_type "#{ENV['BUFFER_TYPE'] || 'memory'}"
+      buffer_path "#{ENV['FILE_BUFFER_PATH_ES']|| '/dev/null'}"
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -20,6 +20,7 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
+      buffer_type "#{ENV['BUFFER_TYPE']}"
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -20,7 +20,8 @@
       flush_interval 5s
       max_retry_wait 300
       disable_retry_limit true
-      buffer_type "#{ENV['BUFFER_TYPE']}"
+      buffer_type "#{ENV['BUFFER_TYPE'] || 'memory'}"
+      buffer_path "#{ENV['FILE_BUFFER_PATH_ESOPS'] || '/dev/null'}"
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -119,6 +119,7 @@ fi
 
 if [ "$BUFFER_TYPE" = "file" -a -z "$FILE_BUFFER_PATH" ]; then
     echo "ERROR: BUFFER_TYPE is set to file but FILE_BUFFER_PATH is empty.  Please specify a FILE_BUFFER_PATH.  Exiting."
+    exit 1
 fi
 
 FILE_BUFFER_PATH_ES=""

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -118,8 +118,7 @@ else
 fi
 
 if [ "$BUFFER_TYPE" = "file" -a -z "$FILE_BUFFER_PATH" ]; then
-    BUFFER_TYPE=memory
-    echo "ERROR: File is set to buffer_type but FILE_BUFFER_PATH is empty.  Using memory buffer"
+    echo "ERROR: BUFFER_TYPE is set to file but FILE_BUFFER_PATH is empty.  Please specify a FILE_BUFFER_PATH.  Exiting."
 fi
 
 FILE_BUFFER_PATH_ES=""
@@ -127,7 +126,7 @@ FILE_BUFFER_PATH_ESOPS=""
 FILE_BUFFER_PATH_ES_COPY=""
 FILE_BUFFER_PATH_ESOPS_COPY=""
 # Default buffer_type: file if FILE_BUFFER_PATH is specified.
-if [ "$BUFFER_TYPE" = "file" ]; then
+if [ "${BUFFER_TYPE:-}" = "file" ]; then
     if [ ! -d $FILE_BUFFER_PATH ]; then
         mkdir -p $FILE_BUFFER_PATH
     fi

--- a/hack/testing/init-log-stack
+++ b/hack/testing/init-log-stack
@@ -11,16 +11,51 @@ ES_HOSTNAME=${ES_HOST:+openshift_logging_es_hostname=$ES_HOST}
 ES_OPS_ALLOW_EXTERNAL=${ES_OPS_HOST:+openshift_logging_es_ops_allow_external=True}
 ES_OPS_HOSTNAME=${ES_OPS_HOST:+openshift_logging_es_ops_hostname=$ES_OPS_HOST}
 
+SET_MUX_CPU_LIMIT=""
+SET_MUX_MEMORY_LIMIT=""
+SET_MUX_BUFFER_QUEUE_LIMIT=""
+SET_MUX_BUFFER_SIZE_LIMIT=""
+SET_MUX_FILE_BUFFER_STORAGE_TYPE=""
+SET_MUX_FILE_BUFFER_PVC_NAME=""
+SET_MUX_FILE_BUFFER_PVC_SIZE=""
+SET_MUX_BUFFER_TYPE=""
+SET_FLUENTD_BUFFER_TYPE=""
 if [ "$MUX_ALLOW_EXTERNAL" = true ] ; then
     SET_MUX_CPU_LIMIT="openshift_logging_mux_cpu_limit=${MUX_CPU_LIMIT:-500m}"
     SET_MUX_MEMORY_LIMIT="openshift_logging_mux_memory_limit=${MUX_MEMORY_LIMIT:-2Gi}"
     SET_MUX_BUFFER_QUEUE_LIMIT="openshift_logging_mux_buffer_queue_limit=${MUX_BUFFER_QUEUE_LIMIT:-1024}"
     SET_MUX_BUFFER_SIZE_LIMIT="openshift_logging_mux_buffer_size_limit=${MUX_BUFFER_SIZE_LIMIT:-1048576}"
+    if [ "$BUFFER_TYPE" = "file" ]; then
+        SET_MUX_BUFFER_TYPE="openshift_logging_mux_buffer_type=file"
+        SET_MUX_FILE_BUFFER_STORAGE_TYPE="openshift_logging_mux_file_buffer_storage_type=${MUX_FILE_BUFFER_STORAGE_TYPE:-emptydir}"
+        if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" ]; then
+          SET_MUX_FILE_BUFFER_PVC_NAME="openshift_logging_mux_file_buffer_pvc_name=logging-mux-pvc"
+          SET_MUX_FILE_BUFFER_PVC_SIZE="openshift_logging_mux_file_buffer_pvc_size=6Gi"
+          echo "### Prepare pvc storage for testing"
+          echo "apiVersion: \"v1\"
+kind: \"PersistentVolume\"
+metadata:
+  name: logging-muxpv-1
+spec:
+  capacity:
+    storage: \"6Gi\"
+  accessModes:
+    - \"ReadWriteOnce\"
+  hostPath:
+    path: ${FILE_BUFFER_PATH:-/var/log/mux/filebufferstorage}" > /tmp/host-pv.yaml
+          cat /tmp/host-pv.yaml
+          cat /tmp/host-pv.yaml | oc create -f -
+    echo "###################################"
+        fi
+    else
+        SET_MUX_BUFFER_TYPE="openshift_logging_mux_buffer_type=memory"
+    fi
+fi
+
+if [ "$BUFFER_TYPE" = "file" ]; then
+    SET_FLUENTD_BUFFER_TYPE="openshift_logging_fluentd_buffer_type=file"
 else
-    SET_MUX_CPU_LIMIT=""
-    SET_MUX_MEMORY_LIMIT=""
-    SET_MUX_BUFFER_QUEUE_LIMIT=""
-    SET_MUX_BUFFER_SIZE_LIMIT=""
+    SET_FLUENTD_BUFFER_TYPE="openshift_logging_fluentd_buffer_type=memory"
 fi
 
 source $OS_O_A_L_DIR/hack/testing/build-images
@@ -60,11 +95,15 @@ $ES_ALLOW_EXTERNAL
 $ES_HOSTNAME
 $ES_OPS_ALLOW_EXTERNAL
 $ES_OPS_HOSTNAME
+$SET_FLUENTD_BUFFER_TYPE
 $SET_MUX_CPU_LIMIT
 $SET_MUX_MEMORY_LIMIT
 $SET_MUX_BUFFER_QUEUE_LIMIT
 $SET_MUX_BUFFER_SIZE_LIMIT
-
+$SET_MUX_BUFFER_TYPE
+$SET_MUX_FILE_BUFFER_STORAGE_TYPE
+$SET_MUX_FILE_BUFFER_PVC_NAME
+$SET_MUX_FILE_BUFFER_PVC_SIZE
 EOL
 
 echo "### Created host inventory file ###"

--- a/hack/testing/init-log-stack
+++ b/hack/testing/init-log-stack
@@ -25,10 +25,10 @@ if [ "$MUX_ALLOW_EXTERNAL" = true ] ; then
     SET_MUX_MEMORY_LIMIT="openshift_logging_mux_memory_limit=${MUX_MEMORY_LIMIT:-2Gi}"
     SET_MUX_BUFFER_QUEUE_LIMIT="openshift_logging_mux_buffer_queue_limit=${MUX_BUFFER_QUEUE_LIMIT:-1024}"
     SET_MUX_BUFFER_SIZE_LIMIT="openshift_logging_mux_buffer_size_limit=${MUX_BUFFER_SIZE_LIMIT:-1048576}"
-    if [ "$BUFFER_TYPE" = "file" ]; then
+    if [ "${BUFFER_TYPE:-}" = "file" ]; then
         SET_MUX_BUFFER_TYPE="openshift_logging_mux_buffer_type=file"
         SET_MUX_FILE_BUFFER_STORAGE_TYPE="openshift_logging_mux_file_buffer_storage_type=${MUX_FILE_BUFFER_STORAGE_TYPE:-emptydir}"
-        if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" ]; then
+        if [ "${MUX_FILE_BUFFER_STORAGE_TYPE:-}" = "pvc" ]; then
           SET_MUX_FILE_BUFFER_PVC_NAME="openshift_logging_mux_file_buffer_pvc_name=logging-mux-pvc"
           SET_MUX_FILE_BUFFER_PVC_SIZE="openshift_logging_mux_file_buffer_pvc_size=6Gi"
           echo "### Prepare pvc storage for testing"
@@ -52,7 +52,7 @@ spec:
     fi
 fi
 
-if [ "$BUFFER_TYPE" = "file" ]; then
+if [ "${BUFFER_TYPE:-}" = "file" ]; then
     SET_FLUENTD_BUFFER_TYPE="openshift_logging_fluentd_buffer_type=file"
 else
     SET_FLUENTD_BUFFER_TYPE="openshift_logging_fluentd_buffer_type=memory"

--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -213,7 +213,6 @@ rm -f $lfds
 # when fluentd starts up it may take a while before it catches up with all of the logs
 # let's wait until that happens
 wait_for_fluentd_ready
-wait_for_fluentd_to_catch_up
 
 # add admin user and normal user for kibana and token auth testing
 export LOG_ADMIN_USER=admin
@@ -244,6 +243,7 @@ if [ "$ENABLE_OPS_CLUSTER" = "true" ] ; then
         curl_es_input $esopspod /$sg_opsindex/rolesmapping/0 -XPUT -d@- | \
         python -mjson.tool
 fi
+wait_for_fluentd_to_catch_up
 
 # verify that $LOG_ADMIN_USER user has access to cluster stats
 sleep 5

--- a/hack/testing/logging.sh
+++ b/hack/testing/logging.sh
@@ -41,6 +41,7 @@ ES_OPS_VOLUME=${ES_OPS_VOLUME:-/var/lib/es-ops}
 export MUX_ALLOW_EXTERNAL=${MUX_ALLOW_EXTERNAL:-false}
 export USE_MUX_CLIENT=${USE_MUX_CLIENT:-false}
 export USE_MUX=${USE_MUX:-false}
+export MUX_FILE_BUFFER_STORAGE_TYPE=${MUX_FILE_BUFFER_STORAGE_TYPE:-""}
 if [ "$MUX_ALLOW_EXTERNAL" = true -o "$USE_MUX_CLIENT" = true ] ; then
     export USE_MUX=true
 fi

--- a/hack/testing/prep-host
+++ b/hack/testing/prep-host
@@ -11,7 +11,7 @@ OS_ANSIBLE_BRANCH=${OS_ANSIBLE_BRANCH:-master}
 OS_ANSIBLE_DIR=$WORKDIR/openhift-ansible
 
 sudo yum makecache fast
-sudo yum install python2-pip $RUAMEL_YAML_RPM $ANSIBLE_RPM -y
+sudo yum install python2-pip $RUAMEL_YAML_RPM $ANSIBLE_RPM bc -y
 
 git clone $OS_ANSIBLE_REPO $OS_ANSIBLE_DIR -b $OS_ANSIBLE_BRANCH --depth=1
 

--- a/hack/testing/test-es-copy.sh
+++ b/hack/testing/test-es-copy.sh
@@ -13,6 +13,11 @@ if ! type get_running_pod > /dev/null 2>&1 ; then
     . ${OS_O_A_L_DIR:-../..}/deployer/scripts/util.sh
 fi
 
+if [ "$USE_MUX_CLIENT" = "true" ] ; then
+    echo "Skipping -- This test is exclusive to USE_MUX_CLIENT != true."
+    exit 0
+fi
+
 if [[ $# -ne 1 || "$1" = "false" ]]; then
   # assuming not using OPS cluster
   CLUSTER="false"
@@ -45,15 +50,21 @@ write_and_verify_logs() {
     return $rc
 }
 
-restart_fluentd() {
-    # delete daemonset which also stops fluentd
-    oc delete daemonset logging-fluentd
-    # wait for fluentd to stop
+undeploy_fluentd() {
+    fpod=`get_running_pod fluentd`
+
+    # undeploy fluentd
+    oc label node --all logging-infra-fluentd-
+
     wait_for_pod_ACTION stop $fpod
-    # create the daemonset which will also start fluentd
-    oc process logging-fluentd-template | oc create -f -
-    # wait for fluentd to start
-    wait_for_pod_ACTION start fluentd
+}
+
+redeploy_fluentd() {
+  # redeploy fluentd
+  oc label node --all logging-infra-fluentd=true
+
+  # wait for fluentd to start
+  wait_for_pod_ACTION start fluentd
 }
 
 TEST_DIVIDER="------------------------------------------"
@@ -64,19 +75,15 @@ TEST_DIVIDER="------------------------------------------"
 # cause messages to be written to the system log - verify that OPS contains
 # two copies
 
-fpod=`get_running_pod fluentd`
+undeploy_fluentd
 
-# first, make sure copy is off
 cfg=`mktemp`
-oc get template logging-fluentd-template -o yaml | \
+# first, make sure copy is off
+oc get daemonset logging-fluentd -o yaml | \
     sed '/- name: ES_COPY/,/value:/ s/value: .*$/value: "false"/' | \
     oc replace -f -
-restart_fluentd
-fpod=`get_running_pod fluentd`
 
-# save original template config
-origconfig=`mktemp`
-oc get template logging-fluentd-template -o yaml > $origconfig
+redeploy_fluentd
 
 # run test to make sure fluentd is working normally - no copy
 write_and_verify_logs 1 || {
@@ -84,13 +91,20 @@ write_and_verify_logs 1 || {
     exit 1
 }
 
+undeploy_fluentd
+
+# save original daemonset config
+origconfig=`mktemp`
+oc get daemonset logging-fluentd -o yaml > $origconfig
+
 cleanup() {
     # may have already been cleaned up
     if [ ! -f $origconfig ] ; then return 0 ; fi
+    undeploy_fluentd
     # put back original configuration
     oc replace --force -f $origconfig
     rm -f $origconfig
-    restart_fluentd
+    redeploy_fluentd
 }
 trap "cleanup" INT TERM EXIT
 
@@ -99,10 +113,16 @@ nocopy=`mktemp`
 sed '/_COPY/,/value/d' $origconfig > $nocopy
 # for every ES_ or OPS_ setting, create a copy called ES_COPY_ or OPS_COPY_
 envpatch=`mktemp`
-sed -n '/^        - env:/,/^          image:/ {
-/^          image:/d
-/^        - env:/d
+sed -n '/^ *- env:/,/^ *image:/ {
+/^ *image:/d
+/^ *- env:/d
 /name: K8S_HOST_URL/,/value/d
+/name: .*JOURNAL.*/,/value/d
+/name: .*BUFFER.*/,/value/d
+/name: .*MUX.*/,/value/d
+/name: FLUENTD_.*_LIMIT/,/valueFrom:/d
+/resourceFieldRef:/,/containerName: fluentd-elasticsearch/d
+/divisor:/,/resource: limits./d
 s/ES_/ES_COPY_/
 s/OPS_/OPS_COPY_/
 p
@@ -110,25 +130,26 @@ p
 
 # add the scheme, and turn on verbose
 cat >> $envpatch <<EOF
-          - name: ES_COPY
-            value: "true"
-          - name: ES_COPY_SCHEME
-            value: https
-          - name: OPS_COPY_SCHEME
-            value: https
-          - name: VERBOSE
-            value: "true"
+        - name: ES_COPY
+          value: "true"
+        - name: ES_COPY_SCHEME
+          value: https
+        - name: OPS_COPY_SCHEME
+          value: https
+        - name: VERBOSE
+          value: "true"
 EOF
 
 # add this back to the dc config
+docopy=`mktemp`
 cat $nocopy | \
-    sed '/^        - env:/r '$envpatch | \
+    sed '/^ *- env:/r '$envpatch > $docopy
+
+cat $docopy | \
     oc replace -f -
 
-rm -f $envpatch $nocopy
-
-restart_fluentd
-fpod=`get_running_pod fluentd`
+redeploy_fluentd
+rm -f $envpatch $nocopy $docopy
 
 write_and_verify_logs 2 || {
     oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1
@@ -138,9 +159,6 @@ write_and_verify_logs 2 || {
 # put back original configuration
 oc replace --force -f $origconfig
 rm -f $origconfig
-
-restart_fluentd
-fpod=`get_running_pod fluentd`
 
 write_and_verify_logs 1 || {
     oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1

--- a/hack/testing/test-mux.sh
+++ b/hack/testing/test-mux.sh
@@ -16,8 +16,8 @@ if ! type get_running_pod > /dev/null 2>&1 ; then
     . ${OS_O_A_L_DIR:-../..}/deployer/scripts/util.sh
 fi
 
-if [ "$USE_MUX_CLIENT" == "false" -o "$MUX_ALLOW_EXTERNAL" == "false" ]; then
-    echo "Skipping -- This test requires both USE_MUX_CLIENT and MUX_ALLOW_EXTERNAL are true."
+if [ "$MUX_ALLOW_EXTERNAL" != "true" ]; then
+    echo "Skipping -- This test requires MUX_ALLOW_EXTERNAL = true."
     exit 0
 fi
 
@@ -53,6 +53,8 @@ cleanup_forward() {
   oc label node --all logging-infra-fluentd-
 
   wait_for_pod_ACTION stop $fpod
+
+  oc set env daemonset/logging-fluentd USE_MUX_CLIENT=false
 
   # Revert configmap if we haven't yet
   oc get configmap/logging-fluentd -o yaml | \
@@ -319,6 +321,14 @@ fi
 if [ -z "`get_running_pod es`" ] ; then
     echo Error: es is not running
     exit 1
+fi
+
+if [ "MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" ]; then
+    echo file_buffer_storage_type: pvc >> $MUXDEBUG
+    oc get pv >> $MUXDEBUG
+    echo "" >> $MUXDEBUG
+    oc get pvc >> $MUXDEBUG
+    echo "" >> $MUXDEBUG
 fi
 
 # run test to make sure fluentd is working normally 

--- a/hack/testing/test-mux.sh
+++ b/hack/testing/test-mux.sh
@@ -16,7 +16,7 @@ if ! type get_running_pod > /dev/null 2>&1 ; then
     . ${OS_O_A_L_DIR:-../..}/deployer/scripts/util.sh
 fi
 
-if [ "$MUX_ALLOW_EXTERNAL" != "true" ]; then
+if [ ${MUX_ALLOW_EXTERNAL:-""} != "true" ]; then
     echo "Skipping -- This test requires MUX_ALLOW_EXTERNAL = true."
     exit 0
 fi
@@ -24,6 +24,12 @@ fi
 ARTIFACT_DIR=${ARTIFACT_DIR:-${TMPDIR:-/tmp}/origin-aggregated-logging}
 if [ ! -d $ARTIFACT_DIR ] ; then
     mkdir -p $ARTIFACT_DIR
+fi
+
+if [ "${VERBOSE:-false}" = true ] ; then
+    MUXDEBUG=$ARTIFACT_DIR/mux-test-ext.$is_testproj.$no_container_vals.$mismatch_namespace.$no_project_tag.log
+else
+    MUXDEBUG="/dev/null"
 fi
 
 if oc get project testproj > /dev/null 2>&1 ; then
@@ -93,6 +99,7 @@ reset_fluentd_daemonset() {
 }
 
 # OPTIONS:
+ENABLE_SECURE_FORWARD=0
 SET_CONTAINER_VALS=1
 NO_CONTAINER_VALS=2
 MISMATCH_NAMESPACE_TAG=3
@@ -161,7 +168,7 @@ update_current_fluentd() {
         CONTAINER_ID_FULL 0123456789012345678901234567890123456789012345678901234567890123\n\
         </record>\n\
       </filter>"}]'
-  else
+  elif [ $myoption -eq $NO_PROJECT_TAG ]; then
       oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "replace", "path": "/data/filter-pre-mux-test-client.conf", "value": "\
       <match journal>\n\
         @type rewrite_tag_filter\n\
@@ -175,6 +182,8 @@ update_current_fluentd() {
         @timestamp ${time.strftime(\"%Y-%m-%dT%H:%M:%S%z\")}\n\
         </record>\n\
       </filter>"}]'
+  else
+      echo "Enabling secure forward"
   fi
 
   reset_fluentd_daemonset
@@ -209,11 +218,6 @@ write_and_verify_logs() {
 
     local rc=0
 
-    if [ "${VERBOSE:-false}" = true ] ; then
-        MUXDEBUG=$ARTIFACT_DIR/mux-test-ext.$is_testproj.$no_container_vals.$mismatch_namespace.$no_project_tag.log
-    else
-        MUXDEBUG="/dev/null"
-    fi
     echo "DEBUG PRINT is_testproj $is_testproj no_container_vals $no_container_vals ====================================" > $MUXDEBUG
 
     espod=$es_pod
@@ -301,6 +305,25 @@ restart_fluentd() {
     oc logs $fpod  > $ARTIFACT_DIR/$fpod.log
 }
 
+reset_ES_HOST() {
+    es_host=${1:-"bogus"}
+    ops_host=${2:-"bogus"}
+
+    oc set env dc logging-mux ES_HOST="$es_host" OPS_HOST="$ops_host"
+
+    wait_for_pod_ACTION start mux
+
+    sleep 10
+
+    while terminating=$(oc get pods | egrep Terminating) || :
+    do
+        if [ "$terminating" = "" ]; then
+            break
+        fi
+        sleep 2
+    done
+}
+
 TEST_DIVIDER="------------------------------------------"
 
 # make sure we are in logging
@@ -323,7 +346,7 @@ if [ -z "`get_running_pod es`" ] ; then
     exit 1
 fi
 
-if [ "MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" ]; then
+if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" ]; then
     echo file_buffer_storage_type: pvc >> $MUXDEBUG
     oc get pv >> $MUXDEBUG
     echo "" >> $MUXDEBUG
@@ -343,6 +366,56 @@ cleanup() {
     oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1
 }
 trap "cleanup" INT TERM EXIT
+
+if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" -o "$MUX_FILE_BUFFER_STORAGE_TYPE" = "hostmount" ]; then
+    echo "------- Test case FILE_BUFFER_STORAGE_TYPE: $MUX_FILE_BUFFER_STORAGE_TYPE -------"
+
+    update_current_fluentd $ENABLE_SECURE_FORWARD
+
+    ES_HOST_BAK=${ES_HOST:-"logging-es"}
+    OPS_HOST_BAK=${OPS_HOST:-"logging-es-ops"}
+
+    # set ES_HOST and OPS_HOST to bogus
+    reset_ES_HOST
+
+    uuid_es=`uuidgen`
+    uuid_es_ops=`uuidgen`
+
+    logger -i -p local6.info -t $uuid_es_ops $uuid_es_ops
+    add_test_message $uuid_es
+
+    # wait long enough to make the test messages are in the buffer
+    sleep 10
+
+    MPOD=`oc get pods -l component=mux -o name | awk -F'/' '{print $2}'`
+    oc exec $MPOD -- ls -l /var/log/mux/filebufferstorage
+    oc logs $MPOD >> $MUXDEBUG
+
+    # set ES_HOST and OPS_HOST to original
+    reset_ES_HOST $ES_HOST_BAK $OPS_HOST_BAK
+
+    expected=1
+    # kibana logs with kibana container/pod values
+    myproject=project.logging
+    espod=`get_running_pod es`
+    mymessage=$uuid_es
+    if wait_until_cmd_or_err test_count_expected test_count_err 600 ; then
+        echo good - found 1 record project $myproject for $uuid_es
+    else
+        echo failed - not found 1 record project $myproject for $uuid_es
+        rc=1
+    fi
+
+    myproject=.operations
+    espod=`get_running_pod es-ops`
+    mymessage=$uuid_es_ops
+    if wait_until_cmd_or_err test_count_expected test_count_err 600 ; then
+        echo good - found 1 record project $myproject for $uuid_es_ops
+    else
+        echo failed - not found 1 record project $myproject for $uuid_es_ops
+        rc=1
+    fi
+fi
 
 echo "------- Test case $SET_CONTAINER_VALS -------"
 echo "fluentd forwards kibana and system logs with tag project.testproj.mux and CONTAINER values."


### PR DESCRIPTION
  Description for calculating buffer_queue_limit
  0) The buffer type is initialized in the ansible inventory file as
       openshift_logging_fluentd_buffer_type: memory|file
       openshift_logging_mux_buffer_type: memory|file
  1) buffer_type: memory
     The available memory size is given via environment varirables FLUENTD_
     MEMORY_LIMIT or MUX_MEMORY_LIMIT, which are initialized by ansible and
     set in daemonset and deploymentconfig as "resource: limits.memory",
     respectively.
     The size is multiplied by 3/4, then divided by the number of output.
     The result is the memory buffer size.  The size is divided by the chunk
     size (by default 1m) and the result is set to buffer_queue_limit.
  2) buffer_type: file
     The available volume size is retrieved from the given FILE_BUFFER_PATH.
       Fluentd uses the existing hostmount "/var/log/fluentd" for the path.
       Mux allows to choose one of the 3 types in the ansible inventory:
         openshift_logging_mux_file_buffer_storage_type: pvc|hostmount|emptydir
       then the path is set to openshift_logging_mux_file_buffer_mount_path.
       It is default to "/mux/filebufferstorage".
     The available size of the volume is multiplied by 1/4 and the result is
     used for the total size.
     Against the total size, file buffer type allows to set an upper limit,
     FILE_BUFFER_LIMIT, which is initialized in the ansible inventory as
       openshift_logging_fluentd_file_buffer_limit  (default to 1G)
       openshift_logging_mux_file_buffer_limit  (default to 2G)
     Note that FILE_BUFFER_LIMIT size is per output.
     Comparing the total size from the volume and (FILE_BUFFER_LIMIT * output),
     the smaller one is chosen for calculating buffer_queue_limit.

CI test: Using daemonset config instead of template in test-es-copy.sh.
         adding PV/PVC test case for test-mux.