### PR TITLE
Bug 1473788 - fluentd drops records when using journal and output queue is full

### DIFF
--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -5,9 +5,15 @@
   shared_key "#{File.open('/etc/fluent/muxkeys/shared_key') do |f| f.readline end.rstrip}"
   secure yes
   ca_cert_path /etc/fluent/muxkeys/ca
-  flush_interval 5s
+  flush_interval "#{ENV['MUX_CLIENT_FLUSH_INTERVAL'] || '5s'}"
   buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
   buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+  max_retry_wait "#{ENV['MUX_CLIENT_RETRY_WAIT'] || '300'}"
+  disable_retry_limit "#{ENV['MUX_CLIENT_DISABLE_RETRY_LIMIT'] || 'true'}"
+  # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+  # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+  # buffer to the remote - default is 'exception' because in_tail handles that case
+  buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
   <server>
     host logging-mux
     port "#{ENV['FORWARD_LISTEN_PORT'] || '24284'}"

--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -22,4 +22,8 @@
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+      # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+      # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+      # buffer to the remote - default is 'exception' because in_tail handles that case
+      buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
     </store>

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -22,4 +22,8 @@
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+      # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+      # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+      # buffer to the remote - default is 'exception' because in_tail handles that case
+      buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
     </store>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -22,4 +22,8 @@
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+      # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+      # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+      # buffer to the remote - default is 'exception' because in_tail handles that case
+      buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
     </store>

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -22,4 +22,8 @@
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+      # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+      # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+      # buffer to the remote - default is 'exception' because in_tail handles that case
+      buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
     </store>

--- a/fluentd/configs.d/user/secure-forward.conf
+++ b/fluentd/configs.d/user/secure-forward.conf
@@ -9,6 +9,15 @@
 # ca_cert_path /path/for/certificate/ca_cert.pem
 # ca_private_key_path /path/for/certificate/ca_key.pem
 # ca_private_key_passphrase passphrase # for private CA secret key
+# flush_interval 5s
+# buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+# buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+# max_retry_wait 300
+# disable_retry_limit true
+# # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+# # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+# # buffer to the remote - default is 'exception' because in_tail handles that case
+# buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
 
 # <server>
 #   host server.fqdn.example.com  # or IP

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -92,6 +92,13 @@ if [ "${USE_MUX:-}" = "true" ] ; then
 else
     ruby generate_throttle_configs.rb
     rm -f $CFG_DIR/openshift/*mux*.conf
+    # assume mux doesn't actually read from the journal file
+    if [ "${USE_JOURNAL:-}" = "true" ] ; then
+        # have output plugins handle back pressure
+        # if you want the old behavior to be forced anyway, set env
+        # BUFFER_QUEUE_FULL_ACTION=exception
+        export BUFFER_QUEUE_FULL_ACTION=${BUFFER_QUEUE_FULL_ACTION:-block}
+    fi
 fi
 
 if [ "${USE_MUX_CLIENT:-}" = "true" ] ; then


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1473788
Workaround for now is to use `buffer_queue_full_action block` when the
input source is journal
[test]
@portante @nhosoi @jcantrill PTAL