### PR TITLE
Add Prometheus Elasticsearch plugin

### DIFF
--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -16,6 +16,7 @@ ENV ES_CLOUD_K8S_VER=2.4.4_01 \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
     OSE_ES_VER=2.4.4.13 \
+    PROMETHEUS_EXPORTER_VER=2.4.4.0 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
     RECOVER_EXPECTED_NODES=1 \
@@ -24,8 +25,10 @@ ENV ES_CLOUD_K8S_VER=2.4.4_01 \
 
 ARG ES_CLOUD_K8S_VER=2.4.4_01
 ARG OSE_ES_VER=2.4.4.13
+ARG PROMETHEUS_EXPORTER_VER=2.4.4.0
 ARG ES_CLOUD_K8S_URL
 ARG OSE_ES_URL
+ARG PROMETHEUS_EXPORTER_URL
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \
       io.k8s.display-name="Elasticsearch ${ES_VER}" \
@@ -42,6 +45,9 @@ RUN rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch && \
                 elasticsearch-${ES_VER} \
                 PyYAML && \
     yum clean all
+
+# temp, see https://github.com/fabric8io/openshift-elasticsearch-plugin/issues/99
+ENV OSE_ES_URL=https://rmeggins.fedorapeople.org/openshift-elasticsearch-plugin-2.4.4.12.zip
 
 ADD sgconfig/ ${HOME}/sgconfig/
 ADD index_templates/ ${ES_HOME}/index_templates/

--- a/elasticsearch/prep-install.origin
+++ b/elasticsearch/prep-install.origin
@@ -9,4 +9,7 @@ fi
 if [ -z "${OSE_ES_URL:-}" ] ; then
     OSE_ES_URL=io.fabric8.elasticsearch/openshift-elasticsearch-plugin/${OSE_ES_VER}
 fi
-es_plugins=($ES_CLOUD_K8S_URL $OSE_ES_URL)
+if [ -z "${PROMETHEUS_EXPORTER_URL:-}" ] ; then
+    PROMETHEUS_EXPORTER_URL=https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/${PROMETHEUS_EXPORTER_VER}/elasticsearch-prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
+fi
+es_plugins=($ES_CLOUD_K8S_URL $OSE_ES_URL $PROMETHEUS_EXPORTER_URL)

--- a/elasticsearch/sgconfig/sg_roles.yml
+++ b/elasticsearch/sgconfig/sg_roles.yml
@@ -7,9 +7,9 @@ sg_role_kibana:
       '*':
         - ALL
 
-sg_role_prometheus:
-  cluster:
-    - cluster:monitor/_prometheus/metrics
+#sg_role_prometheus:
+#  cluster:
+#    - cluster:monitor/_prometheus/metrics
 
 sg_role_fluentd:
   indices:

--- a/elasticsearch/sgconfig/sg_roles.yml
+++ b/elasticsearch/sgconfig/sg_roles.yml
@@ -7,8 +7,9 @@ sg_role_kibana:
       '*':
         - ALL
 
-#sg_role_prometheus:
-#  cluster:
+sg_role_prometheus:
+  cluster:
+    - indices:data/read/_prometheus
 #    - cluster:monitor/_prometheus/metrics
 
 sg_role_fluentd:

--- a/elasticsearch/sgconfig/sg_roles.yml
+++ b/elasticsearch/sgconfig/sg_roles.yml
@@ -9,7 +9,7 @@ sg_role_kibana:
 
 sg_role_prometheus:
   cluster:
-    - indices:data/read/_prometheus
+    - "*"
 #    - cluster:monitor/_prometheus/metrics
 
 sg_role_fluentd:

--- a/elasticsearch/sgconfig/sg_roles.yml
+++ b/elasticsearch/sgconfig/sg_roles.yml
@@ -7,6 +7,10 @@ sg_role_kibana:
       '*':
         - ALL
 
+sg_role_prometheus:
+  cluster:
+    - cluster:monitor/_prometheus/metrics
+
 sg_role_fluentd:
   indices:
     '*':

--- a/elasticsearch/sgconfig/sg_roles_mapping.yml
+++ b/elasticsearch/sgconfig/sg_roles_mapping.yml
@@ -2,9 +2,9 @@ sg_role_kibana:
   users:
     - 'CN=system.logging.kibana,OU=OpenShift,O=Logging'
 
-#sg_role_prometheus:
-#  users:
-#    - 'prometheus'
+sg_role_prometheus:
+  users:
+    - 'prometheus'
 # ??    - 'system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:aggregated-logging-elasticsearch'
 
 sg_role_fluentd:

