### PR TITLE
bug 1469711: kibana OOM

### DIFF
--- a/kibana/run.sh
+++ b/kibana/run.sh
@@ -26,6 +26,9 @@ if [[ "${KIBANA_MEMORY_LIMIT:-736M}" =~ $regex ]]; then
     num=${BASH_REMATCH[1]}
     unit=${BASH_REMATCH[2]}
 
+    #set max_old_space_size to half of memory limit to allow some heap for other V8 spaces
+    num=$((num/2))
+
     if [[ $unit =~ [Gg] ]]; then
         ((num = num * ${BYTES_PER_GIG})) # enables math to work out for odd Gi
     elif [[ $unit =~ [Mm] ]]; then


### PR DESCRIPTION
The javascript engine V8 used by nodejs has heap split to 4 different
spaces. Setting `max_old_space_size` to half of what the container
has available so other heap spaces have some available memory. This
should prevent the container from getting OOM killed.

The issue occured originally with kibana-proxy but since both use
nodejs, it is fixed here as well as a preventative measure.

(cherry picked from commit 4cb131929ba887aaea840c5357ad06e2fb750929)