### PR TITLE
use new fluentd es plugin to handle bulk index failures, logstash_prefix_key

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
 ENV DATA_VERSION=1.6.0 \
     FLUENTD_VERSION=0.12.39 \
-    FLUENTD_ES=1.9.5-2 \
+    FLUENTD_ES=1.9.5.1-1 \
     FLUENTD_FLATTEN_HASH=0.4.0-1 \
     FLUENTD_KUBE_METADATA=0.29.0-1 \
     FLUENTD_REWRITE_TAG=1.5.6-1 \

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -33,13 +33,16 @@ RUN mkdir -p ${HOME} && \
      'elasticsearch-api:<5' \
      'elasticsearch:<5' \
       fluentd:${FLUENTD_VERSION} \
-     'fluent-plugin-elasticsearch:>1.9.2' \
       fluent-plugin-kubernetes_metadata_filter \
       fluent-plugin-rewrite-tag-filter \
       fluent-plugin-secure-forward \
      'fluent-plugin-systemd:<0.1.0' \
       fluent-plugin-viaq_data_model \
       systemd-journal
+
+RUN curl -s https://github.com/ViaQ/fluent-plugin-elasticsearch/releases/download/v1.9.5.1/fluent-plugin-elasticsearch-1.9.5.1.gem > ${HOME}/fluent-plugin-elasticsearch-1.9.5.1.gem && \
+    cd ${HOME} && \
+    gem install -N --conservative --minimal-deps --no-ri --local fluent-plugin-elasticsearch-1.9.5.1.gem
 
 ADD configs.d/ /etc/fluent/configs.d/
 ADD run.sh generate_throttle_configs.rb ${HOME}/


### PR DESCRIPTION
(cherry picked from commit c77a760b9514aa83da007a925c5ab29d45d0113a)
[test]