### PR TITLE
Fluentd - one output tag per plugin (3.6 version of #686)

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -138,11 +138,6 @@ export OPS_COPY_HOST OPS_COPY_PORT OPS_COPY_SCHEME OPS_COPY_CLIENT_CERT \
 # If it exists, we could use the label and take advantage.
 # If not, give up one output tag per plugin for now.
 output_label=$( egrep "<label @OUTPUT>" $CFG_DIR/../fluent.conf || : )
-if [ "$output_label" = "" ]; then
-    echo "WARNING: There is no @OUTPUT label declared in /etc/fluent/fluent.conf."
-    echo "         Disabling \"One output tag per plugin feature\" in this deployment."
-    echo "         To enable it, please set <label @OUTPUT> just before the output section."
-fi
 
 # How many outputs?
 if [ -n "${MUX_CLIENT_MODE:-}" ] ; then


### PR DESCRIPTION
Removing "WARNING: There is no @OUTPUT label declared in /etc/fluent/fluent.conf."

(cherry picked from commit 712adeaa63cff4db5e0ecad0b8b9af9f009bfde6)