### PR TITLE
the --head argument is required when using curl --request HEAD

### DIFF
--- a/deployer/scripts/util.sh
+++ b/deployer/scripts/util.sh
@@ -490,7 +490,8 @@ function wait_for_es_ready() {
     secret_dir=/etc/elasticsearch/secret
     local ii=$2
     local path=${3:-.searchguard.$1}
-    while ! response_code=$(oc exec $1 -- curl -s -X HEAD \
+    while ! response_code=$(oc exec $1 -- curl -s \
+        --request HEAD --head --output /dev/null \
         --cacert $secret_dir/admin-ca \
         --cert $secret_dir/admin-cert \
         --key  $secret_dir/admin-key \

--- a/elasticsearch/run.sh
+++ b/elasticsearch/run.sh
@@ -83,7 +83,8 @@ wait_for_port_open() {
     rm -f $LOG_FILE
     # test for ES to be up first and that our SG index has been created
     info "Checking if Elasticsearch is ready on $ES_REST_BASEURL"
-    while ! response_code=$(curl ${DEBUG:+-v} -s -X HEAD \
+    while ! response_code=$(curl ${DEBUG:+-v} -s \
+        --request HEAD --head \
         --cacert $secret_dir/admin-ca \
         --cert $secret_dir/admin-cert \
         --key  $secret_dir/admin-key \
@@ -128,7 +129,8 @@ verify_or_add_index_templates() {
     do
         template=`basename $template_file`
         # Check if index template already exists
-        response_code=$(curl ${DEBUG:+-v} -s -X HEAD \
+        response_code=$(curl ${DEBUG:+-v} -s \
+            --request HEAD --head --output /dev/null \
             --cacert $secret_dir/admin-ca \
             --cert $secret_dir/admin-cert \
             --key  $secret_dir/admin-key \

--- a/elasticsearch/utils/es_load_kibana_ui_objects
+++ b/elasticsearch/utils/es_load_kibana_ui_objects
@@ -27,7 +27,9 @@ fi
 
 kibindex=$( get_kibana_index_name "$1" )
 
-resp_code=$( QUERY="/$kibindex" es_util -XHEAD -w '%{response_code}' )
+resp_code=$( QUERY="/$kibindex" es_util \
+                  --request HEAD --head --output /dev/null \
+                  -w '%{response_code}' )
 
 if [ "$resp_code" != 200 ] ; then
     error Could not find kibana index $kibindex for user $1: $resp_code

--- a/kibana/probe/readiness.sh
+++ b/kibana/probe/readiness.sh
@@ -23,6 +23,8 @@ max_time="${max_time:-4}"
 response_code="$(
     curl --silent                          \
          --request HEAD                    \
+         --head                            \
+         --output /dev/null                \
          --max-time "${max_time}"          \
          --write-out '%{response_code}'    \
          "${KIBANA_REST_BASEURL}/"

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -51,14 +51,14 @@ elasticsearch_api="$( oc get svc "${OAL_ELASTICSEARCH_SERVICE}" -o jsonpath='{ .
 
 for kibana_pod in $( oc get pods --selector component="${OAL_KIBANA_COMPONENT}"  -o jsonpath='{ .items[*].metadata.name }' ); do
 	os::log::info "Testing Kibana pod ${kibana_pod} for a successful start..."
-	os::cmd::try_until_text "oc exec ${kibana_pod} -c kibana -- curl -s --request HEAD --write-out '%{response_code}' http://localhost:5601/" "200" "$(( 10*TIME_MIN ))"
+	os::cmd::try_until_text "oc exec ${kibana_pod} -c kibana -- curl --silent --request HEAD --head --output /dev/null --write-out '%{response_code}' http://localhost:5601/" "200" "$(( 10*TIME_MIN ))"
 	os::cmd::try_until_text "oc get pod ${kibana_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"kibana\")].ready }'" "true"
 	os::cmd::try_until_text "oc get pod ${kibana_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"kibana-proxy\")].ready }'" "true"
 done
 
 for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARCH_COMPONENT}" -o jsonpath='{ .items[*].metadata.name }' ); do
 	os::log::info "Testing Elasticsearch pod ${elasticsearch_pod} for a successful start..."
-	os::cmd::try_until_text "curl_es '${elasticsearch_pod}' '/' -X HEAD -w '%{response_code}'" '200' "$(( 10*TIME_MIN ))"
+	os::cmd::try_until_text "curl_es '${elasticsearch_pod}' '/' --request HEAD --head --output /dev/null --write-out '%{response_code}'" '200' "$(( 10*TIME_MIN ))"
 	os::cmd::try_until_text "oc get pod ${elasticsearch_pod} -o jsonpath='{ .status.containerStatuses[?(@.name==\"elasticsearch\")].ready }'" "true"
 
 	os::log::info "Checking that Elasticsearch pod ${elasticsearch_pod} recovered its indices after starting..."
@@ -106,7 +106,7 @@ for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARC
 	os::log::info "Checking that Elasticsearch pod ${elasticsearch_pod} contains common data model index templates..."
 	os::cmd::expect_success "oc exec ${elasticsearch_pod} -- ls -1 /usr/share/java/elasticsearch/index_templates"
 	for template in $( oc exec "${elasticsearch_pod}" -- ls -1 /usr/share/java/elasticsearch/index_templates ); do
-		os::cmd::expect_success_and_text "curl_es '${elasticsearch_pod}' '/_template/${template}' -X HEAD -w '%{response_code}'" '200'
+		os::cmd::expect_success_and_text "curl_es '${elasticsearch_pod}' '/_template/${template}' --request HEAD --head --output /dev/null --write-out '%{response_code}'" '200'
 	done
 done
 


### PR DESCRIPTION
I've noticed curl hanging when running some of the tests interactively,
and this even slows down the CI test e.g.
https://ci.openshift.redhat.com/jenkins/job/test_pull_request_origin_aggregated_logging_ansible/510/console
```
Running test/cluster/functionality.sh:54: executing 'oc exec logging-kibana-1-5wg2z -c kibana -- curl -s --request HEAD --write-out '%{response_code}' http://localhost:5601/' expecting any result and text '200'; re-trying every 0.2s until completion or 600.000s...
SUCCESS after 120.285s: test/cluster/functionality.sh:54: executing 'oc exec logging-kibana-1-5wg2z -c kibana -- curl -s --request HEAD --write-out '%{response_code}' http://localhost:5601/' expecting any result and text '200'; re-trying every 0.2s until completion or 600.000s
```
That is, it takes 120 seconds for the curl to return from a simple HEAD
request because of the missing `--head`.  The only reason it succeeds is
because it will eventually time out after 120 seconds.

This also has implications for our readiness probes which also use
`--request HEAD`.
@jcantrill @nhosoi @stevekuznetsov ptal
[test]