### PR TITLE
Replacing deprecated excludeN with <exclude> section.

### DIFF
--- a/fluentd/configs.d/openshift/filter-exclude-journal-debug.conf
+++ b/fluentd/configs.d/openshift/filter-exclude-journal-debug.conf
@@ -1,4 +1,7 @@
 <filter journal>
   @type grep
-  exclude1 PRIORITY ^7$
+  <exclude>
+    key PRIORITY
+    pattern ^7$
+  </exclude>
 </filter>


### PR DESCRIPTION
This patch eliminates the following warning from the fluentd log:

` [warn]: 'exclude1' parameter is deprecated: Use <exclude> section`