### PR TITLE
Raise ES output plugin request timeout to 600s

### DIFF
--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -18,15 +18,13 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '5s'}"
+      flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
       max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_type file
       buffer_path '/var/lib/fluentd/buffer-output-es-config'
-      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
-      # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-      # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-      # buffer to the remote - default is 'exception' because in_tail handles that case
-      buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+      buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
+      request_timeout 600
     </store>

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -18,15 +18,13 @@
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '5s'}"
+      flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '1s'}"
       max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_type file
       buffer_path '/var/lib/fluentd/buffer-output-es-ops-config'
-      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
-      # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-      # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-      # buffer to the remote - default is 'exception' because in_tail handles that case
-      buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
+      buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+      buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+      buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
+      request_timeout 600
     </store>


### PR DESCRIPTION
The most significant change here is to use a request_timeout of 600
seconds for the Elasticsearch output plugin, replacing the plugin's
default of 5 seconds. If an Elasticsearch instance takes a long time to
process a request, timing out and retransmitting just adds additional
load, and duplicates data (since we don't generate our own IDs for each
record).  Raising the request timeout prevents a "fall-off-a-cliff"
scenario where all clients start retransmitting the same data, never
making any forward progress due to the timeouts.

In addition, use the "block" action when the buffer queue becomes full
for the Elasticsearch output plugin. Using the blocking behavior
combined with the increased request timeout allows for a normal back-
pressure system to queue up larger, more efficient chunk sizes (which
often take longer than the default 5s timeout).

Finally, we use a 1 second flush interval by default so that we emit
data early and often to keep the request payloads towards the smaller
size. Should the payloads grow in that one second, we default to 8 MB
chunks as a maximum for what is sent to Elasticsearch, and only queue 32
of them total (256 MB total, not including accounting overhead).

See also [BZ 1497836 "default fluentd elasticsearch plugin request
timeout too short by default, leads to potential log loss and stalled
log flow"](https://bugzilla.redhat.com/show_bug.cgi?id=1497836).