### PR TITLE
Backporting fluentd file buffer to release 1.4

### DIFF
--- a/deployer/templates/fluentd.yaml
+++ b/deployer/templates/fluentd.yaml
@@ -308,3 +308,11 @@ parameters:
   description: 'Read the journal starting from the very beginning (false|true).'
   name: JOURNAL_READ_FROM_HEAD
   value: "false"
+-
+  description: 'Fluentd buffer queue limit (0.12 only)'
+  name: BUFFER_QUEUE_LIMIT
+  value: "1024"
+-
+  description: 'Fluentd buffer size limit'
+  name: BUFFER_SIZE_LIMIT
+  value: "1048576"

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -22,6 +22,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
       ruby-devel \
       libcurl-devel \
       make \
+      bc \
       iproute && \
     yum clean all
 RUN mkdir -p ${HOME} && \

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 ENV HOME=/opt/app-root/src \
   PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \
   RUBY_VERSION=2.0 \
-  FLUENTD_VERSION=0.12.29 \
+  FLUENTD_VERSION=0.12.39 \
   GEM_HOME=/opt/app-root/src
 
 LABEL io.k8s.description="Fluentd container for collecting of docker container logs" \
@@ -29,12 +29,14 @@ RUN mkdir -p ${HOME} && \
     gem install -N --conservative --minimal-deps \
       fluentd:${FLUENTD_VERSION} \
       'activesupport:<5' \
+      'public_suffix:<3' \
       fluent-plugin-kubernetes_metadata_filter \
       fluent-plugin-elasticsearch \
       'fluent-plugin-systemd:<0.1.0' \
       systemd-journal \
       fluent-plugin-rewrite-tag-filter \
-      fluent-plugin-secure-forward
+      fluent-plugin-secure-forward \
+      excon
 
 ADD configs.d/ /etc/fluent/configs.d/
 ADD run.sh generate_throttle_configs.rb ${HOME}/

--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -19,5 +19,7 @@
       reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
-      disable_retry_limit
+      disable_retry_limit true
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -20,6 +20,8 @@
       flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '5s'}"
       max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
+      buffer_type file
+      buffer_path '/var/lib/fluentd/buffer-es-copy-config'
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-copy-config.conf
@@ -17,8 +17,8 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
-      max_retry_wait 300
+      flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '5s'}"
+      max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -20,6 +20,8 @@
       flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '5s'}"
       max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
+      buffer_type file
+      buffer_path '/var/lib/fluentd/buffer-es-ops-copy-config'
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -19,5 +19,7 @@
       reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
-      disable_retry_limit
+      disable_retry_limit true
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/es-ops-copy-config.conf
+++ b/fluentd/configs.d/openshift/es-ops-copy-config.conf
@@ -17,8 +17,8 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
-      max_retry_wait 300
+      flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '5s'}"
+      max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -20,6 +20,8 @@
       flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '5s'}"
       max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
+      buffer_type file
+      buffer_path '/var/lib/fluentd/buffer-output-es-config'
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -19,5 +19,7 @@
       reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
-      disable_retry_limit
+      disable_retry_limit true
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -17,8 +17,8 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
-      max_retry_wait 300
+      flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '5s'}"
+      max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -20,6 +20,8 @@
       flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '5s'}"
       max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
+      buffer_type file
+      buffer_path '/var/lib/fluentd/buffer-output-es-ops-config'
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -19,5 +19,7 @@
       reload_on_failure false
       flush_interval 5s
       max_retry_wait 300
-      disable_retry_limit
+      disable_retry_limit true
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     </store>

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -17,8 +17,8 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval 5s
-      max_retry_wait 300
+      flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '5s'}"
+      max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"

--- a/fluentd/configs.d/user/secure-forward.conf
+++ b/fluentd/configs.d/user/secure-forward.conf
@@ -9,6 +9,15 @@
 # ca_cert_path /path/for/certificate/ca_cert.pem
 # ca_private_key_path /path/for/certificate/ca_key.pem
 # ca_private_key_passphrase passphrase # for private CA secret key
+# buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+# buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+# flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
+# max_retry_wait "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
+# disable_retry_limit true
+# # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+# # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+# # buffer to the remote - default is 'exception' because in_tail handles that case
+# buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
 
 # <server>
 #   host server.fqdn.example.com  # or IP

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -35,8 +35,32 @@ IPADDR4=`/usr/sbin/ip -4 addr show dev eth0 | grep inet | sed -e "s/[ \t]*inet \
 IPADDR6=`/usr/sbin/ip -6 addr show dev eth0 | grep inet6 | sed "s/[ \t]*inet6 \([a-f0-9:]*\).*/\1/"`
 export IPADDR4 IPADDR6
 
+BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-1048576}
+FLUENTD_CPU_LIMIT=${FLUENTD_CPU_LIMIT:-100m}
+FLUENTD_MEMORY_LIMIT=${FLUENTD_MEMORY_LIMIT:-512Mi}
+
 CFG_DIR=/etc/fluent/configs.d
 ruby generate_throttle_configs.rb
+
+TOTAL_MEMORY_LIMIT=`echo $FLUENTD_MEMORY_LIMIT |  sed -e "s/[Kk]/*1024/g;s/[Mm]/*1024*1024/g;s/[Gg]/*1024*1024*1024/g;s/i//g" | bc`
+BUFFER_SIZE_LIMIT=`echo $BUFFER_SIZE_LIMIT |  sed -e "s/[Kk]/*1024/g;s/[Mm]/*1024*1024/g;s/[Gg]/*1024*1024*1024/g;s/i//g" | bc`
+if [ $BUFFER_SIZE_LIMIT -eq 0 ]; then
+    BUFFER_SIZE_LIMIT=1048576
+fi
+
+DIV=1
+if [ "$ES_HOST" != "$OPS_HOST" ] || [ "$ES_PORT" != "$OPS_PORT" ] ; then
+    # using ops cluster
+    DIV=`expr $DIV \* 2`
+fi
+
+# MEMORY_LIMIT per buffer
+MEMORY_LIMIT=`expr $TOTAL_MEMORY_LIMIT / $DIV`
+BUFFER_QUEUE_LIMIT=`expr $MEMORY_LIMIT / $BUFFER_SIZE_LIMIT`
+if [ $BUFFER_QUEUE_LIMIT -eq 0 ]; then
+    BUFFER_QUEUE_LIMIT=1024
+fi
+export BUFFER_QUEUE_LIMIT BUFFER_SIZE_LIMIT
 
 OPS_COPY_HOST="${OPS_COPY_HOST:-$ES_COPY_HOST}"
 OPS_COPY_PORT="${OPS_COPY_PORT:-$ES_COPY_PORT}"

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -35,32 +35,57 @@ IPADDR4=`/usr/sbin/ip -4 addr show dev eth0 | grep inet | sed -e "s/[ \t]*inet \
 IPADDR6=`/usr/sbin/ip -6 addr show dev eth0 | grep inet6 | sed "s/[ \t]*inet6 \([a-f0-9:]*\).*/\1/"`
 export IPADDR4 IPADDR6
 
-BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-1048576}
-FLUENTD_CPU_LIMIT=${FLUENTD_CPU_LIMIT:-100m}
-FLUENTD_MEMORY_LIMIT=${FLUENTD_MEMORY_LIMIT:-512Mi}
+BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-16777216}
 
 CFG_DIR=/etc/fluent/configs.d
 ruby generate_throttle_configs.rb
 
-TOTAL_MEMORY_LIMIT=`echo $FLUENTD_MEMORY_LIMIT |  sed -e "s/[Kk]/*1024/g;s/[Mm]/*1024*1024/g;s/[Gg]/*1024*1024*1024/g;s/i//g" | bc`
-BUFFER_SIZE_LIMIT=`echo $BUFFER_SIZE_LIMIT |  sed -e "s/[Kk]/*1024/g;s/[Mm]/*1024*1024/g;s/[Gg]/*1024*1024*1024/g;s/i//g" | bc`
-if [ $BUFFER_SIZE_LIMIT -eq 0 ]; then
-    BUFFER_SIZE_LIMIT=1048576
+# fluentd usually has 2 outputs.
+NUM_OUTPUTS=2
+if [ "$ES_COPY" = "true" ]; then
+    NUM_OUTPUTS=`expr $NUM_OUTPUTS \* 2`
 fi
 
-DIV=1
-if [ "$ES_HOST" != "$OPS_HOST" ] || [ "$ES_PORT" != "$OPS_PORT" ] ; then
-    # using ops cluster
-    DIV=`expr $DIV \* 2`
+# If FILE_BUFFER_PATH exists and it is not a directory, mkdir fails with the error.
+FILE_BUFFER_PATH=/var/lib/fluentd
+mkdir -p $FILE_BUFFER_PATH
+
+# Get the available disk size; use 1/4 of it
+DF_LIMIT=$(df -B1 $FILE_BUFFER_PATH | grep -v Filesystem | awk '{print $2}')
+DF_LIMIT=${DF_LIMIT:-0}
+DF_LIMIT=$(expr $DF_LIMIT / 4) || :
+if [ $DF_LIMIT -eq 0 ]; then
+    echo "ERROR: No disk space is available for file buffer in $FILE_BUFFER_PATH."
+    exit 1
+fi
+# Determine final total given the number of outputs we have.
+TOTAL_LIMIT=$(echo ${FILE_BUFFER_LIMIT:-2Gi} | sed -e "s/[Kk]/*1024/g;s/[Mm]/*1024*1024/g;s/[Gg]/*1024*1024*1024/g;s/i//g" | bc) || :
+if [ $TOTAL_LIMIT -le 0 ]; then
+    echo "ERROR: Invalid file buffer limit ($FILE_BUFFER_LIMIT) is given.  Failed to convert to bytes."
+    exit 1
+fi
+TOTAL_LIMIT=$(expr $TOTAL_LIMIT \* $NUM_OUTPUTS) || :
+if [ $DF_LIMIT -lt $TOTAL_LIMIT ]; then
+    echo "WARNING: Available disk space ($DF_LIMIT bytes) is less than the user specified file buffer limit ($FILE_BUFFER_LIMIT times $NUM_OUTPUTS)."
+    TOTAL_LIMIT=$DF_LIMIT
 fi
 
