### PR TITLE
increase rsyslog rate limits for json-file; add debugging for json-file

### DIFF
--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -22,6 +22,36 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 
 # HACK HACK HACK
+# richm 2017-09-18 rsyslog is rate limiting the journal when running
+# with json-file - messages show up in the journal but not in
+# /var/log/messages - increase the limits for testing
+if docker_uses_journal ; then
+    os::log::info docker uses journal, skipping
+else
+    os::log::info docker uses json-file - increase rate limits for rsyslog
+    restart=
+    if sudo grep -q -i '^[$]IMJournalRatelimitInterval' /etc/rsyslog.conf ; then
+        os::log::info Keeping limit $( sudo grep -i '^[$]IMJournalRatelimitInterval' /etc/rsyslog.conf )
+    else
+        # default is 600, so increase by a factor of 10
+        sudo sed -i '/^[$]IMJournalStateFile/a\
+$IMJournalRatelimitInterval 60' /etc/rsyslog.conf
+        restart=1
+    fi
+    if sudo grep -q -i '^[$]IMJournalRatelimitBurst' /etc/rsyslog.conf ; then
+        os::log::info Keeping limit $( sudo grep -i '^[$]IMJournalRatelimitBurst' /etc/rsyslog.conf )
+    else
+        # default is 20000
+        sudo sed -i '/^[$]IMJournalStateFile/a\
+$IMJournalRatelimitBurst 20000' /etc/rsyslog.conf
+        restart=1
+    fi
+    if [ -n "$restart" ] ; then
+        sudo systemctl restart rsyslog
+    fi
+fi
+
+# HACK HACK HACK
 # There seems to be some sort of performance problem - richm 2017-08-15
 # not sure what has changed, but now running an all-in-one for CI, with both
 # openshift master and node running as systemd services logging to the journal

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -199,8 +199,11 @@ function wait_for_fluentd_to_catch_up() {
         if sudo journalctl | grep -q "$fullmsg" ; then
             os::log::error "Found '$fullmsg' in journal"
             os::log::debug "$( sudo journalctl | grep "$fullmsg" )"
+        elif sudo grep -q "$fullmsg" /var/log/containers/* ; then
+            os::log::error "Found '$fullmsg' in /var/log/containers/*"
+            os::log::debug "$( sudo grep -q "$fullmsg" /var/log/containers/* )"
         else
-            os::log::error "Unable to find '$fullmsg' in journal"
+            os::log::error "Unable to find '$fullmsg' in journal or /var/log/containers/*"
         fi
 
         rc=1
@@ -243,11 +246,11 @@ docker_uses_journal() {
     # otherwise, look for /etc/sysconfig/docker
     if type -p docker > /dev/null && sudo docker info | grep -q 'Logging Driver: journald' ; then
         return 0
-    elif grep -q '^[^#].*"log-driver":' /etc/docker/daemon.json 2> /dev/null ; then
-        if grep -q '^[^#].*"log-driver":.*journald' /etc/docker/daemon.json 2> /dev/null ; then
+    elif sudo grep -q '^[^#].*"log-driver":' /etc/docker/daemon.json 2> /dev/null ; then
+        if sudo grep -q '^[^#].*"log-driver":.*journald' /etc/docker/daemon.json 2> /dev/null ; then
             return 0
         fi
-    elif grep -q "^OPTIONS='[^']*--log-driver=journald" /etc/sysconfig/docker 2> /dev/null ; then
+    elif sudo grep -q "^OPTIONS='[^']*--log-driver=journald" /etc/sysconfig/docker 2> /dev/null ; then
         return 0
     fi
     return 1
@@ -257,9 +260,9 @@ wait_for_fluentd_ready() {
     local timeout=${1:-60}
     # wait until fluentd is actively reading from the source (journal or files)
     if docker_uses_journal ; then
-        os::cmd::try_until_success "test -f /var/log/journal.pos" $(( timeout * second ))
+        os::cmd::try_until_success "sudo test -f /var/log/journal.pos" $(( timeout * second ))
     else
-        os::cmd::try_until_success "test -f /var/log/node.log.pos" $(( timeout * second ))
-        os::cmd::try_until_success "test -f /var/log/es-containers.log.pos" $(( timeout * second ))
+        os::cmd::try_until_success "sudo test -f /var/log/node.log.pos" $(( timeout * second ))
+        os::cmd::try_until_success "sudo test -f /var/log/es-containers.log.pos" $(( timeout * second ))
     fi
 }


### PR DESCRIPTION
When using json-file on 3.6, the number of messages exceeds the rsyslog
imjournal limit, so test messages are dropped.  This increases the
limits for rsyslog.
This also adds some debugging when using json-file.
@jcantrill @nhosoi ptal
[test]