### PR TITLE
refactor es_util to pass query as arg. introduce es_acl

### DIFF
--- a/elasticsearch/utils/es_acl
+++ b/elasticsearch/utils/es_acl
@@ -1,0 +1,76 @@
+#!/bin/bash -e
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+source es_util_env
+
+helpMsg() {
+cat <<MSG
+
+ Usage: $0 <get> [option]*
+ Manipulate Openshift aggregated logging ACL documents.
+
+   commands:
+     get                  Retrieve a given ACL document by name
+
+   options:
+     --doc=<docname>      A document to retrieve. One of:
+                          roles, rolesmapping, actiongroups, config, internalusers
+     --verbose            Debug mode
+     --help               This message.
+
+MSG
+}
+
+while (($#))
+do
+case $1 in
+    get)
+      cmd=${1}
+      ;;
+    --doc=*)
+      doc=${1#*=}
+      ;;
+    --help|-h)
+      helpMsg
+      exit 0
+      ;;
+    --verbose|-v)
+      set -x
+      ;;
+    *)
+      echo Ignoring unknown argument $1
+      ;;
+  esac
+  shift
+done
+
+if [ -z ${cmd:-''} ] ; then
+  helpMsg
+  exit 0
+fi
+
+if [ ${cmd} == "get" ] ; then
+  if [ -z ${doc:-""} ] ; then
+    helpMsg
+    exit
+  fi
+fi
+
+config=${ES_HOME}/config/elasticsearch.yml
+index=$(python -c "import yaml; print yaml.load(open('${config}'))['searchguard']['config_index_name']" | xargs -i sh -c "echo {}")
+
+QUERY="${index}/${doc}/0?pretty" es_util

--- a/elasticsearch/utils/es_util
+++ b/elasticsearch/utils/es_util
@@ -1,10 +1,39 @@
 #!/bin/bash -e
-
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Utility to grab documents from the ES
 # instance using the admin certs and keys
+set -euo pipefail
 source es_util_env
 
-QUERY=${QUERY:-""} 
+while (($#))
+do
+case $1 in
+    --query=*)
+      QUERY=${1#*=}
+      ;;
+    *)
+      echo Ignoring unknown argument $1
+      ;;
+  esac
+  shift
+done
+
+QUERY=${QUERY:-""}
 INDEX=${INDEX:-"project.*"}
 TYPE=${TYPE:-"_search"}
 SIZE=${SIZE:-10}


### PR DESCRIPTION
This PR:

* Makes it so you can use es_util from 'oc exec' by allowing you to pass the query as an arg
* Introduces es_acl to facilitate retrieving the ACL documents.