--- a/elasticsearch/sgconfig/sg_roles_mapping.yml
+++ b/elasticsearch/sgconfig/sg_roles_mapping.yml
@@ -2,9 +2,9 @@ sg_role_kibana:
   users:
     - 'CN=system.logging.kibana,OU=OpenShift,O=Logging'
 
-sg_role_prometheus:
-  users:
-    - 'prometheus'
+#sg_role_prometheus:
+#  users:
+#    - 'prometheus'
 # ??    - 'system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:aggregated-logging-elasticsearch'
 
 sg_role_fluentd:

--- a/elasticsearch/sgconfig/sg_roles_mapping.yml
+++ b/elasticsearch/sgconfig/sg_roles_mapping.yml
@@ -2,6 +2,11 @@ sg_role_kibana:
   users:
     - 'CN=system.logging.kibana,OU=OpenShift,O=Logging'
 
+sg_role_prometheus:
+  users:
+    - 'prometheus'
+# ??    - 'system:serviceaccount:{{ openshift_logging_elasticsearch_namespace }}:aggregated-logging-elasticsearch'
+
 sg_role_fluentd:
   users:
     - 'CN=system.logging.fluentd,OU=OpenShift,O=Logging'

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -8,6 +8,8 @@
 #  - the Kibana cert and key are functional
 #  - indices have been successfully created by Fluentd
 #    in Elasticsearch
+#  - Expected plugins are installed on every Elasticsearch node
+#  - Prometheus exporter plugin yields metrics
 #
 # This script expects the following environment
 # variables:
@@ -97,7 +99,7 @@ for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARC
 		index="$( rev <<<"${index}" | cut -d"." -f 4- | rev )"
 
 		for kibana_pod in $( oc get pods --selector component="${OAL_KIBANA_COMPONENT}"  -o jsonpath='{ .items[*].metadata.name }' ); do
-			os::log::info "Cheking for index ${index} with Kibana pod ${kibana_pod}..."
+			os::log::info "Checking for index ${index} with Kibana pod ${kibana_pod}..."
 			# As we're checking system log files, we need to use `sudo`
 			os::cmd::expect_success "sudo -E VERBOSE=true go run '${OS_O_A_L_DIR}/hack/testing/check-logs.go' '${kibana_pod}' '${elasticsearch_api}' '${index}' '${index_search_path}' '${query_size}' '${test_user}' '${test_token}' '${test_ip}'"
 		done
@@ -108,6 +110,35 @@ for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARC
 	for template in $( oc exec "${elasticsearch_pod}" -- ls -1 /usr/share/java/elasticsearch/index_templates ); do
 		os::cmd::expect_success_and_text "curl_es '${elasticsearch_pod}' '/_template/${template}' --request HEAD --head --output /dev/null --write-out '%{response_code}'" '200'
 	done
+
+	os::log::info "Checking that Elasticsearch pod ${elasticsearch_pod} has expected plugins installed"
+	curl_es "${elasticsearch_pod}" '/_cat/plugins?local=true&v'
+	matching_plugins=0
+	for plugin in $( curl_es "${elasticsearch_pod}" '/_cat/plugins?local=true&h=component' ); do
+		os::log::info "Installed plugin: ${plugin}"
+		if [ "${plugin}" = "cloud-kubernetes" ]; then
+			(( matching_plugins+=1 ))
+#		SearchGuard not listed until ES 5.x
+#		elif [ "${plugin}" = "search-guard2" ]; then
+#			(( matching_plugins+=1 ))
+		elif [ "${plugin}" = "openshift-elasticsearch" ]; then
+			(( matching_plugins+=1 ))
+		elif [ "${plugin}" = "prometheus-exporter" ]; then
+			(( matching_plugins+=1 ))
+		fi
+	done
+	if [ "$matching_plugins" -lt "3" ]; then
+		os::log::fatal "Elasticsearch pod ${elasticsearch_pod} is missing expected plugin(s)"
+	else
+		os::log::info "Elasticsearch pod ${elasticsearch_pod} contains expected plugin(s)"
+	fi
+
+#	WIP, uncommented unless we figure out how to get user name
+#	os::log::info "Checking that Elasticsearch pod ${elasticsearch_pod} exports Prometheus metrics"
+#	user_name="prometheus" #?
+#	barer_token="_na_"     #?
+#	prometheus_metrics=$( curl_es_with_token "${elasticsearch_pod}" '/_prometheus/metrics' "$user_name" "$barer_token" )
+
 done
 
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Initial work to add Elasticsearch Prometheus plugin.

This needs to be followed by:
- ansible work in [openshift/openshift-ansible](https://github.com/openshift/openshift-ansible)
- discussion: Are there needed and changes to SearchGuard configuration (i.e. how do we want to control access to the new `_prometheus/metrics` endpoint)