### PR TITLE
use record['fieldname'] instead of 'fieldname' - was throwing exception

### DIFF
--- a/fluentd/configs.d/openshift/filter-kibana-transform.conf
+++ b/fluentd/configs.d/openshift/filter-kibana-transform.conf
@@ -2,7 +2,7 @@
   @type record_transformer
   enable_ruby
   <record>
-    log ${(err rescue nil) || (msg rescue nil) || record['MESSAGE'] || log}
+    log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}   
   </record>
   remove_keys req,res,msg,name,level,v,pid,err
 </filter>


### PR DESCRIPTION
Was seeing an exception being thrown in some cases, relating to an
undefined variable `log`.  Instead of relying on the `record_transformer`
behavior of adding local variables with the same name as the field,
use the explicit behavior of using the field from `record`.  This also
clears up any ambiguity between the `log` logging object and a field
named `log`.
/test