### PR TITLE
Backport 3.6 - elasticsearch: readiness probe extension

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 9200
 EXPOSE 9300
 USER 0
 
-ENV ES_CLOUD_K8S_VER=2.4.4 \
+ENV ES_CLOUD_K8S_VER=2.4.4_01 \
     ES_CONF=/usr/share/java/elasticsearch/config \
     ES_JAVA_OPTS="-Dmapper.allow_dots_in_name=true" \
     ES_HOME=/usr/share/java/elasticsearch \
@@ -22,7 +22,7 @@ ENV ES_CLOUD_K8S_VER=2.4.4 \
     RECOVER_AFTER_TIME=5m \
     RELEASE_STREAM=prod
 
-ARG ES_CLOUD_K8S_VER=2.4.4
+ARG ES_CLOUD_K8S_VER=2.4.4_01
 ARG OSE_ES_VER=2.4.4.13
 ARG ES_CLOUD_K8S_URL
 ARG OSE_ES_URL

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -6,7 +6,7 @@ EXPOSE 9200
 EXPOSE 9300
 USER 0
 
-ENV ES_CLOUD_K8S_VER=2.4.4 \
+ENV ES_CLOUD_K8S_VER=2.4.4_01 \
     ES_CONF=/usr/share/java/elasticsearch/config \
     ES_JAVA_OPTS="-Dmapper.allow_dots_in_name=true" \
     ES_HOME=/usr/share/java/elasticsearch \
@@ -22,7 +22,7 @@ ENV ES_CLOUD_K8S_VER=2.4.4 \
     RECOVER_AFTER_TIME=5m \
     RELEASE_STREAM=origin
 
-ARG ES_CLOUD_K8S_VER=2.4.4
+ARG ES_CLOUD_K8S_VER=2.4.4_01
 ARG OSE_ES_VER=2.4.4.13
 ARG ES_CLOUD_K8S_URL
 ARG OSE_ES_URL

--- a/elasticsearch/probe/readiness.sh
+++ b/elasticsearch/probe/readiness.sh
@@ -19,20 +19,45 @@
 # TODO: try re-use code from ./run.sh
 ES_REST_BASEURL=https://localhost:9200
 EXPECTED_RESPONSE_CODE=200
+EXPECTED_SG_DOCUMENT_COUNT=5
 secret_dir=/etc/elasticsearch/secret
 max_time=${READINESS_PROBE_TIMEOUT:-30}
 
-response_code=$(curl -s -X HEAD \
-    --cacert $secret_dir/admin-ca \
-    --cert $secret_dir/admin-cert \
-    --key  $secret_dir/admin-key \
-    --max-time $max_time \
-    -w '%{response_code}' \
-    "${ES_REST_BASEURL}/")
 
-if [ ${response_code} == ${EXPECTED_RESPONSE_CODE} ]; then
-  exit 0
-else
-  echo "Elasticsearch node is not ready to accept HTTP requests yet [response code: ${response_code}]"
+function check_if_ready() {
+  path="$1"
+  err_msg="$2"
+  response_code=$(curl -s --head \
+      --cacert $secret_dir/admin-ca \
+      --cert $secret_dir/admin-cert \
+      --key  $secret_dir/admin-key \
+      --max-time $max_time \
+      -o /dev/null \
+      -w '%{response_code}' \
+      "${ES_REST_BASEURL}${path}")
+
+  if [ "${response_code}" != ${EXPECTED_RESPONSE_CODE} ]; then
+    echo "${err_msg} [response code: ${response_code}]"
+    exit 1
+  fi
+}
+
+check_if_ready "/" "Elasticsearch node is not ready to accept HTTP requests yet"
+check_if_ready "/.searchguard.$DC_NAME" "Searchguard index '.searchguard.$DC_NAME' is missing in ES cluster"
+sg_doc_count=$(curl -s --get \
+  --cacert $secret_dir/admin-ca \
+  --cert $secret_dir/admin-cert \
+  --key  $secret_dir/admin-key \
+  --max-time $max_time \
+  "${ES_REST_BASEURL}/.searchguard.$DC_NAME/_search?size=0" \
+  | python -c "import sys, json; print json.load(sys.stdin)['hits']['total']")
+
+if [ "$sg_doc_count" != $EXPECTED_SG_DOCUMENT_COUNT ]; then
+  echo "Incorrect SG document count, expected $EXPECTED_SG_DOCUMENT_COUNT [received doc count: ${sg_doc_count}]"
   exit 1
 fi
+
+for template_file in ${ES_HOME}/index_templates/*.json; do
+  template=`basename $template_file`
+  check_if_ready "/_template/$template" "Index template '$template' is missing in ES cluster"
+done


### PR DESCRIPTION
Backport of https://github.com/openshift/origin-aggregated-logging/pull/609 to 3.6

Interim readiness probe until multi-role Elasticsearch topology from https://github.com/openshift/openshift-ansible/pull/5001 is introduced.

Proposed changes are based on this document: https://docs.google.com/document/d/1m9-LXr-UThs9WhRfkFRbwf1Lppxa5Opw_PYRY1wuDbY/

**List of implemented readiness probe checks:**
1) `localhost:9200/` returns `OK 200`
2) `localhost:9200/.searchguard.${DC_NAME}` returns `OK 200`
3) `localhost:9200/_template/${template}` returns `OK 200` for each `$template` in `$ES_HOME/index_templates/*.json`
4) `localhost:9200/.searchguard.$DC_NAME/_count` returns count of 5 documents in the response body

**Depends on this PR**
https://github.com/fabric8io/elasticsearch-cloud-kubernetes/pull/98