-# MEMORY_LIMIT per buffer
-MEMORY_LIMIT=`expr $TOTAL_MEMORY_LIMIT / $DIV`
-BUFFER_QUEUE_LIMIT=`expr $MEMORY_LIMIT / $BUFFER_SIZE_LIMIT`
-if [ $BUFFER_QUEUE_LIMIT -eq 0 ]; then
-    BUFFER_QUEUE_LIMIT=1024
+BUFFER_SIZE_LIMIT=$(echo $BUFFER_SIZE_LIMIT |  sed -e "s/[Kk]/*1024/g;s/[Mm]/*1024*1024/g;s/[Gg]/*1024*1024*1024/g;s/i//g" | bc)
+BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-16777216}
+
+# TOTAL_BUFFER_SIZE_LIMIT per buffer
+TOTAL_BUFFER_SIZE_LIMIT=$(expr $TOTAL_LIMIT / $NUM_OUTPUTS) || :
+if [ -z $TOTAL_BUFFER_SIZE_LIMIT -o $TOTAL_BUFFER_SIZE_LIMIT -eq 0 ]; then
+    echo "ERROR: Calculated TOTAL_BUFFER_SIZE_LIMIT is 0. TOTAL_LIMIT $TOTAL_LIMIT is too small compared to NUM_OUTPUTS $NUM_OUTPUTS. Please increase FILE_BUFFER_LIMIT $FILE_BUFFER_LIMIT and/or the volume size of $FILE_BUFFER_PATH."
+    exit 1
+fi
+BUFFER_QUEUE_LIMIT=$(expr $TOTAL_BUFFER_SIZE_LIMIT / $BUFFER_SIZE_LIMIT) || :
+if [ -z $BUFFER_QUEUE_LIMIT -o $BUFFER_QUEUE_LIMIT -eq 0 ]; then
+    echo "ERROR: Calculated BUFFER_QUEUE_LIMIT is 0. TOTAL_BUFFER_SIZE_LIMIT $TOTAL_BUFFER_SIZE_LIMIT is too small compared to BUFFER_SIZE_LIMIT $BUFFER_SIZE_LIMIT. Please increase FILE_BUFFER_LIMIT $FILE_BUFFER_LIMIT and/or the volume size of $FILE_BUFFER_PATH."
+    exit 1
 fi
 export BUFFER_QUEUE_LIMIT BUFFER_SIZE_LIMIT
+export K8S_FILTER_REMOVE_KEYS
 
 OPS_COPY_HOST="${OPS_COPY_HOST:-$ES_COPY_HOST}"
 OPS_COPY_PORT="${OPS_COPY_PORT:-$ES_COPY_PORT}"

--- a/hack/testing/test-es-copy.sh
+++ b/hack/testing/test-es-copy.sh
@@ -9,6 +9,10 @@ fi
 set -o nounset
 set -o pipefail
 
