### PR TITLE
Bug 1493188 - operations namespace logs not sent to .operations index

### DIFF
--- a/fluentd/configs.d/openshift/filter-retag-journal.conf
+++ b/fluentd/configs.d/openshift/filter-retag-journal.conf
@@ -57,12 +57,12 @@
   # k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2
   # we filter these logs through the kibana_transform.conf filter
   rewriterule1 CONTAINER_NAME ^k8s_kibana\. kubernetes.journal.container.kibana
-  # mark container logs in default namespace/project as system logs
-  rewriterule2 CONTAINER_NAME ^k8s_[^\.]+\.[^_]+_[^_]+_default_ kubernetes.journal.container._default_
-  # mark openshift-infra container logs as system logs
-  rewriterule3 CONTAINER_NAME ^k8s_[^\.]+\.[^_]+_[^_]+_openshift-infra_ kubernetes.journal.container._openshift-infra_
-  # mark openshift container logs as system logs
-  rewriterule4 CONTAINER_NAME ^k8s_[^\.]+\.[^_]+_[^_]+_openshift_ kubernetes.journal.container._openshift_
+  # mark for processing as k8s logs but stored as system logs
+  rewriterule2 CONTAINER_NAME ^k8s_[^_]+_[^_]+_default_ kubernetes.journal.container._default_
+  # mark for processing as k8s logs but stored as system logs
+  rewriterule3 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift-infra_ kubernetes.journal.container._openshift-infra_
+  # mark for processing as k8s logs but stored as system logs
+  rewriterule4 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift_ kubernetes.journal.container._openshift_
   # mark fluentd container logs
   rewriterule5 CONTAINER_NAME ^k8s_.*fluentd kubernetes.journal.container.fluentd
   # this is a kubernetes container


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1493188
The format of the CONTAINER_NAME field changed from
k8s_container-name.container-hash_ ...
to
k8s_container-name_ ....
which caused problems for the retag filter.  Since we don't care about
the value of container-hash in this context, just ignore it.

Also added some test to ensure that operations namespace logs end up
in es-ops in the .operations.* indices and nowhere else.

(cherry picked from commit e29f72f7e38e8e70b975f1284efe8514c1f32ac9)
(cherry picked from commit afdd6b69441d5c3229575313793bff2bab83c28f)
The tests are omitted for the release-1.5 branch

@jcantrill please merge - no CI for 1.5 branch