### PR TITLE
various fixes related to running tests with various mux modes

### DIFF
--- a/test/mux-client-mode.sh
+++ b/test/mux-client-mode.sh
@@ -49,11 +49,12 @@ cleanup() {
     fi
     if [ -n "${saveds:-}" ] ; then
         if [ -f "${saveds:-}" ]; then
-            os::log::debug "$( oc replace -f $saveds )"
+            os::log::debug "$( oc replace --force -f $saveds )"
             rm -f $saveds
         fi
     fi
     os::log::debug "$( oc label node --all logging-infra-fluentd=true || : )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
     exit $return_code

--- a/test/mux.sh
+++ b/test/mux.sh
@@ -216,6 +216,7 @@ cleanup() {
         os::log::debug "$( oc replace --force -f $saveds )"
     fi
     os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     os::log::debug "$( oc delete project testproj 2>&1 || : )"
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output

--- a/test/viaq-data-model.sh
+++ b/test/viaq-data-model.sh
@@ -36,6 +36,7 @@ cleanup() {
         os::log::debug "$( oc replace --force -f $saveds )"
     fi
     os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
     exit $return_code
@@ -59,6 +60,12 @@ es_ops_pod=${es_ops_pod:-$es_pod}
 fpod=$( get_running_pod fluentd )
 os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
 os::cmd::try_until_failure "oc get pod $fpod"
+
+# doesn't currently work with MUX_CLIENT_MODE=minimal - force to maximal
+if oc set env daemonset/logging-fluentd --list | grep -q ^MUX_CLIENT_MODE=minimal ; then
+    os::log::info MUX_CLIENT_MODE=minimal not supported - using MUX_CLIENT_MODE=maximal for test
+    oc set env ds/logging-fluentd MUX_CLIENT_MODE=maximal
+fi
 
 # make sure we are not using the test volume
 os::log::debug "$( oc set volumes daemonset/logging-fluentd --remove --name=viaq-test 2>&1 || : )"
@@ -110,7 +117,9 @@ os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search?q=systemd.u.
 
 # these fields are present because it is a kibana log message - we
 # want to ignore them for the purposes of our tests
-keep_fields="method,statusCode,type,@timestamp,req,res"
+# keep CONTAINER_NAME,CONTAINER_ID_FULL because when using mux we want to pass
+# these from fluentd to mux
+keep_fields="method,statusCode,type,@timestamp,req,res,CONTAINER_NAME,CONTAINER_ID_FULL"
 
 # TEST 2
 # cdm - undefined fields are stored in 'undefined' field
@@ -155,6 +164,13 @@ os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search?q=systemd.u.
 # preserve specified empty field as empty
 os::log::debug "$( oc set env daemonset/logging-fluentd CDM_EXTRA_KEEP_FIELDS=undefined4,undefined5,empty1,undefined3,$keep_fields CDM_KEEP_EMPTY_FIELDS=undefined4,undefined5,empty1,undefined3 )"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+# if using MUX_CLIENT_MODE=maximal, also have to tell mux to keep the empty fields
+if oc set env daemonset/logging-fluentd --list | grep -q ^MUX_CLIENT_MODE=maximal ; then
+    muxpod=$( get_running_pod mux )
+    oc set env dc/logging-mux CDM_KEEP_EMPTY_FIELDS=undefined4,undefined5,empty1,undefined3
+    os::cmd::try_until_failure "oc get pod $muxpod"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
+fi
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_ready
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
@@ -163,3 +179,10 @@ os::cmd::expect_success "curl_es $es_pod /project.logging.*/_search?q=message:$l
 
 os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search?q=systemd.u.SYSLOG_IDENTIFIER:$logmessage2 | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test5 allow_empty"
+
+if oc set env daemonset/logging-fluentd --list | grep -q ^MUX_CLIENT_MODE=maximal ; then
+    muxpod=$( get_running_pod mux )
+    oc set env dc/logging-mux CDM_KEEP_EMPTY_FIELDS-
+    os::cmd::try_until_failure "oc get pod $muxpod"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
+fi


### PR DESCRIPTION
The viaq test requires some settings on both the fluentd and mux side.
Among other things, it requires that the CONTAINER_NAME and
CONTAINER_ID_FULL values are passed to mux so that mux can do the k8s
meta filtering.
Also cleans up some various test failures and flakes when using mux.
[merge]
(cherry picked from commit eefff0997c99deade84fea6d9b6c1eba176efd1c)