### PR TITLE
fluentd - disabling unnecessary fluentd output configs (3.6 version for #577)

### DIFF
--- a/fluentd/configs.d/filter-post-z-mux-client.conf
+++ b/fluentd/configs.d/filter-post-z-mux-client.conf
@@ -1,0 +1,5 @@
+# Must be processed at the end of filter-post-*
+<match **>
+  @type relabel
+  @label @OUTPUT
+</match>

--- a/fluentd/configs.d/filter-post-z-retag-one.conf
+++ b/fluentd/configs.d/filter-post-z-retag-one.conf
@@ -1,0 +1,13 @@
+# Must be processed at the end of filter-post-*
+<match mux.** **.fluentd>
+  @type relabel
+  @label @OUTPUT
+</match>
+
+<match **>
+  @type rewrite_tag_filter
+  @label @OUTPUT
+  rewriterule1 message .+ output_tag
+  rewriterule2 MESSAGE .+ output_tag
+  rewriterule3 log .+ output_tag
+</match>

--- a/fluentd/configs.d/filter-post-z-retag-two.conf
+++ b/fluentd/configs.d/filter-post-z-retag-two.conf
@@ -1,0 +1,21 @@
+# Must be processed at the end of filter-post-*
+<match mux.** **.fluentd>
+  @type relabel
+  @label @OUTPUT
+</match>
+
+<match journal.** system.var.log** **_default_** **_openshift_** **_openshift-infra_**>
+  @type rewrite_tag_filter
+  @label @OUTPUT
+  rewriterule1 message .+ output_ops_tag
+  rewriterule2 MESSAGE .+ output_ops_tag
+  rewriterule3 log .+ output_tag_tag
+</match>
+
+<match **>
+  @type rewrite_tag_filter
+  @label @OUTPUT
+  rewriterule1 message .+ output_tag
+  rewriterule2 MESSAGE .+ output_tag
+  rewriterule3 log .+ output_tag
+</match>

--- a/fluentd/configs.d/openshift/output-operations.conf
+++ b/fluentd/configs.d/openshift/output-operations.conf
@@ -1,6 +1,6 @@
 <match journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops>
   @type copy
-  @include output-es-ops-config.conf
+  @include ../dynamic/output-es-ops-config.conf
   @include ../user/output-ops-extra-*.conf
   @include ../dynamic/es-ops-copy-config.conf
   @include ../user/secure-forward.conf

--- a/fluentd/configs.d/openshift/output-operations.conf
+++ b/fluentd/configs.d/openshift/output-operations.conf
@@ -1,4 +1,4 @@
-<match journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops>
+<match output_ops_tag journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops>
   @type copy
   @include ../dynamic/output-es-ops-config.conf
   @include ../user/output-ops-extra-*.conf

--- a/test/es-copy.sh
+++ b/test/es-copy.sh
@@ -22,6 +22,9 @@ fi
 saveds=$( mktemp )
 oc get daemonset logging-fluentd -o yaml > $saveds
 
+cmap=$( mktemp )
+oc get configmap/logging-fluentd -o yaml > $cmap
+
 cleanup() {
     local return_code="$?"
     set +e
@@ -30,6 +33,7 @@ cleanup() {
     else
         mycmd=os::log::error
     fi
+
     $mycmd es-copy test finished at $( date )
     # dump the pod before we restart it
     if [ -n "${fpod:-}" ] ; then
@@ -37,6 +41,9 @@ cleanup() {
     fi
     os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
     os::cmd::try_until_failure "oc get pod $fpod"
+    if [ -n "${cmap:-}" -a -f "${cmap:-}" ] ; then
+        os::log::debug "$( oc replace --force -f $cmap 2>&1 || : )"
+    fi
     if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
         os::log::debug "$( oc replace --force -f $saveds )"
     fi
@@ -46,6 +53,35 @@ cleanup() {
     exit $return_code
 }
 trap "cleanup" EXIT
+
+check_copy_conf () {
+  local expect=$1
+  local copy_conf_file=$2
+  local fpod=$( get_running_pod fluentd )
+  local existcopy=""
+  local lsout=$( oc exec $fpod -- ls -l /etc/fluent/configs.d/dynamic/$copy_conf_file 2>&1 || : )
+  if expr "$lsout" : ".* No such file" > /dev/null ; then
+    existcopy="false"
+    verb="does not exist"
+  else
+    fsize=$( echo $lsout | awk '{print $5}' )
+    if [ $fsize -le 1 ]; then
+      existcopy="false"
+      verb="does not exist"
+    else
+      existcopy="true"
+      verb="exists"
+    fi
+  fi
+  if [ "$expect" = "$existcopy" ]; then
+     result="good"
+     mycmd=os::log::debug
+  else
+     result="failed"
+     mycmd=os::log::error
+  fi
+  $mycmd "$result - $copy_conf_file $verb."
+}
 
 os::log::info Starting es-copy test at $( date )
 
@@ -84,6 +120,95 @@ os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* 
 fpod=$( get_running_pod fluentd )
 
 wait_for_fluentd_ready
+check_copy_conf false "es-copy-config.conf"
+check_copy_conf false "es-ops-copy-config.conf"
+os::cmd::expect_success "wait_for_fluentd_to_catch_up '' '' 1"
+os::cmd::expect_success_and_text "oc logs $fpod 2>&1" "Disabling the copy"
+
+newenvvars=""
+for k_eq_val in $envvars ; do
+    case "$k_eq_val" in
+        *_COPY_HOST*) new=$( echo $k_eq_val | sed 's/\(=.*$\)/\1-copy/' ); newenvvars="$newenvvars $new" ;;
+        VERBOSE*) newenvvars="$newenvvars $k_eq_val" ;;
+        *) continue ;;
+    esac
+done
+newenvvars="$newenvvars ES_COPY=true ES_COPY_SCHEME=https OPS_COPY_SCHEME=https SET_ES_COPY_HOST_ALIAS=true"
+
+modcmap=$( mktemp )
+sed -n '{
+s/^ *@include configs.d\/openshift\/output-operations.conf/    <match journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops>\
+     @type copy\
+     @include configs.d\/dynamic\/output-es-ops-config.conf\
+     @include configs.d\/user\/output-ops-extra-*.conf\
+     <store>\
+        @type elasticsearch_dynamic\
+        host \"#{ENV['"'OPS_COPY_HOST'"']}\"\
+        port \"#{ENV['"'OPS_COPY_PORT'"']}\"\
+        scheme \"#{ENV['"'OPS_COPY_SCHEME'"']}\"\
+        index_name .operations.${record['"'@timestamp'"'].nil? ? Time.at(time).getutc.strftime(@logstash_dateformat) : Time.parse(record['"'@timestamp'"']).getutc.strftime(@logstash_dateformat)}\
+        user \"#{ENV['"'OPS_COPY_USERNAME'"']}\"\
+        password \"#{ENV['"'OPS_COPY_PASSWORD'"']}\"\
+        client_key \"#{ENV['"'OPS_COPY_CLIENT_KEY'"']}\"\
+        client_cert \"#{ENV['"'OPS_COPY_CLIENT_CERT'"']}\"\
+        ca_file \"#{ENV['"'OPS_COPY_CA'"']}\"\
+        type_name com.redhat.viaq.common\
+        reload_connections false\
+        reload_on_failure false\
+        flush_interval 5s\
+        max_retry_wait 300\
+        disable_retry_limit true\
+        buffer_type file\
+        buffer_path '"'\/var\/lib\/fluentd\/buffer-es-ops-copy-config'"'\
+        buffer_queue_limit \"#{ENV['"'BUFFER_QUEUE_LIMIT'"'] || '"'1024'"' }\"\
+        buffer_chunk_limit \"#{ENV['"'BUFFER_SIZE_LIMIT'"'] || '"'1m'"' }\"\
+        buffer_queue_full_action \"#{ENV['"'BUFFER_QUEUE_FULL_ACTION'"'] || '"'exception'"'}\"\
+        ssl_verify false\
+     <\/store>\
+     @include configs.d\/user\/secure-forward.conf\
+    <\/match>/
+s/^ *@include configs.d\/openshift\/output-applications.conf/    <match **>\
+     @type copy\
+     @include configs.d\/openshift\/output-es-config.conf\
+     @include configs.d\/user\/output-extra-*.conf\
+     <store>\
+        @type elasticsearch_dynamic\
+        host \"#{ENV['"'ES_COPY_HOST'"']}\"\
+        port \"#{ENV['"'ES_COPY_PORT'"']}\"\
+        scheme \"#{ENV['"'ES_COPY_SCHEME'"']}\"\
+        index_name project.${record['"'kubernetes'"']['"'namespace_name'"']}.${record['"'kubernetes'"']['"'namespace_id'"']}.${Time.parse(record['"'@timestamp'"']).getutc.strftime(@logstash_dateformat)}\
+        user \"#{ENV['"'ES_COPY_USERNAME'"']}\"\
+        password \"#{ENV['"'ES_COPY_PASSWORD'"']}\"\
+        client_key \"#{ENV['"'ES_COPY_CLIENT_KEY'"']}\"\
+        client_cert \"#{ENV['"'ES_COPY_CLIENT_CERT'"']}\"\
+        ca_file \"#{ENV['"'ES_COPY_CA'"']}\"\
+        type_name com.redhat.viaq.common\
+        reload_connections false\
+        reload_on_failure false\
+        flush_interval 5s\
+        max_retry_wait 300\
+        disable_retry_limit true\
+        buffer_type file\
+        buffer_path '"'\/var\/lib\/fluentd\/buffer-es-copy-config'"'\
+        buffer_queue_limit \"#{ENV['"'BUFFER_QUEUE_LIMIT'"'] || '"'1024'"' }\"\
+        buffer_chunk_limit \"#{ENV['"'BUFFER_SIZE_LIMIT'"'] || '"'1m'"' }\"\
+        buffer_queue_full_action \"#{ENV['"'BUFFER_QUEUE_FULL_ACTION'"'] || '"'exception'"'}\"\
+        ssl_verify false\
+     <\/store>\
+     @include configs.d\/user\/secure-forward.conf\
+    <\/match>/
+p
+}' $cmap > $modcmap
+os::log::debug "$( oc replace --force -f $modcmap )"
+
+# turn on all of the COPY settings
+os::log::debug "$( oc set env daemonset/logging-fluentd $newenvvars )"
+os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+fpod=$( get_running_pod fluentd )
+
+wait_for_fluentd_ready
+check_copy_conf true "es-copy-config.conf"
+check_copy_conf true "es-ops-copy-config.conf"
 os::cmd::expect_success "wait_for_fluentd_to_catch_up '' '' 2"
 
 # turn off the COPY settings


### PR DESCRIPTION
(cherry picked from commit ffa39f508e8884c8785af3f572f286c5e92e809f)

Changes made in fluentd/run.sh:
-  check ES_HOST and OPS_HOST as well as ES_PORT and OPS_PORT; if the pairs are identical, do not configure output-es-ops-config.conf.
-   check ES_COPY_HOST and ES_HOST as well as ES_COPY_PORT and ES_PORT; if the pairs are identical, do not configure es-copy-config.conf. If SET_ES_COPY_HOST_ALIAS is true, add ES_COPY_HOST to /etc/hosts as an alias of ES_HOST.
-   check OPS_COPY_HOST and OPS_HOST as well as OPS_COPY_PORT and OPS_PORT; if the pairs are identical, do not configure es-ops-copy-config.conf. If SET_ES_COPY_HOST_ALIAS is true, add OPS_COPY_HOST to /etc/hosts as an alias of OPS_HOST.

Note: CI test is done in test-es-copy.sh using logging.sh in the release-3.6 branch only.