### PR TITLE
bug 1473599. Default KIBANA_MEMORY_LIMIT

### DIFF
--- a/kibana/run.sh
+++ b/kibana/run.sh
@@ -22,7 +22,7 @@ regex='^([[:digit:]]+)([GgMm])?i?$'
 
 export NODE_OPTIONS=""
 
-if [[ "${KIBANA_MEMORY_LIMIT:-}" =~ $regex ]]; then
+if [[ "${KIBANA_MEMORY_LIMIT:-736M}" =~ $regex ]]; then
     num=${BASH_REMATCH[1]}
     unit=${BASH_REMATCH[2]}
 


### PR DESCRIPTION
Defaults the env var to the value defined in ansible