### PR TITLE
Vendor origin/hack/lib at 3777cfb

### DIFF
--- a/hack/lib/OWNERS
+++ b/hack/lib/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - stevekuznetsov
+  - smarterclayton
+  - kargakis
+  - soltysh
+  - liggitt
+  - jhadvig
+  - fabianofranz
+approvers:
+  - stevekuznetsov
+  - smarterclayton
+  - kargakis
+  - soltysh

--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -82,9 +82,9 @@ function os::build::setup_env() {
   if [[ "${TRAVIS:-}" != "true" ]]; then
     local go_version
     go_version=($(go version))
-    if [[ "${go_version[2]}" < "go1.7" ]]; then
+    if [[ "${go_version[2]}" < "go1.8" ]]; then
       os::log::fatal "Detected Go version: ${go_version[*]}.
-Origin builds require Go version 1.7 or greater."
+Origin builds require Go version 1.8 or greater."
     fi
   fi
   # For any tools that expect this to be set (it is default in golang 1.6),
@@ -509,7 +509,7 @@ function os::build::ldflags() {
 
   declare -a ldflags=()
 
-  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/bootstrap/docker.defaultImageStreams" "${OS_BUILD_LDFLAGS_DEFAULT_IMAGE_STREAMS}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/oc/bootstrap/docker.defaultImageStreams" "${OS_BUILD_LDFLAGS_DEFAULT_IMAGE_STREAMS}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/cmd/util/variable.DefaultImagePrefix" "${OS_BUILD_LDFLAGS_IMAGE_PREFIX}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.majorFromGit" "${OS_GIT_MAJOR}"))
   ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.minorFromGit" "${OS_GIT_MINOR}"))

--- a/hack/lib/build/constants.sh
+++ b/hack/lib/build/constants.sh
@@ -53,6 +53,9 @@ readonly OPENSHIFT_BINARY_SYMLINKS=(
   openshift-recycle
   openshift-sti-build
   openshift-docker-build
+  openshift-git-clone
+  openshift-manage-dockerfile
+  openshift-extract-image-content
   origin
   osc
   oadm

--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -292,7 +292,7 @@ readonly -f os::cleanup::find_cache_alterations
 function os::cleanup::dump_pprof_output() {
 	if go tool -n pprof >/dev/null 2>&1 && [[ -s cpu.pprof ]]; then
 		os::log::info "[CLEANUP] \`pprof\` output logged to $( os::util::repository_relative_path "${LOG_DIR}/pprof.out" )"
-		go tool pprof -text "./_output/local/bin/$(os::util::host_platform)/openshift" cpu.pprof >"${LOG_DIR}/pprof.out" 2>&1
+		go tool pprof -text "./_output/local/bin/$(os::build::host_platform)/openshift" cpu.pprof >"${LOG_DIR}/pprof.out" 2>&1
 	fi
 }
 readonly -f os::cleanup::dump_pprof_output

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -33,6 +33,8 @@ readonly -f os::util::absolute_path
 init_source="$( dirname "${BASH_SOURCE}" )/../.."
 OS_ROOT="$( os::util::absolute_path "${init_source}" )"
 export OS_ROOT
+OS_O_A_L_DIR="${OS_ROOT}"
+export OS_O_A_L_DIR
 cd "${OS_ROOT}"
 
 for library_file in $( find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -path '*/hack/lib/init.sh' ); do

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -33,8 +33,6 @@ readonly -f os::util::absolute_path
 init_source="$( dirname "${BASH_SOURCE}" )/../.."
 OS_ROOT="$( os::util::absolute_path "${init_source}" )"
 export OS_ROOT
-OS_O_A_L_DIR="${OS_ROOT}"
-export OS_O_A_L_DIR
 cd "${OS_ROOT}"
 
 for library_file in $( find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -path '*/hack/lib/init.sh' ); do

--- a/hack/lib/test/junit.sh
+++ b/hack/lib/test/junit.sh
@@ -186,7 +186,7 @@ function os::test::junit::internal::generate_report() {
     os::util::ensure::built_binary_exists 'junitreport'
 
     local report_file
-    report_file="$( mktemp --tmpdir="${ARTIFACT_DIR}" "${report_type}_report_XXXXX" --suffix ".xml" )"
+    report_file="$( mktemp "${ARTIFACT_DIR}/${report_type}_report_XXXXX" ).xml"
     os::log::info "jUnit XML report placed at $( os::util::repository_relative_path ${report_file} )"
     junitreport --type "${report_type}"             \
                 --suites nested                     \

--- a/hack/lib/util/ensure.sh
+++ b/hack/lib/util/ensure.sh
@@ -45,11 +45,11 @@ function os::util::ensure::built_binary_exists() {
 
 	if ! os::util::find::built_binary "${binary}" >/dev/null 2>&1; then
 		if [[ -z "${target}" ]]; then
-			if [[ -d "${OS_ROOT}/cmd/${binary}" ]]; then
+			if [[ -d "${OS_ROOT}/../origin/cmd/${binary}" ]]; then
 				target="cmd/${binary}"
-			elif [[ -d "${OS_ROOT}/tools/${binary}" ]]; then
+			elif [[ -d "${OS_ROOT}/../origin/tools/${binary}" ]]; then
 				target="tools/${binary}"
-			elif [[ -d "${OS_ROOT}/tools/rebasehelpers/${binary}" ]]; then
+			elif [[ -d "${OS_ROOT}/../origin/tools/rebasehelpers/${binary}" ]]; then
 				target="tools/rebasehelpers/${binary}"
 			fi
 		fi
@@ -57,7 +57,7 @@ function os::util::ensure::built_binary_exists() {
 		if [[ -n "${target}" ]]; then
 			os::log::info "No compiled \`${binary}\` binary was found. Attempting to build one using:
   $ hack/build-go.sh ${target}"
-			"${OS_ROOT}/hack/build-go.sh" "${target}"
+			"${OS_ROOT}/../origin/hack/build-go.sh" "${target}"
 		else
 			os::log::fatal "No compiled \`${binary}\` binary was found and no build target could be determined.
 Provide the binary and try running $0 again."

--- a/hack/lib/util/ensure.sh
+++ b/hack/lib/util/ensure.sh
@@ -45,19 +45,19 @@ function os::util::ensure::built_binary_exists() {
 
 	if ! os::util::find::built_binary "${binary}" >/dev/null 2>&1; then
 		if [[ -z "${target}" ]]; then
-			if [[ -d "${OS_ROOT}/../origin/cmd/${binary}" ]]; then
+			if [[ -d "${OS_ROOT}/cmd/${binary}" ]]; then
 				target="cmd/${binary}"
-			elif [[ -d "${OS_ROOT}/../origin/tools/${binary}" ]]; then
+			elif [[ -d "${OS_ROOT}/tools/${binary}" ]]; then
 				target="tools/${binary}"
-			elif [[ -d "${OS_ROOT}/../origin/tools/rebasehelpers/${binary}" ]]; then
+			elif [[ -d "${OS_ROOT}/tools/rebasehelpers/${binary}" ]]; then
 				target="tools/rebasehelpers/${binary}"
 			fi
 		fi
 
 		if [[ -n "${target}" ]]; then
-			os::log::warning "No compiled \`${binary}\` binary was found. Attempting to build one using:
+			os::log::info "No compiled \`${binary}\` binary was found. Attempting to build one using:
   $ hack/build-go.sh ${target}"
-			"${OS_ROOT}/../origin/hack/build-go.sh" "${target}"
+			"${OS_ROOT}/hack/build-go.sh" "${target}"
 		else
 			os::log::fatal "No compiled \`${binary}\` binary was found and no build target could be determined.
 Provide the binary and try running $0 again."

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -104,7 +104,7 @@ readonly -f os::util::environment::setup_all_server_vars
 function os::util::environment::update_path_var() {
     local prefix
     if os::util::find::system_binary 'go' >/dev/null 2>&1; then
-        prefix+="${OS_OUTPUT_BINPATH}/$(os::util::host_platform):"
+        prefix+="${OS_OUTPUT_BINPATH}/$(os::build::host_platform):"
     fi
     if [[ -n "${GOPATH:-}" ]]; then
         prefix+="${GOPATH}/bin:"

--- a/hack/lib/util/golang.sh
+++ b/hack/lib/util/golang.sh
@@ -8,11 +8,10 @@ function os::golang::verify_go_version() {
 
 	local go_version
 	go_version=($(go version))
-	if [[ "${go_version[2]}" != go1.7* ]]; then
+	if [[ "${go_version[2]}" != go1.8* ]]; then
 		os::log::info "Detected go version: ${go_version[*]}."
 		if [[ -z "${PERMISSIVE_GO:-}" ]]; then
-			os::log::error "Please install Go version 1.7 or use PERMISSIVE_GO=y to bypass this check."
-			return 0
+			os::log::fatal "Please install Go version 1.8 or use PERMISSIVE_GO=y to bypass this check."
 		else
 			os::log::warning "Detected golang version doesn't match preferred Go version for Origin."
 			os::log::warning "This version mismatch could lead to differences in execution between this run and the Origin CI systems."

--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -190,21 +190,6 @@ function os::util::curl_etcd() {
 	fi
 }
 
-# os::util::host_platform determines what the host OS and architecture
-# are, as Golang sees it. The go tool chain does some slightly different
-# things when the target platform matches the host platform.
-#
-# Globals:
-#  None
-# Arguments:
-#  None
-# Returns:
-#  None
-function os::util::host_platform() {
-	echo "$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
-}
-readonly -f os::util::host_platform
-
 # os::util::list_go_src_files lists files we consider part of our project
 # source code, useful for tools that iterate over source to provide vet-
 # ting or linting, etc.
@@ -222,7 +207,7 @@ function os::util::list_go_src_files() {
 		-o -wholename './.*' \
 		-o -wholename './pkg/assets/bindata.go' \
 		-o -wholename './pkg/assets/*/bindata.go' \
-		-o -wholename './pkg/bootstrap/bindata.go' \
+		-o -wholename './pkg/oc/bootstrap/bindata.go' \
 		-o -wholename './openshift.local.*' \
 		-o -wholename './test/extended/testdata/bindata.go' \
 		-o -wholename '*/vendor/*' \


### PR DESCRIPTION
Vendor origin/hack/lib at 3777cfb

Changelog:
2291628 Treat the missing binary message as an info not warning
75737aa mktemp is not LCD bash
2b44ff7 hack/lib: dedup os::util::host_platform and os::build::host_platform
ce7709e Use oc adm instead of oadm which might not exist in various installations.
e29078d hack/env: mount a volume for /tmp
d278ea6 Bootstrap Origin policies in post start hook
d5ed80b Check for golang 1.8.
f661ac9 Correctly propogate error code from image builds up
a8c09da replace build context setup with init containers
3880a8b update surrounding files to handle the change
f8038cc remove deads2k from some of the more specific packages
4f5da06 Bootstrap OWNERS files for the repository

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

[carry] Ensure that $OS_ROOT = $OS_O_A_L_DIR

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

[carry] Point os::util::ensure::built_binary_exists at Origin

When the Bash tooling relies on tools built out of Origin, it tries to
build them from the Origin repository. This is not a great hack as it
requires you to have Origin checked out still as a sister repository,
but we need to do more thinking for this.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/cc @richm 
[test]