### PR TITLE
fluentd: optionally disable transformation of k8 events

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -237,6 +237,10 @@ else
     umount /var/lib/docker/containers/*/shm || :
 fi
 
+if [ "${TRANSFORM_EVENTS:-}" != true ] ; then
+    sed -i 's/\(.*@type viaq_data_model.*\)/\1\n  process_kubernetes_events false/' $CFG_DIR/openshift/filter-viaq-data-model.conf
+fi
+
 if [[ $DEBUG ]] ; then
     exec fluentd $fluentdargs > /var/log/fluentd.log 2>&1
 else


### PR DESCRIPTION
Optionally disable kubernetes events transformations in ViaQ plugin if eventrouter is not deployed.

**Related PRs:**
- [x] https://github.com/openshift/openshift-ansible/pull/4973
- [x] https://github.com/ViaQ/elasticsearch-templates/pull/55
- [X] https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/85
- [x] https://github.com/ViaQ/fluent-plugin-viaq_data_model/pull/9