### PR TITLE
Use UTF-8 instead of ASCII-8BIT

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -35,6 +35,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
      'elasticsearch:<5' \
       fluentd:${FLUENTD_VERSION} \
       fluent-plugin-kubernetes_metadata_filter \
+      'fluent-plugin-record-modifier:<1.0.0' \
       fluent-plugin-rewrite-tag-filter \
       fluent-plugin-secure-forward \
      'fluent-plugin-systemd:<0.1.0' \

--- a/fluentd/configs.d/openshift/filter-pre-force-utf8.conf
+++ b/fluentd/configs.d/openshift/filter-pre-force-utf8.conf
@@ -1,0 +1,4 @@
+<filter **>
+  @type record_modifier
+  char_encoding utf-8
+</filter>

--- a/hack/testing/test-utf8-characters.py
+++ b/hack/testing/test-utf8-characters.py
@@ -1,0 +1,31 @@
+import sys
+import json
+
+obj = json.loads(sys.stdin.read())
+
+message_uuid = sys.argv[1]
+message = sys.argv[2]
+
+for dd in obj['hits']['hits']:
+    if dd['_score'] < 1.0:
+        print "ignoring spurious hit"
+        continue
+    if not dd['_source']['message'].startswith(message):
+        print 'Error: message field does not start with [%s]: [%s]' % (message, dd['_source']['message'])
+        sys.exit(1)
+    if not 'systemd' in dd['_source']:
+        print 'Error: systemd field not in record: [%s]' % json.dumps(dd['_source'])
+        sys.exit(1)
+    if not 'u' in dd['_source']['systemd']:
+        print 'Error: systemd.u field not in record: [%s]' % json.dumps(dd['_source'])
+        sys.exit(1)
+    if not 'SYSLOG_IDENTIFIER' in dd['_source']['systemd']['u']:
+        print 'Error: systemd.u.SYSLOG_IDENTIFIER field not in record: [%s]' % json.dumps(dd['_source'])
+        sys.exit(1)
+    syslog_identifier = dd['_source']['systemd']['u']['SYSLOG_IDENTIFIER']
+    if syslog_identifier == message_uuid:
+        print 'Error: field systemd.u.SYSLOG_IDENTIFIER does not have expected value [%s]: [%s]' % (message_uuid, str(syslog_identifier))
+        sys.exit(1)
+
+print 'Success: record contains all of the expected fields/values'
+sys.exit(0)

--- a/hack/testing/test-utf8-characters.sh
+++ b/hack/testing/test-utf8-characters.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/utf8-characters.sh

--- a/test/utf8-characters.sh
+++ b/test/utf8-characters.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This logging test ensures that a log message containing
+# extended UTF-8 characters will be correctly processed by
+# Fluentd and appear in Elasticsearch.
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+os::util::environment::use_sudo
+
+os::test::junit::declare_suite_start "test/utf8-characters"
+
+if [ -n "${DEBUG:-}" ] ; then
+    set -x
+fi
+
+cleanup() {
+    local return_code="$?"
+    set +e
+    if [ $return_code = 0 ] ; then
+        mycmd=os::log::info
+    else
+        mycmd=os::log::error
+    fi
+    $mycmd "utf8-characters test finished at $( date )"
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
+
+os::log::info "Starting utf8-characters test at $( date )"
+
+message_uuid="$( uuidgen )"
+message="$(printf '%s-\xC2\xB5' "$message_uuid" )"
+logger -p local6.info -t "$message_uuid" "$message"
+
+wait_for_fluentd_ready
+wait_for_fluentd_to_catch_up
+
+es_pod="$( get_running_pod es )"
+
+os::log::info "Checking that message was successfully processed..."
+os::cmd::expect_success "curl_es $es_pod /.operations.*/_search?q=systemd.u.SYSLOG_IDENTIFIER:$message_uuid | \
+                         python $OS_O_A_L_DIR/hack/testing/test-utf8-characters.py $message $message_uuid"


### PR DESCRIPTION
The various origin services log messages including the character `µ`, which is encoded in UTF-8 as the 2-byte sequence `0xC2B5`. Both the [`in_tail`][in_tail] and [`in_systemd`][in_systemd] inputs treat messages as ASCII-8BIT by default, with only the `in_tail` plugin providing a way to override this. As a result, if one of these messages (or any other message with UTF-8 characters) is read in and later needs to be converted to UTF-8 (e.g. as part of being marshaled to JSON), the conversion will fail with an `UndefinedConversionError`. By forcing the message to be treated as UTF-8, we avoid this issue and other potential issues arising from the use of ASCII-8BIT.

Fixes #621.

[in_tail]: https://docs.fluentd.org/v0.12/articles/in_tail#encoding-fromencoding
[in_systemd]: https://github.com/openshift/origin-aggregated-logging/issues/621#issuecomment-325780592