### PR TITLE
viaq-data-model.sh - make sure pods are up and running at the beginning of the test.

### DIFF
--- a/test/viaq-data-model.sh
+++ b/test/viaq-data-model.sh
@@ -43,6 +43,15 @@ cleanup() {
 }
 trap "cleanup" EXIT
 
+# Make sure all the pods are running at the beginning of the test suite.
+os::cmd::try_until_text "oc get pods -l component=es" "^logging-es.* Running "
+os::cmd::try_until_text "oc get pods -l component=kibana" "^logging-kibana-.* Running "
+os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+if [ "${USE_MUX:-}" = "true" ]; then
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
+fi
+os::log::debug "$( oc get pods )"
+
 # save current fluentd daemonset
 saveds=$( mktemp )
 oc get daemonset logging-fluentd -o yaml > $saveds


### PR DESCRIPTION
When viaq-data-model.sh is executed, some pods are sometimes not fully
started with the "Running" status, which makes the test fail.

(cherry picked from commit 57b8005e7a155fb6dab40a48f9da832ee8cbea78)

cherry-picked pr#652 for release-3.6
