### PR TITLE
Allow using both json-file and journald

### DIFF
--- a/docs/checking-efk-health.md
+++ b/docs/checking-efk-health.md
@@ -11,10 +11,9 @@ Check Fluentd logs for the message that it has read in its config file:
 ```
 
 Verify that Fluentd has been able to start reading in log files
-by checking the contents of `/var/log/node.log.pos` and `/var/log/es-containers.log.pos`.
-The `node.log.pos` file is a position file that keeps track of where Fluentd is in reading the syslog log files.  
-The `es-containers.log.pos` is a similiar file to keep track of where fluentd is in reading the docker log files (i.e `/var/log/containers`).  
-If the OpenShift node is configured to use the systemd journal as the log source, the position file is `/var/log/journal.pos`.
+by checking the contents of `/var/log/es-containers.log.pos` and `/var/log/journal.pos`.
+The `es-containers.log.pos` keeps track of where fluentd is in reading the docker log files (i.e `/var/log/containers`).  
+The `/var/log/journal.pos` keeps track of where fluentd is in reading the journal.
 
 You can view the journal starting at the location where fluentd last read it by using a command like the following (as root):
 

--- a/docs/log-drivers-and-throttling.md
+++ b/docs/log-drivers-and-throttling.md
@@ -1,0 +1,78 @@
+Introduction
+============
+
+When Fluentd is collecting node logs, the main sources are the system logs from
+the journal, and container logs, the source of which depends on the `docker
+--log-driver` configuration:
+
+* `journald` - container logs are written to the journal and denoted with the
+  `CONTAINER_NAME` field
+* `json-file` - container logs are made available in `/var/log/containers`
+  (through a long a complicated process of several layers of symlinks).
+
+Fluentd will always read system logs from the journal, and will always read
+container logs from both `journald` and `json-file`.
+
+### JSON file container log parameters ###
+
+These are provided for documentation purposes only.  Do not set these unless
+you know what you are doing.
+
+* `JSON_FILE_PATH` - default `/var/log/containers/*.log` - full path and filename
+match pattern for docker json-file log driver logs
+* `JSON_FILE_POS_FILE` - default `/var/log/es-containers.log.pos` - full path
+and filename for the Fluentd `in_tail` position file.  This file should be on a
+persistent volume (e.g. bind mounted from the host) so that Fluentd can resume
+reading from where it left off if the Fluentd pod is restarted.
+* `JSON_FILE_READ_FROM_HEAD` - default `true` - if `false`, start reading from
+the tail/end of the file.  If the `JSON_FILE_POS_FILE` exists and has an
+entry for this file, the `JSON_FILE_READ_FROM_HEAD` setting is ignored.
+
+### journal parameters ###
+
+These are provided for documentation purposes only.  Do not set these unless
+you know what you are doing.
+
+* `JOURNAL_SOURCE` - no default - Fluentd will attempt to use
+`/var/log/journal` if it exists, otherwise, it will fall back on
+`/run/log/journal`.
+* `JOURNAL_POS_FILE` - default `/var/log/journal.pos` - full path
+and filename for the Fluentd `in_systemd` position file.  This file should be on a
+persistent volume (e.g. bind mounted from the host) so that Fluentd can resume
+reading from where it left off if the Fluentd pod is restarted.
+* `JOURNAL_READ_FROM_HEAD` - default `false` - if `false`, start reading from
+the tail/end of the journal.  If the `JOURNAL_POS_FILE` exists, the
+`JOURNAL_READ_FROM_HEAD` setting is ignored.  **WARNING** if this is set to
+`true`, it may take hours, if not longer, until Fluentd reaches the end of the
+journal, so be aware that it may take long time for recent records to show up
+in Elasticsearch.
+* `JOURNAL_FILTERS_JSON` - default `[]` - see
+[systemd filter](http://www.rubydoc.info/gems/systemd-journal/Systemd%2FJournal%2FFilterable%3Afilter)
+documentation for more information.
+
+### Log throttling ###
+
+Log throttling currently only works for container logs read by the Fluentd
+`in_tail` input, from files written by the docker `json-file` log driver.  It
+relies on the
+(`read_lines_limit`)[https://docs.fluentd.org/v0.12/articles/in_tail#readlineslimit]
+feature to make Fluentd read one or a few lines at a time rather than the
+default `1000`.  It also relies on the fact that the JSON log files in
+`/var/log/containers` have names in the following format:
+`/var/log/containers/POD-NAME_NAMESPACE-NAME_CONTAINER-NAME-CONTAINER-ID.log`
+That is, the name of the namespace to be throttled can be matched by the
+pattern `/var/log/containers/*_NAMESPACE-NAME_*.log`.  If this name format
+changes, throttling will not work.
+
+To configure log throttling:
+
+Edit the logging-fluentd configmap - the `throttle-config.yaml` setting:
+
+    PROJECT-NAME:
+      read_lines_limit: NUMBER
+    ANOTHER-PROJECT-NAME:
+      read_lines_limit: ANOTHER-NUMBER
+
+Where `PROJECT-NAME` is the name of the project whose logs you want to
+throttle, and `NUMBER` is the number of lines to read at a time.  The default
+is `1000`.  A lower number means more throttling.  `1` is the minimum.

--- a/docs/mux-logging-service.md
+++ b/docs/mux-logging-service.md
@@ -216,7 +216,9 @@ from whichever of these it is configured to read from.
 using the ViaQ data model (i.e. the `kubernetes` and `docker` namespaces).
 
 `Filter syslog` takes the `/var/log/messages` or journald system log input and
-formats it using the ViaQ data model (i.e. the `systemd` namespace).
+formats it using the ViaQ data model (i.e. the `systemd` namespace).  **NOTE**
+reading from `/var/log/messages` is no longer supported.  `journald` is always
+used for system logs.
 
 `Filter k8s meta` looks up Kubernetes metadata for container log records from
 the Kubernetes server such as namespace\_uuid, pod\_uuid, labels, and

--- a/fluentd/configs.d/openshift/input-pre-systemd.conf
+++ b/fluentd/configs.d/openshift/input-pre-systemd.conf
@@ -1,0 +1,9 @@
+<source>
+  @type systemd
+  @label @INGRESS
+  path "#{ENV['JOURNAL_SOURCE'] || '/run/log/journal'}"
+  pos_file "#{ENV['JOURNAL_POS_FILE'] || '/var/log/journal.pos'}"
+  filters "#{ENV['JOURNAL_FILTERS_JSON'] || '[]'}"
+  tag journal
+  read_from_head "#{ENV['JOURNAL_READ_FROM_HEAD'] || 'false'}"
+</source>

--- a/fluentd/generate_throttle_configs.rb
+++ b/fluentd/generate_throttle_configs.rb
@@ -2,62 +2,71 @@ require 'yaml'
 require 'date'
 require 'logger'
 
+log_level = ENV['LOG_LEVEL'] || 'WARN'
 @log = Logger.new(STDOUT)
-@log.level = Logger::WARN
 
-@Valid_Settings = {"read_lines_limit" => "number"}
+begin
+  @log.level = eval("Logger::#{log_level}")
+rescue
+  @log.level = Logger::WARN
+  @log.warn "#{log_level} is not a valid value. Must be one of: DEBUG, WARN, INFO, ERROR"
+  @log.warn "Setting log level to WARN"
+end
 
-def get_file_name(name, isSyslog)
+ENV.sort.each do |entry|
+  @log.debug entry
+end if @log.debug?
+
+DEFAULT_OPS_PROJECTS = ['default', 'openshift', 'openshift-infra']
+DEFAULT_FILENAME = "/etc/fluent/configs.d/user/throttle-config.yaml"
+
+VALID_SETTINGS = {"read_lines_limit" => "number"}
+
+def json_pos_file
+  ENV['JSON_FILE_POS_FILE'] || '/var/log/es-containers.log.pos'
+end
+
+def get_file_name(name)
   ## file_name follows pattern: gen-#{name}-YYYYMMDD.conf ##
 
-  file_name = "/etc/fluent/configs.d/dynamic/input-docker-" unless isSyslog
-  file_name = "/etc/fluent/configs.d/dynamic/input-syslog-" if isSyslog
+  file_name = '/etc/fluent/configs.d/dynamic/input-docker-'
   file_name << name
-  file_name << "-"
-  file_name << Date.today.strftime("%Y%m%d")
-  file_name << ".conf"
+  file_name << '-'
+  file_name << Date.today.strftime('%Y%m%d')
+  file_name << '.conf'
 
   return file_name
 end
 
-def seed_file(file_name, project, isSyslog)
+def seed_file(file_name, project)
 
-  pos_file = "/var/log/es-containers.log.pos"
-  if project.eql?(".operations")
-    if isSyslog
-      path = "/var/log/messages"
-      pos_file = "/var/log/node.log.pos"
-    else
-      path = get_project_pattern("default")
-      path << ","
-      path << get_project_pattern("openshift")
-      path << ","
-      path << get_project_pattern("openshift-infra")
-    end
+  if project.eql?('.operations')
+    path = DEFAULT_OPS_PROJECTS.map{|p| get_project_pattern(p)}.join(',')
   else
     path = get_project_pattern(project)
   end
 
   File.open(file_name, 'w') { |file|
+    @log.debug "Seeding #{file_name} with path: '#{path}' and pos_file: '#{json_pos_file}'"
     file.write(<<-CONF)
 <source>
   @type tail
   @label @INGRESS
   path #{path}
-  pos_file #{pos_file}
+  pos_file #{json_pos_file}
     CONF
   }
 end
 
+def write_to_file(project, key, value)
 
-def write_to_file(project, key, value, isSyslog)
-
-  file_name = get_file_name(project, isSyslog)
+  file_name = get_file_name(project)
 
   # check if the file already exists, if not create it
-  seed_file(file_name, project, isSyslog) if !File.exist?(file_name)
+  seed_file(file_name, project) if !File.exist?(file_name)
 
   File.open(file_name, 'a') { |file|
+    @log.debug "Writing key: '#{key}' value: '#{value}' to file: #{file_name}"
     file.write(<<-CONF)
   #{key} #{value}
     CONF
@@ -65,118 +74,56 @@ def write_to_file(project, key, value, isSyslog)
 
 end
 
-def close_file(project, isSyslog)
-  file_name = get_file_name(project, isSyslog)
+def close_file(project)
+  file_name = get_file_name(project)
 
-  if isSyslog
-    File.open(file_name, 'a') { |file|
-      file.write(<<-CONF)
-  tag system.*
-  format multiline
-  # Begin possible multiline match: "Mmm DD HH:MM:SS "
-  format_firstline /^[A-Z][a-z]{2}\\s+[0-3]?[0-9]\\s+[0-2][0-9]:[0-5][0-9]:[0-6][0-9]\\s/
-  # extract metadata from same line that matched format_firstline
-  format1 /^(?<time>\\S+\\s+\\S+\\s+\\S+)\\s+(?<host>\\S+)\\s+(?<ident>[\\w\\/\\.\\-]*)(?:\\[(?<pid>[0-9]+)\\])?[^\\:]*\\:\\s*(?<message>.*)$/
-  time_format %b %d %H:%M:%S
-  read_from_head true
-  keep_time_key true
-</source>
-    CONF
-    } if File.exist?(file_name)
-  else
-    File.open(file_name, 'a') { |file|
-      file.write(<<-CONF)
+  File.open(file_name, 'a') { |file|
+    @log.debug "Closing file: #{file_name}"
+    file.write(<<-CONF)
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
   format json
   keep_time_key true
-  read_from_head true
+  read_from_head "#{ENV['JSON_FILE_READ_FROM_HEAD'] || 'true'}"
 </source>
     CONF
-    } if File.exist?(file_name)
-  end
+  } if File.exist?(file_name)
 end
 
 def create_default_docker(excluded)
 
-  file_name = "/etc/fluent/configs.d/dynamic/input-docker-default-docker.conf"
+  file_name = '/etc/fluent/configs.d/dynamic/input-docker-default-docker.conf'
 
   File.open(file_name, 'w') { |file|
+    @log.debug "Creating default docker input config file #{file_name}"
     file.write(<<-CONF)
 <source>
   @type tail
   @label @INGRESS
-  path /var/log/containers/*.log
-  pos_file /var/log/es-containers.log.pos
+  path "#{ENV['JSON_FILE_PATH'] || '/var/log/containers/*.log'}"
+  pos_file "#{ENV['JSON_FILE_POS_FILE'] || '/var/log/es-containers.log.pos'}"
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
   format json
   keep_time_key true
-  read_from_head true
+  read_from_head "#{ENV['JSON_FILE_READ_FROM_HEAD'] || 'true'}"
   exclude_path #{excluded}
 </source>
     CONF
   }
 end
 
-def create_default_syslog()
-
-  file_name = "/etc/fluent/configs.d/dynamic/input-syslog-default-syslog.conf"
-
-  if ENV['USE_JOURNAL'] == "true"
-    File.open(file_name, 'w') { |file|
-      file.write(<<-CONF)
-<source>
-  @type systemd
-  @label @INGRESS
-  path "#{ENV['JOURNAL_SOURCE'] || '/run/log/journal'}"
-  pos_file /var/log/journal.pos
-  tag journal
-    CONF
-      # workaround for https://github.com/reevoo/fluent-plugin-systemd/issues/19
-      if ENV['JOURNAL_READ_FROM_HEAD'] == "true"
-        file.write(<<-CONF2)
-  read_from_head true
-      CONF2
-      end
-      file.write(<<-CONF3)
-</source>
-    CONF3
-    }
-  else
-    File.open(file_name, 'w') { |file|
-      file.write(<<-CONF)
-<source>
-  @type tail
-  @label @INGRESS
-  path /var/log/messages
-  pos_file /var/log/node.log.pos
-  tag system.*
-  format multiline
-  # Begin possible multiline match: "Mmm DD HH:MM:SS "
-  format_firstline /^[A-Z][a-z]{2}\\s+[0-3]?[0-9]\\s+[0-2][0-9]:[0-5][0-9]:[0-6][0-9]\\s/
-  # extract metadata from same line that matched format_firstline
-  format1 /^(?<time>\\S+\\s+\\S+\\s+\\S+)\\s+(?<host>\\S+)\\s+(?<ident>[\\w\\/\\.\\-]*)(?:\\[(?<pid>[0-9]+)\\])?[^\\:]*\\:\\s*(?<message>.*)$/
-  time_format %b %d %H:%M:%S
-  read_from_head true
-  keep_time_key true
-</source>
-    CONF
-    }
-  end
-end
-
 def validate(key, value)
   # if the key is in valid settings, validate the value by required type
-  if @Valid_Settings.keys.include?(key)
-    case @Valid_Settings[key]
-    when "time"
+  if VALID_SETTINGS.keys.include?(key)
+    case VALID_SETTINGS[key]
+    when 'time'
       valid = value.to_s.match('^\d+[sSmMhH]$') { |m| if m.nil?; false; else m.to_s.match('\d+').to_s.to_i > 0 end }
-    when "size"
+    when 'size'
       valid = value.to_s.match('^\d+[kKmMgG]$') { |m| if m.nil?; false; else m.to_s.match('\d+').to_s.to_i > 0 end }
-    when "number"
+    when 'number'
       valid = value.to_s.match('^\d+$') { |m| if m.nil?; false; else m.to_s.to_i > 0 end }
-    when "boolean"
+    when 'boolean'
       valid = value.to_s.match('^true$|^false$') { |m| !m.nil? }
     else
       #unknown type
@@ -195,53 +142,60 @@ def validate(key, value)
 end
 
 def get_project_pattern(name)
-
-  project_pattern = "/var/log/containers/*_"
-  project_pattern << name
-  project_pattern << "_*.log"
+  "/var/log/containers/*_#{name}_*.log"
 end
 
-filename = "/etc/fluent/configs.d/user/throttle-config.yaml"
-
-parsed = ""
-parsed = YAML.load_file(filename) if File.exists?(filename)
+filename = ENV['THROTTLE_CONF_LOCATION'] || DEFAULT_FILENAME
+begin
+  parsed = if File.exists?(filename) && (hsh = YAML.load_file(filename)) && hsh.respond_to?(:map)
+             @log.debug "throttle hash #{hsh}"
+             Hash[hsh.map{|k,v|[k,v]}]
+           else
+             Hash.new
+           end
+rescue Exception => ex
+  @log.warn "Could not parse YAML file #{filename} : #{ex} - ignoring..."
+  parsed = Hash.new
+end
 
 excluded = Array.new
-excludeSyslog = false
-
 # We do not yet support throttling logs read from the journal
-unless ENV['USE_JOURNAL'] == "true"
-  parsed.each { |project|
-    name = project[0]
-    options = project[1]
+# So we don't support throttling operations logs here - use the journald
+# journald.conf to do that
+parsed.each { |name,options|
+  @log.info("Evaluating log throttle settings from #{filename} #{name} #{options}...")
+  # YAML parser allows some strange things . . .
+  unless name.class.eql?(String)
+    @log.warn "Invalid value #{name} for project name -- ignoring..."
+    next
+  end
+  unless options.class.eql?(Hash)
+    @log.warn "Invalid value #{options} for options project #{name} -- ignoring..."
+    next
+  end
 
-    options.each_pair { |k,v|
+  needclose = false
+  options.each_pair { |k,v|
+    @log.debug("Evaluating throttling for project '#{name}'")
+    if validate(k,v)
+      write_to_file(name, k, v)
+      needclose = true
 
-      if validate(k,v)
-        write_to_file(name, k, v, false)
-        # build the list of paths the exclude
-        excluded.push(get_project_pattern(name)) unless name.eql?(".operations")
-
-        if name.eql?(".operations")
-          excluded.push(get_project_pattern("default"))
-          excluded.push(get_project_pattern("openshift"))
-          excluded.push(get_project_pattern("openshift-infra"))
-
-          excludeSyslog = true
-          write_to_file(name, k, v, true)
+      if name.eql?('.operations')
+        @log.debug("Found throttling settings for operations. Excluding projects: #{DEFAULT_OPS_PROJECTS}")
+        DEFAULT_OPS_PROJECTS.each do |p|
+          excluded.push(get_project_pattern(p))
         end
       else
-        @log.warn "Invalid key/value pair {\"#{k}\":\"#{v}\"} provided -- ignoring..."
+        excluded.push(get_project_pattern(name))
       end
-      #}
-    } if !options.nil?
+    else
+      @log.warn "Invalid key/value pair {\"#{k}\":\"#{v}\"} provided -- ignoring..."
+    end
+  } if !options.nil?
 
-    # if file was created, close it here
-    close_file(name, false)
-    close_file(name, true) if name.eql?(".operations")
+  # if file was created, close it here
+  close_file(name) if needclose
+}
 
-  } if parsed.respond_to?( :each )
-end
-
-create_default_docker(excluded) unless ENV['USE_JOURNAL'] == "true"
-create_default_syslog() unless excludeSyslog
+create_default_docker(excluded)

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -30,21 +30,17 @@ docker_uses_journal() {
 }
 
 if [ -z "${USE_MUX:-}" -o "${USE_MUX:-}" = "false" ] ; then
-    if [ -z "${USE_JOURNAL:-}" -o "${USE_JOURNAL:-}" = true ] ; then
-        if [ -z "${JOURNAL_SOURCE:-}" ] ; then
-            if [ -d /var/log/journal ] ; then
-                export JOURNAL_SOURCE=/var/log/journal
-            else
-                export JOURNAL_SOURCE=/run/log/journal
-            fi
+    if [ -z "${JOURNAL_SOURCE:-}" ] ; then
+        if [ -d /var/log/journal ] ; then
+            export JOURNAL_SOURCE=/var/log/journal
+        else
+            export JOURNAL_SOURCE=/run/log/journal
         fi
-        if [ -z "${USE_JOURNAL:-}" ] ; then
-            if docker_uses_journal ; then
-                export USE_JOURNAL=true
-            else
-                export USE_JOURNAL=false
-            fi
-        fi
+    fi
+    if docker_uses_journal ; then
+        export USE_JOURNAL=true
+    else
+        export USE_JOURNAL=false
     fi
 else
     # mux requires USE_JOURNAL=true so that the k8s meta plugin will look
@@ -74,13 +70,10 @@ if [ "${USE_MUX:-}" = "true" ] ; then
 else
     ruby generate_throttle_configs.rb
     rm -f $CFG_DIR/openshift/*mux*.conf
-    # assume mux doesn't actually read from the journal file
-    if [ "${USE_JOURNAL:-}" = "true" ] ; then
-        # have output plugins handle back pressure
-        # if you want the old behavior to be forced anyway, set env
-        # BUFFER_QUEUE_FULL_ACTION=exception
-        export BUFFER_QUEUE_FULL_ACTION=${BUFFER_QUEUE_FULL_ACTION:-block}
-    fi
+    # have output plugins handle back pressure
+    # if you want the old behavior to be forced anyway, set env
+    # BUFFER_QUEUE_FULL_ACTION=exception
+    export BUFFER_QUEUE_FULL_ACTION=${BUFFER_QUEUE_FULL_ACTION:-block}
 fi
 
 # this is the list of keys to remove when the record is transformed from the raw systemd journald

--- a/hack/testing/check-logs.go
+++ b/hack/testing/check-logs.go
@@ -16,7 +16,7 @@ func main() {
 	kibana_pod := args[0]
 	es_svc := args[1]
 	index := args[2]
-	filePath := args[3]
+	filePath := args[3] // set to "journal" to look in the journal
 	querySize := args[4]
 	userName := args[5]
 	userToken := args[6]
@@ -94,7 +94,7 @@ func main() {
 		message := record.Fields.Message[0]
 
 		searchCmd := ""
-		if journal == "true" {
+		if filePath == "journal" || journal == "true" {
 			// escape certain characters that were being interpreted by bash
 			message = strings.Replace(message, `\`, `\\`, -1)
 			message = strings.Replace(message, `"`, `\"`, -1)

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -22,36 +22,6 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 
 # HACK HACK HACK
-# richm 2017-09-18 rsyslog is rate limiting the journal when running
-# with json-file - messages show up in the journal but not in
-# /var/log/messages - increase the limits for testing
-if docker_uses_journal ; then
-    os::log::info docker uses journal, skipping
-else
-    os::log::info docker uses json-file - increase rate limits for rsyslog
-    restart=
-    if sudo grep -q -i '^[$]IMJournalRatelimitInterval' /etc/rsyslog.conf ; then
-        os::log::info Keeping limit $( sudo grep -i '^[$]IMJournalRatelimitInterval' /etc/rsyslog.conf )
-    else
-        # default is 600, so increase by a factor of 10
-        sudo sed -i '/^[$]IMJournalStateFile/a\
-$IMJournalRatelimitInterval 60' /etc/rsyslog.conf
-        restart=1
-    fi
-    if sudo grep -q -i '^[$]IMJournalRatelimitBurst' /etc/rsyslog.conf ; then
-        os::log::info Keeping limit $( sudo grep -i '^[$]IMJournalRatelimitBurst' /etc/rsyslog.conf )
-    else
-        # default is 20000
-        sudo sed -i '/^[$]IMJournalStateFile/a\
-$IMJournalRatelimitBurst 20000' /etc/rsyslog.conf
-        restart=1
-    fi
-    if [ -n "$restart" ] ; then
-        sudo systemctl restart rsyslog
-    fi
-fi
-
-# HACK HACK HACK
 # There seems to be some sort of performance problem - richm 2017-08-15
 # not sure what has changed, but now running an all-in-one for CI, with both
 # openshift master and node running as systemd services logging to the journal

--- a/hack/testing/test-read-throttling.sh
+++ b/hack/testing/test-read-throttling.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/read-throttling.sh

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -259,10 +259,10 @@ docker_uses_journal() {
 wait_for_fluentd_ready() {
     local timeout=${1:-60}
     # wait until fluentd is actively reading from the source (journal or files)
+    os::cmd::try_until_success "sudo test -f /var/log/journal.pos" $(( timeout * second ))
     if docker_uses_journal ; then
-        os::cmd::try_until_success "sudo test -f /var/log/journal.pos" $(( timeout * second ))
+        : # done
     else
-        os::cmd::try_until_success "sudo test -f /var/log/node.log.pos" $(( timeout * second ))
         os::cmd::try_until_success "sudo test -f /var/log/es-containers.log.pos" $(( timeout * second ))
     fi
 }

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -82,8 +82,8 @@ for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARC
 	for index in $( curl_es "${elasticsearch_pod}" '/_cat/indices?h=index' ); do
 		if [[ "${index}" == ".operations"* ]]; then
 			# If this is an operations index, we will be searching
-			# on disk for it
-			index_search_path="/var/log/messages"
+			# the journal for it
+			index_search_path="journal"
 		elif [[ "${index}" == "project."* ]]; then
 			# Otherwise, we will find it in the container log, which
 			# we can identify with the UUID

--- a/test/future_dated_log.sh
+++ b/test/future_dated_log.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-# This logging test ensures that a log message created
-# one hour in the future and added to /var/log/messages
-# will show up in the Elasticsearch log as well as that
-# all Fluentd pods have the same time-zone as the node.
+# This logging test ensures that all Fluentd pods have the
+# same time-zone as the node.
 #
 # This script expects the following environment variables:
 #  - OAL_ELASTICSEARCH_COMPONENT: the component labels that
@@ -15,41 +13,9 @@ os::util::environment::use_sudo
 
 os::test::junit::declare_suite_start "test/future_dated_log"
 
-fluentd_prior_log_dir="${LOG_DIR}/fluentd/prior"
-mkdir -p "${fluentd_prior_log_dir}"
-
 for fluentd_pod in $( oc get pods --selector component=fluentd  -o jsonpath='{ .items[*].metadata.name }' ); do
 	os::log::info "Ensuring Fluentd pod ${fluentd_pod} timezone matches node timezone..."
 	os::cmd::expect_success_and_text "oc exec ${fluentd_pod} -- date +%Z" "$( date +%Z )"
-	oc logs "${fluentd_pod}" > "${fluentd_prior_log_dir}/${fluentd_pod}.log"
 done
-
-if docker_uses_journal; then
-    os::log::info "The rest of the test is not applicable when using the journal - skipping"
-    exit 0
-fi
-
-# NOTE: can't use `logger` for this because we need complete
-# control over the date and format so have to use sudo to
-# write directly to /var/log/messages
-message_date="$( date -u +"%b %d %H:%M:%S" --date="1 hour hence" )"
-message_uuid="$( uuidgen )"
-message="${message_date} localhost ${message_uuid}: ${message_uuid} message from test/future_dated_log"
-echo "${message}" | ${USE_SUDO:+sudo} tee -a /var/log/messages >/dev/null
-
-for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARCH_COMPONENT}" -o jsonpath='{ .items[*].metadata.name }' ); do
-	os::log::info "Ensuring Elasticsearch pod ${elasticsearch_pod} persisted the message added to /var/log/messages..."
-	os::cmd::try_until_text "curl_es '${elasticsearch_pod}' '/.operations*/_count?q=systemd.u.SYSLOG_IDENTIFIER:${message_uuid}' | python -c 'import json, sys; print json.load(sys.stdin)[\"count\"];'" "1"
-done
-
-fluentd_posterior_log_dir="${LOG_DIR}/fluentd/posterior"
-mkdir -p "${fluentd_posterior_log_dir}"
-
-for fluentd_pod in $( oc get pods --selector component=fluentd  -o jsonpath='{ .items[*].metadata.name }' ); do
-	oc logs "${fluentd_pod}" > "${fluentd_posterior_log_dir}/${fluentd_pod}.log"
-done
-
-os::log::info "Checking that Fluentd had no new messages..."
-os::cmd::expect_success "diff --new-file --text --recursive ${fluentd_prior_log_dir} ${fluentd_posterior_log_dir}"
 
 os::test::junit::declare_suite_end

--- a/test/read-throttling.sh
+++ b/test/read-throttling.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# test fluentd json-file read throttling
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+
+# does not work with the journald log driver
+if docker_uses_journal ; then
+    os::log::info This test only works with the json-file docker log driver
+    exit 0
+fi
+
+trap os::test::junit::reconcile_output EXIT
+os::util::environment::use_sudo
+
+os::test::junit::declare_suite_start "test/read-throttling"
+
+# save current fluentd daemonset
+saveds=$( mktemp )
+oc get daemonset logging-fluentd -o yaml > $saveds
+
+# save current fluentd configmap
+savecm=$( mktemp )
+oc get configmap logging-fluentd -o yaml > $savecm
+
+cleanup() {
+    local return_code="$?"
+    set +e
+
+    # dump the pod before we restart it
+    if [ -n "${fpod:-}" ] ; then
+        oc logs $fpod > $ARTIFACT_DIR/$fpod.log 2>&1
+    fi
+    os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+    os::cmd::try_until_failure "oc get pod $fpod"
+    if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
+        os::log::debug "$( oc replace --force -f $savecm 2>&1 )"
+    fi
+    if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
+        os::log::debug "$( oc replace --force -f $saveds 2>&1 )"
+    fi
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
+
+fpod=$( get_running_pod fluentd )
+
+# generate throttle config with invalid YAML
+os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+os::cmd::try_until_failure "oc get pod $fpod"
+os::log::debug "$( oc patch configmap/logging-fluentd --type=json \
+   --patch '[{ "op": "replace", "path": "/data/throttle-config.yaml", "value": "\
+    test-proj: read_lines_limit: bogus-value"}]' )"
+os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+fpod=$( get_running_pod fluentd )
+# should have fluentd log messages like this
+os::cmd::expect_success_and_text "oc logs $fpod" "Could not parse YAML file"
+
+# generate throttle config with a bogus key - verify the correct error
+os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+os::cmd::try_until_failure "oc get pod $fpod"
+os::log::debug "$( oc patch configmap/logging-fluentd --type=json \
+   --patch '[{ "op": "replace", "path": "/data/throttle-config.yaml", "value": "\
+    test-proj:\n  read_lines_limit: bogus-value\nbogus-project:\n  bogus-key: bogus-value"}]' )"
+os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+fpod=$( get_running_pod fluentd )
+# should have fluentd log messages like this
+os::cmd::expect_success_and_text "oc logs $fpod" 'Unknown option "bogus-key"'
+os::cmd::expect_success_and_text "oc logs $fpod" 'Invalid key/value pair {"bogus-key":"bogus-value"} provided -- ignoring...'
+os::cmd::expect_success_and_text "oc logs $fpod" 'Invalid value type matched for "bogus-value"'
+os::cmd::expect_success_and_text "oc logs $fpod" 'Invalid key/value pair {"read_lines_limit":"bogus-value"} provided -- ignoring...'


### PR DESCRIPTION
https://trello.com/c/jmVrTI3q/522-5-allow-using-both-json-file-and-journald-loggingepic-ois-agl-perf
The input configuration is generated at runtime by
fluentd/generate_throttle_configs.rb
This has been changed to always create an input for both journald
and json-file.  I've added some documentation to explain how the
settings work, and how throttling works and how to configure it.
I've added a test to check for throttling configuration errors.
Note: It is not yet possible to have an automated test to see if
throttling is happening, and by how much.
Also gets rid of most usage of USE_JOURNAL and /var/log/messages.  There
is still some vestigal use of /var/log/messages in an old perf test,
and USE_JOURNAL is still used by the k8s meta plugin, and by mux.
Also gets rid of references to node.log.pos.
@jcantrill @nhosoi ptal
[test]