### PR TITLE
eventrouter: submodule and tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "kibana-proxy"]
 	path = kibana-proxy
 	url = https://github.com/fabric8io/openshift-auth-proxy.git
+[submodule "eventrouter"]
+	path = eventrouter
+	url = https://github.com/openshift/eventrouter

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -21,3 +21,4 @@ OS_BUILD_IMAGE_ARGS="-f elasticsearch/${dockerfile}" os::build::image "${tag_pre
 OS_BUILD_IMAGE_ARGS="-f kibana/${dockerfile}" os::build::image "${tag_prefix}-logging-kibana"               kibana
 OS_BUILD_IMAGE_ARGS="-f curator/${dockerfile}" os::build::image "${tag_prefix}-logging-curator"             curator
 OS_BUILD_IMAGE_ARGS="-f kibana-proxy/${dockerfile}" os::build::image "${tag_prefix}-logging-auth-proxy"     kibana-proxy
+OS_BUILD_IMAGE_ARGS="-f eventrouter/${dockerfile}" os::build::image "${tag_prefix}-logging-eventrouter"     eventrouter

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -38,6 +38,7 @@ images=(
   ${PREFIX}logging-elasticsearch
   ${PREFIX}logging-kibana
   ${PREFIX}logging-auth-proxy
+  ${PREFIX}logging-eventrouter
 )
 
 PUSH_OPTS=""

--- a/hack/testing/test-eventrouter.sh
+++ b/hack/testing/test-eventrouter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/eventrouter.sh

--- a/test/eventrouter.sh
+++ b/test/eventrouter.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This is a test suite for the eventrouter
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+os::test::junit::declare_suite_start "test/eventrouter"
+
+function warn_nonformatted() {
+    local index=$1
+    # check if eventrouter and fluentd with correct ViaQ plugin are deployed
+    local non_formatted_event_count=$( curl_es $espod /$index/_count?q=verb:* | get_count_from_json )
+    if [ "$non_formatted_event_count" != 0 ]; then
+        os::log::warning "$non_formatted_event_count events from eventrouter in index $index were not processed by ViaQ fluentd plugin"
+    fi
+}
+function get_eventrouter_pod() {
+    oc get pods --namespace=default -l component=eventrouter --no-headers | awk '$3 == "Running" {print $1}' 
+}
+
+evpod=$( get_eventrouter_pod )
+if [ -z "$evpod" ]; then
+    os::log::warning "Eventrouter not deployed"
+else
+    espod=$( get_es_pod es )
+
+    warn_nonformatted '/project.*'
+    warn_nonformatted '/.operations.*/'
+
+    os::cmd::expect_success_and_not_text "curl_es $espod /.operations.*/_count?q=kubernetes.event.verb:* | get_count_from_json" "^0\$"
+fi


### PR DESCRIPTION
I would like to add the eventrouter as a submodule to the origin repository similarly to how auth-proxy is. I also tried to add a simple test that verifies only that events from eventrouter were inserted to ES and passed ViaQ plugin in fluentd.

Depends on:
- [ ] https://github.com/openshift/origin-aggregated-logging/pull/573
- [ ] https://github.com/openshift/openshift-ansible/pull/4973
- [x] having ViaQ plugin 0.0.10 in fluentd image