### PR TITLE
Bug 1467963 There are no Kibana dashboards for container admins

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -20,7 +20,12 @@ ENV ES_CLOUD_K8S_VER=2.4.4 \
     RECOVER_AFTER_NODES=1 \
     RECOVER_EXPECTED_NODES=1 \
     RECOVER_AFTER_TIME=5m \
-    RELEASE_STREAM=prod 
+    RELEASE_STREAM=prod
+
+ARG ES_CLOUD_K8S_VER=2.4.4
+ARG OSE_ES_VER=2.4.4.9
+ARG ES_CLOUD_K8S_URL
+ARG OSE_ES_URL
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \
       io.k8s.display-name="Elasticsearch ${ES_VER}" \
@@ -44,9 +49,11 @@ RUN yum-config-manager --enable rhel-7-server-ose-3.6-rpms \
     rpm -V $packages && \
     yum clean all
 
+
 ADD sgconfig/ ${HOME}/sgconfig/
 ADD index_templates/ ${ES_HOME}/index_templates/
 ADD index_patterns/ ${ES_HOME}/index_patterns/
+ADD kibana_ui_objects/ ${ES_HOME}/kibana_ui_objects/
 ADD probe/ ${ES_HOME}/probe/
 ADD run.sh prep-install.${RELEASE_STREAM} install.sh ${HOME}/
 COPY utils/** /usr/local/bin/

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -47,7 +47,7 @@ RUN rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch && \
 ADD sgconfig/ ${HOME}/sgconfig/
 ADD index_templates/ ${ES_HOME}/index_templates/
 ADD index_patterns/ ${ES_HOME}/index_patterns/
-ADD kibana_ui_objects/ /usr/share/elasticsearch/kibana_ui_objects/
+ADD kibana_ui_objects/ ${ES_HOME}/kibana_ui_objects/
 ADD probe/ ${ES_HOME}/probe/
 ADD run.sh prep-install.${RELEASE_STREAM} install.sh ${HOME}/
 COPY utils/** /usr/local/bin/

--- a/elasticsearch/utils/es_load_kibana_ui_objects
+++ b/elasticsearch/utils/es_load_kibana_ui_objects
@@ -37,9 +37,9 @@ fi
 info Adding Kibana dashboards and other UI objects for user $1 index $kibindex
 
 INDEX_PATTERN=${INDEX_PATTERN:-project.*}
-INDEX_PATTERN_FILE=${INDEX_PATTERN_FILE:-/usr/share/java/elasticsearch/index_patterns/com.redhat.viaq-openshift.index-pattern.json}
+INDEX_PATTERN_FILE=${INDEX_PATTERN_FILE:-$ES_HOME/index_patterns/com.redhat.viaq-openshift.index-pattern.json}
 INDEX_PATTERN_TYPE=${INDEX_PATTERN_TYPE:-index-pattern}
-KIBANA_UI_OBJECTS_DIR=${KIBANA_UI_OBJECTS_DIR:-/usr/share/java/elasticsearch/kibana_ui_objects}
+KIBANA_UI_OBJECTS_DIR=${KIBANA_UI_OBJECTS_DIR:-$ES_HOME/kibana_ui_objects}
 
 info Adding the index pattern for "$INDEX_PATTERN" . . .
 
@@ -50,6 +50,11 @@ cat $INDEX_PATTERN_FILE | \
 info Adding the Kibana UI objects . . .
 {
     for file in $KIBANA_UI_OBJECTS_DIR/*.json ; do
+        if [ ! -f "$file" ] ; then
+            error Missing file "$file" in $KIBANA_UI_OBJECTS_DIR
+            ls -alrtF $KIBANA_UI_OBJECTS_DIR
+            continue
+        fi
         cat "$file" | python -c '
 import sys
 import json


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1467963
Additional fixes:
* Add kibana_ui_objects directory to downstream Dockerfile
* Other fixes to sync upstream and downstream Dockerfiles
* use ES_HOME instead of hardcoded path
* check for missing files and directories
@jcantrill PTAL
[test]
need to merge this asap