### PR TITLE
Bug 1493188 - operations namespace logs not sent to .operations index

### DIFF
--- a/fluentd/configs.d/openshift/filter-retag-journal.conf
+++ b/fluentd/configs.d/openshift/filter-retag-journal.conf
@@ -57,12 +57,12 @@
   # k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2
   # we filter these logs through the kibana_transform.conf filter
   rewriterule1 CONTAINER_NAME ^k8s_kibana\. kubernetes.journal.container.kibana
-  # mark container logs in default namespace/project as system logs
-  rewriterule2 CONTAINER_NAME ^k8s_[^\.]+\.[^_]+_[^_]+_default_ kubernetes.journal.container._default_
-  # mark openshift-infra container logs as system logs
-  rewriterule3 CONTAINER_NAME ^k8s_[^\.]+\.[^_]+_[^_]+_openshift-infra_ kubernetes.journal.container._openshift-infra_
-  # mark openshift container logs as system logs
-  rewriterule4 CONTAINER_NAME ^k8s_[^\.]+\.[^_]+_[^_]+_openshift_ kubernetes.journal.container._openshift_
+  # mark for processing as k8s logs but stored as system logs
+  rewriterule2 CONTAINER_NAME ^k8s_[^_]+_[^_]+_default_ kubernetes.journal.container._default_
+  # mark for processing as k8s logs but stored as system logs
+  rewriterule3 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift-infra_ kubernetes.journal.container._openshift-infra_
+  # mark for processing as k8s logs but stored as system logs
+  rewriterule4 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift_ kubernetes.journal.container._openshift_
   # mark fluentd container logs
   rewriterule5 CONTAINER_NAME ^k8s_.*fluentd kubernetes.journal.container.fluentd
   # this is a kubernetes container

--- a/hack/testing/test-zzz-correct-index-names.sh
+++ b/hack/testing/test-zzz-correct-index-names.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/zzz-correct-index-names.sh

--- a/test/zzz-correct-index-names.sh
+++ b/test/zzz-correct-index-names.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# This is a test suite for correct index naming
+# This test should be run last in the test suite with a
+# well populated elasticsearch containing both indices from
+# the tests as well as indices from openshift and system logs
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+os::util::environment::use_sudo
+
+os::test::junit::declare_suite_start "test/zzz-correct-index-names"
+
+# ensure that _default_, _openshift_, and _openshift-infra_ indices
+# are not present in es
+
+# ensure that _default_, _openshift_, and _openshift-infra_ namespace
+# records are not present in es
+
+# ensure that _default_, _openshift_, and _openshift-infra_ namespace
+# records are present in es-ops
+
+es_pod=$( get_es_pod es )
+es_ops_pod=$( get_es_pod es-ops )
+es_ops_pod=${es_ops_pod:-$es_pod}
+
+for project in default openshift openshift-infra ; do
+    qs='{"query":{"term":{"kubernetes.namespace_name":"'"${project}"'"}}}'
+    os::cmd::expect_success_and_not_text "curl_es $es_pod /_cat/indices" "project.${project}."
+    os::cmd::expect_success_and_text "curl_es $es_pod /project.${project}.*/_count | get_count_from_json" "^0\$"
+    os::cmd::expect_success_and_text "curl_es $es_pod /project.*/_count -X POST -d '$qs' | get_count_from_json" "^0\$"
+    if [ "$es_pod" != "$es_ops_pod" ] ; then
+        os::cmd::expect_success_and_not_text "curl_es $es_ops_pod /_cat/indices" "project.${project}."
+        os::cmd::expect_success_and_text "curl_es $es_ops_pod /project.${project}.*/_count | get_count_from_json" "^0\$"
+        os::cmd::expect_success_and_text "curl_es $es_ops_pod /project.*/_count -X POST -d '$qs' | get_count_from_json" "^0\$"
+    fi
+    # there will almost always be logs from the default namespace from router and registry
+    # there will almost never be logs from openshift and openshift-infra
+    if [ "$project" = "default" ] ; then
+        os::cmd::expect_success_and_not_text "curl_es $es_ops_pod /.operations.*/_count -X POST -d '$qs' | get_count_from_json" "^0\$"
+    fi
+done


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1493188
The format of the CONTAINER_NAME field changed from
k8s_container-name.container-hash_ ...
to
k8s_container-name_ ....
which caused problems for the retag filter.  Since we don't care about
the value of container-hash in this context, just ignore it.

Also added some test to ensure that operations namespace logs end up
in es-ops in the .operations.* indices and nowhere else.

(cherry picked from commit e29f72f7e38e8e70b975f1284efe8514c1f32ac9)
[test]