### PR TITLE
bz#1497937: run oc deploy when installedVersion is >= 1

### DIFF
--- a/deployer/scripts/upgrade.sh
+++ b/deployer/scripts/upgrade.sh
@@ -386,7 +386,7 @@ function patchIfValid() {
 
   if oc patch $object --type=json -p="[$(join , "${actualPatch[@]}")]"; then
     if [[ $isDC = true ]]; then
-      [[ $installedVersion -ge 2 ]] && oc deploy $object --latest
+      [[ $installedVersion -ge 1 ]] && oc deploy $object --latest
 
       waitForChange $currentVersion $object &
       patchPIDs+=( $!)


### PR DESCRIPTION
This patch changes to run `oc deploy $object --latest` when
`installedVersion` >= 1. Without this patch, `oc deploy --latest` will
not be executed and deployer pod will not complete.