### PR TITLE
do not dump env vars unless VERBOSE is set

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-echo ">>>>>> ENVIRONMENT VARS <<<<<"
-env | sort
-echo ">>>>>>>>>>>>><<<<<<<<<<<<<<<<"
-
 if [[ $VERBOSE ]]; then
   set -ex
   fluentdargs="-vv"
+  echo ">>>>>> ENVIRONMENT VARS <<<<<"
+  env | sort
+  echo ">>>>>>>>>>>>><<<<<<<<<<<<<<<<"
 else
   set -e
   fluentdargs=


### PR DESCRIPTION
do not dump env vars unless VERBOSE is set
this makes the fluentd logs a bit too noisy
You can always get the list of env vars in the fluentd process like this:
```
```
@jcantrill @nhosoi PTAL
[test]