### PR TITLE
CI test fixes for MUX and OPS_CLUSTER

### DIFF
--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -10,7 +10,7 @@ oal_expected_daemonsets=( "logging-fluentd" )
 oal_elasticseach_components=( "es" )
 oal_kibana_components=( "kibana" )
 
-if [[ $# -eq 1 ]]; then
+if [ "$1" = "true" ]; then
 	# There is an ops cluster set up, so we
 	# need to expect to see more objects.
 	oal_expected_deploymentconfigs+=( "logging-kibana-ops" "logging-curator-ops" )
@@ -43,7 +43,7 @@ if [[ "$( wc -w <<<"${es_dcs}" )" -ne 1 ]]; then
 fi
 
 oal_expected_deploymentconfigs+=( ${es_dcs} )
-if [[ $# -eq 1 ]]; then
+if [ "$1" = "true" ]; then
 	es_ops_dcs="$( get_es_dc es-ops )"
 	if [[ "$( wc -w <<<"${es_ops_dcs}" )" -ne 1 ]]; then
 		os::log::fatal "Expected to find one OPS Elasticsearch DeploymentConfig, got: '${es_ops_dcs:-"<none>"}'"

--- a/hack/testing/check-logs.sh
+++ b/hack/testing/check-logs.sh
@@ -36,7 +36,7 @@ OAL_KIBANA_COMPONENT="kibana"   \
 OAL_ELASTICSEARCH_SERVICE="logging-es" \
 "${OS_O_A_L_DIR}/test/cluster/functionality.sh"
 
-if [[ $# -eq 1 ]]; then
+if [ "$1" = "true" ]; then
   # There is an ops cluster set up, so we
   # need to verify it's functionality as well.
   USE_JOURNAL="${USE_JOURNAL}"        \

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -106,7 +106,7 @@ function run_suite() {
 	os::test::junit::declare_suite_end
 
 	os::log::info "Logging test suite ${suite_name} started at $( date )"
-	ops_cluster="true"
+	ops_cluster=${ENABLE_OPS_CLUSTER:-"true"}
 	if "${test}" "${ops_cluster}"; then
 		os::log::info "Logging test suite ${suite_name} succeeded at $( date )"
 		if grep -q "${suite_name}" <<<"${expected_failures[@]}"; then

--- a/hack/testing/test-upgrade.sh
+++ b/hack/testing/test-upgrade.sh
@@ -23,10 +23,11 @@ if [ ! -d $ARTIFACT_DIR ] ; then
     mkdir -p $ARTIFACT_DIR
 fi
 
+OS_O_A_L_DIR=${OS_O_A_L_DIR:-$(dirname "${BASH_SOURCE}")/../..}
 if [ "function" = "`type -t get_es_dcs 2> /dev/null`" ] ; then
     : # already sourced
 else
-    source ../../deployer/scripts/util.sh
+    source "${OS_O_A_L_DIR}/deployer/scripts/util.sh"
 fi
 
 if [ -z "${imageprefix:-}" ] ; then
@@ -34,7 +35,6 @@ if [ -z "${imageprefix:-}" ] ; then
 fi
 
 USE_LOCAL_SOURCE=${USE_LOCAL_SOURCE:-true}
-OS_O_A_L_DIR=${OS_O_A_L_DIR:-$(dirname "${BASH_SOURCE}")/../..}
 ENABLE_OPS_CLUSTER=${ENABLE_OPS_CLUSTER:-$CLUSTER}
 masterurlhack=${masterurlhack:-"-p MASTER_URL=https://172.30.0.1:443"}
 my_pvc_params=""

--- a/test/mux.sh
+++ b/test/mux.sh
@@ -3,8 +3,8 @@
 # test the mux route and service
 # - can accept secure_forward from a "client" fluentd
 
-if [ -z "${MUX_CLIENT_MODE:-}" -o "${MUX_ALLOW_EXTERNAL:-false}" = "false" ]; then
-    echo "Skipping -- This test requires MUX_CLIENT_MODE and MUX_ALLOW_EXTERNAL are true."
+if [ "${USE_MUX:-false}" = "false" ]; then
+    echo "Skipping -- This test requires USE_MUX=true."
     exit 0
 fi
 


### PR DESCRIPTION
- Checking just USE_MUX to run mux.sh.
- Supporting ENABLE_OPS_CLUSTER=false

To disable ops cluster, please add "-e openshift_logging_use_ops=False" to ansible-playbook as well as set "export ENABLE_OPS_CLUSTER=false" at the test run time.