### PR TITLE
fluentd - available disk space for the file buffer (bz1486743 -- backport to 3.6)

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -131,10 +131,13 @@ fi
 FILE_BUFFER_PATH=/var/lib/fluentd
 mkdir -p $FILE_BUFFER_PATH
 
-# Get the available disk size; use 1/4 of it
+# Get the available disk size.
 DF_LIMIT=$(df -B1 $FILE_BUFFER_PATH | grep -v Filesystem | awk '{print $2}')
 DF_LIMIT=${DF_LIMIT:-0}
-DF_LIMIT=$(expr $DF_LIMIT / 4) || :
+if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "hostmount" ]; then
+    # Use 1/4 of the disk space for hostmount.
+    DF_LIMIT=$(expr $DF_LIMIT / 4) || :
+fi
 if [ $DF_LIMIT -eq 0 ]; then
     echo "ERROR: No disk space is available for file buffer in $FILE_BUFFER_PATH."
     exit 1


### PR DESCRIPTION
In the calculation of available disk space for the file buffer, 25% of the found
space was used, which limitation is not necessary for pvc but is for hostmount.
This patch takes care of it.

(cherry picked from commit f14d1c7f84f2f55c6519c0d98c9d83d7e125cba9)