### PR TITLE
allow flush_interval to be tunable; name tunable depending on output

### DIFF
--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -5,11 +5,11 @@
   shared_key "#{File.open('/etc/fluent/muxkeys/shared_key') do |f| f.readline end.rstrip}"
   secure yes
   ca_cert_path /etc/fluent/muxkeys/ca
-  flush_interval "#{ENV['MUX_CLIENT_FLUSH_INTERVAL'] || '5s'}"
+  flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
   buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
   buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
-  max_retry_wait "#{ENV['MUX_CLIENT_RETRY_WAIT'] || '300'}"
-  disable_retry_limit "#{ENV['MUX_CLIENT_DISABLE_RETRY_LIMIT'] || 'true'}"
+  max_retry_wait "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
+  disable_retry_limit true
   # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
   # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
   # buffer to the remote - default is 'exception' because in_tail handles that case

--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -17,8 +17,8 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
-      max_retry_wait 300
+      flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '5s'}"
+      max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -17,8 +17,8 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
-      max_retry_wait 300
+      flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '5s'}"
+      max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -17,8 +17,8 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
-      max_retry_wait 300
+      flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '5s'}"
+      max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -17,8 +17,8 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
-      max_retry_wait 300
+      flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '5s'}"
+      max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"

--- a/fluentd/configs.d/user/secure-forward.conf
+++ b/fluentd/configs.d/user/secure-forward.conf
@@ -9,10 +9,10 @@
 # ca_cert_path /path/for/certificate/ca_cert.pem
 # ca_private_key_path /path/for/certificate/ca_key.pem
 # ca_private_key_passphrase passphrase # for private CA secret key
-# flush_interval 5s
 # buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
 # buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
-# max_retry_wait 300
+# flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
+# max_retry_wait "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
 # disable_retry_limit true
 # # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 # # queue limit is hit - 'block' will halt further reads and keep retrying to flush the


### PR DESCRIPTION
Each output has several tunables associated with it:

FORWARD_FLUSH_INTERVAL, ES_FLUSH_INTERVAL, OPS_FLUSH_INTERVAL
This is the flush_interval of the output plugin e.g. 10s for ten
seconds, 2m for 2 minutes, etc.  If ES_FLUSH_INTERVAL is specified
but OPS_FLUSH_INTERVAL is not, the ops ES output will use the
ES_FLUSH_INTERVAL.  The default is '5s' (5 seconds).

FORWARD_RETRY_WAIT, ES_RETRY_WAIT, OPS_RETRY_WAIT
This is the maximum time in seconds that fluentd will wait before
retrying the send operation.  If fluentd cannot send the data, it will
exponentially back off until it hits this limit.  If OPS_RETRY_WAIT
is not set but ES_RETRY_WAIT is set, the ES ops output will use the
ES_RETRY_WAIT.  The default is '300' (meaning 300 seconds).

@jcantrill @portante PTAL
[test]