+if ! type get_running_pod > /dev/null 2>&1 ; then
+    . ${OS_O_A_L_DIR:-../..}/deployer/scripts/util.sh
+fi
+
 if [[ $# -ne 1 || "$1" = "false" ]]; then
   # assuming not using OPS cluster
   CLUSTER="false"
@@ -186,15 +190,21 @@ write_and_verify_logs() {
     return $rc
 }
 
-restart_fluentd() {
-    # delete daemonset which also stops fluentd
-    oc delete daemonset logging-fluentd
-    # wait for fluentd to stop
+undeploy_fluentd() {
+    fpod=`get_running_pod fluentd`
+
+    # undeploy fluentd
+    oc label node --all logging-infra-fluentd-
+
     wait_for_pod_ACTION stop $fpod
-    # create the daemonset which will also start fluentd
-    oc process logging-fluentd-template | oc create -f -
-    # wait for fluentd to start
-    wait_for_pod_ACTION start fluentd
+}
+
+redeploy_fluentd() {
+  # redeploy fluentd
+  oc label node --all logging-infra-fluentd=true
+
+  # wait for fluentd to start
+  wait_for_pod_ACTION start fluentd
 }
 
 TEST_DIVIDER="------------------------------------------"
@@ -209,19 +219,15 @@ testport=5432
 # cause messages to be written to the system log - verify that OPS contains
 # two copies
 
-fpod=`get_running_pod fluentd`
+undeploy_fluentd
 
-# first, make sure copy is off
 cfg=`mktemp`
-oc get template logging-fluentd-template -o yaml | \
+# first, make sure copy is off
+oc get daemonset logging-fluentd -o yaml | \
     sed '/- name: ES_COPY/,/value:/ s/value: .*$/value: "false"/' | \
     oc replace -f -
-restart_fluentd
-fpod=`get_running_pod fluentd`
 
-# save original template config
-origconfig=`mktemp`
-oc get template logging-fluentd-template -o yaml > $origconfig
+redeploy_fluentd
 
 # run test to make sure fluentd is working normally - no copy
 write_and_verify_logs 1 || {
@@ -229,13 +235,20 @@ write_and_verify_logs 1 || {
     exit 1
 }
 
+undeploy_fluentd
+
+# save original daemonset config
+origconfig=`mktemp`
+oc get daemonset logging-fluentd -o yaml > $origconfig
+
 cleanup() {
     # may have already been cleaned up
     if [ ! -f $origconfig ] ; then return 0 ; fi
+    undeploy_fluentd
     # put back original configuration
     oc replace --force -f $origconfig
     rm -f $origconfig
-    restart_fluentd
+    redeploy_fluentd
 }
 trap "cleanup" INT TERM EXIT
 
@@ -244,10 +257,15 @@ nocopy=`mktemp`
 sed '/_COPY/,/value/d' $origconfig > $nocopy
 # for every ES_ or OPS_ setting, create a copy called ES_COPY_ or OPS_COPY_
 envpatch=`mktemp`
-sed -n '/^        - env:/,/^          image:/ {
-/^          image:/d
-/^        - env:/d
+sed -n '/^ *- env:/,/^ *image:/ {
+/^ *image:/d
+/^ *- env:/d
 /name: K8S_HOST_URL/,/value/d
+/name: .*JOURNAL.*/,/value/d
+/name: .*BUFFER.*/,/value/d
+/name: FLUENTD_.*_LIMIT/,/valueFrom:/d
+/resourceFieldRef:/,/containerName: fluentd-elasticsearch/d
+/divisor:/,/resource: limits./d
 s/ES_/ES_COPY_/
 s/OPS_/OPS_COPY_/
 p
@@ -255,25 +273,26 @@ p
 
 # add the scheme, and turn on verbose
 cat >> $envpatch <<EOF
-          - name: ES_COPY
-            value: "true"
-          - name: ES_COPY_SCHEME
-            value: https
-          - name: OPS_COPY_SCHEME
-            value: https
-          - name: VERBOSE
-            value: "true"
+        - name: ES_COPY
+          value: "true"
+        - name: ES_COPY_SCHEME
+          value: https
+        - name: OPS_COPY_SCHEME
+          value: https
+        - name: VERBOSE
+          value: "true"
 EOF
 
 # add this back to the dc config
+docopy=`mktemp`
 cat $nocopy | \
-    sed '/^        - env:/r '$envpatch | \
+    sed '/^ *- env:/r '$envpatch > $docopy
+
+cat $docopy | \
     oc replace -f -
 
-rm -f $envpatch $nocopy
-
-restart_fluentd
-fpod=`get_running_pod fluentd`
+redeploy_fluentd
+rm -f $envpatch $nocopy $docopy
 
 write_and_verify_logs 2 || {
     oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1
@@ -283,9 +302,6 @@ write_and_verify_logs 2 || {
 # put back original configuration
 oc replace --force -f $origconfig
 rm -f $origconfig
-
-restart_fluentd
-fpod=`get_running_pod fluentd`
 
 write_and_verify_logs 1 || {
     oc get events -o yaml > $ARTIFACT_DIR/all-events.yaml 2>&1


### PR DESCRIPTION
Bug 1477513 - [3.4] Data loss of logs can occur if fluentd pod is terminated/restarted when Elasticsearch is unavailable

Backporting "Impl fluentd file buffer [1]" with dependent patches [2] and [3]

[1] - commit 6252ba1d1ae2695a51795339478b2f0a876bced3
[2] - allow flush_interval to be tunable; name tunable depending on output
       (commit a9a14f5f79d05cf4a14ef188a5c9d937063b1760)
[3] - Introducing following environment variables with the initial value for fluentd.
       (commit 3818101b713d92f11a1ff33fe44f6d735fda2eda)
