### PR TITLE
preserve ops namespace tags in mux mode

### DIFF
--- a/docs/mux-logging-service.md
+++ b/docs/mux-logging-service.md
@@ -321,6 +321,16 @@ TLS server `cert` and `key`, as well as the `ca` cert and the `shared_key`.
 These records are sent to the `@MUX` label.  The first thing here is this
 filter:
 
+    <match journal>
+      @type relabel
+      @label @INGRESS
+    </match>
+
+Records tagged with `journal` are "raw" records from a Fluentd running in
+`minimal` mode.  Just send these to `@INGRESS` for regular processing.
+
+The next filter is this:
+
     <filter kubernetes.var.log.containers.**>
 
 Since mux has no way to know if the Kubernetes records were read from
@@ -334,19 +344,15 @@ the `json-file` Fluentd tags.
 
 The next stage in the pipeline is this match:
 
-    <match journal system.var.log.messages system.var.log.messages.** kubernetes.var.log.containers.**>
+    <match system.var.log.messages** kubernetes.** journal.container** journal.system**>
 
-This uses the `relabel` plugin to redirect the standard OpenShift logging tags
-to their usual destination via the `@INGRESS` label.
-
-The next stage in the pipeline is this match:
-
-    <match journal.container** journal.system>
-
-Records with these tags are operations logs and have already been processed and
-formatted by an OpenShift Fluentd.  These are retagged with `mux.ops` and sent
-to the `@INGRESS` label, where they will skip the filtering stages and go to
-the output stages.
+If this record has already been processed by Fluentd e.g. in
+`MUX_CLIENT_MODE=maximal` then tag it so that it will be processed by the k8s
+plugin (if `kubernetes.**`), and have an index name created for it, but will
+not be processed in any other way.  Assume that if the record has the
+`@timestamp` field then it has already been processed, and tag it with a `.mux`
+suffix.  Otherwise, assume it is a raw record, tag it with a `.raw` suffix, and
+redirect to `@INGRESS` processing.
 
 The next stage in the pipeline is this filter:
 
@@ -358,11 +364,7 @@ the value of `namespacename` if it is in that form, or `mux-undefined`
 otherwise.  This also examines the record to see if the
 `kubernetes.metadata_uuid` field exists and has a value, to see if the record
 can bypass the k8s metadata plugin, and adds the field `mux_need_k8s_meta` with
-a value of `true` or `false`.  This also handles logs coming from inside the
-cluster that have been sent from a fluentd running in
-`MUX_CLIENT_MODE=maximal`.  In that case, the records will not have a
-`project.*` tag, but will have a `kubernetes.*` tag and/or fields
-such as `CONTAINER_NAME` which will be used to perform the k8s metadata lookup.
+a value of `true` or `false`.
 
 The next stage in the pipeline is a rewrite tag filter:
 
@@ -371,34 +373,44 @@ The next stage in the pipeline is a rewrite tag filter:
 If `mux_need_k8s_meta` is `false`, the tag is rewritten to be `mux`.  This
 causes all further filtering to be bypassed (except for the viaq filter).  If
 `mux_need_k8s_meta` is `true`, the tag is rewritten in the following format:
-`kubernetes.mux.var.log.containers.mux-mux.mux-mux_$1_mux-64digits.log` where
+`kubernetes.var.log.containers.mux-mux.mux-mux_$1_mux-64digits.log.mux` where
 `$1` is the value of the `mux_namespace_name` field.  This tag format was
 chosen because it will match the k8s meta filter plugin match
 
     <filter kubernetes.**>
 
-and will match that plugin's tag match pattern (if for some reason it is using the
-`json-file` method), but it will not match any of the other kubernetes log
-record filters.
+but it will not match any of the other kubernetes log record filters.
 
 Then all records are passed to the `@INGRESS` label, where there are two
 additional mux related filters.  The first one is this:
 
-    <filter kubernetes.mux.var.log.containers.mux-mux.mux-mux_**>
+    <filter kubernetes.var.log.containers.mux-mux.mux-mux_**.mux>
 
 This filter will add the `CONTAINER_NAME` and `CONTAINER_ID_FULL` fields to the
 record if they do not already exist so that the k8s meta filter plugin will
-add the Kubernetes `namespace_uuid`, labels, and annotations.
+add the `kubernetes.namespace_id`, labels, and annotations.
 
-The next filter is this:
+The next step is this filter:
 
-    <filter kubernetes.mux.var.log.containers.mux-mux.mux-mux_**>
+    <filter kubernetes.var.log.containers.**.raw>
+
+Records from container `json-file` logs, passed by a Fluentd running in
+`minimal` mode, will not have undergone JSON file parsing of the `log` field,
+and that process will also be skipped in mux since mux runs the k8s meta
+plugin, which normally does the JSON file parsing of the `log` field, in
+`use_journal true` mode, which looks for the `MESSAGE` field instead.  This
+filter does the JSON `log` field parsing.
+
+The ViaQ filter plugin will construct the index name using the fields
+`kubernetes.namespace_name` and `kubernetes.namespace_id` added by the k8s
+meta filter plugin (or by the client), and the `@timestamp` field.
+
+The last mux related filter is this one, run after the ViaQ filter:
+
+    <filter kubernetes.var.log.containers.mux-mux.mux-mux_**.mux>
 
 This filter just strips away the transient fields added by the above
 processing, such as
-`mux_namespace_name,docker,CONTAINER_NAME,CONTAINER_ID_FULL,mux_need_k8s_meta`,
-that we do not want to store in Elasticsearch.
-
-The Elasticsearch output will construct the index name using the fields
-`kubernetes.namespace_name` and `kubernetes.namespace_uuid` added by the k8s
-meta filter plugin (or by the client), and the `@timestamp` field.
+`docker,kubernetes,CONTAINER_NAME,CONTAINER_ID_FULL,mux_namespace_name,mux_need_k8s_meta,namespace_name,namespace_uuid`
+that we do not want to store in Elasticsearch, and are not needed after
+constructing the index name.

--- a/fluentd/configs.d/filter-post-mux.conf
+++ b/fluentd/configs.d/filter-post-mux.conf
@@ -1,5 +1,8 @@
-<filter mux kubernetes.mux.var.log.containers.mux-mux.mux-mux_**>
+<filter mux kubernetes.var.log.containers.mux-mux.mux-mux_**.mux>
   # remove any fields added by previous steps
   @type record_transformer
-  remove_keys mux_namespace_name,docker,CONTAINER_NAME,CONTAINER_ID_FULL,mux_need_k8s_meta,namespace_name,namespace_uuid
+  # docker and k8s fields are added by k8s meta plugin when we look up
+  # the namespace_id - we don't need these any more after the viaq filter
+  # runs to add the viaq_index_name field
+  remove_keys docker,kubernetes,CONTAINER_NAME,CONTAINER_ID_FULL,mux_namespace_name,mux_need_k8s_meta,namespace_name,namespace_uuid
 </filter>

--- a/fluentd/configs.d/filter-pre-mux.conf
+++ b/fluentd/configs.d/filter-pre-mux.conf
@@ -1,4 +1,4 @@
-<filter kubernetes.mux.var.log.containers.mux-mux.mux-mux_**>
+<filter kubernetes.var.log.containers.mux-mux.mux-mux_**.mux>
   @type record_transformer
   enable_ruby
   <record>
@@ -8,4 +8,12 @@
     CONTAINER_NAME ${record.fetch('CONTAINER_NAME', 'k8s_mux-mux.mux-mux_mux_' + record['mux_namespace_name'] + '_mux_01234567')}
     CONTAINER_ID_FULL ${record.fetch('CONTAINER_ID_FULL', '0123456789012345678901234567890123456789012345678901234567890123')}
   </record>
+</filter>
+
+<filter kubernetes.var.log.containers.**.raw>
+  @type k8s_meta_filter_for_mux_client
+  # do the JSON processing of the "log" field from json-file mux clients,
+  # since mux hardcodes use_journal true, which looks for the MESSAGE
+  # field
+  use_journal false
 </filter>

--- a/fluentd/configs.d/input-post-forward-mux.conf
+++ b/fluentd/configs.d/input-post-forward-mux.conf
@@ -20,40 +20,41 @@
   # specifically - an openshift fluentd collector configured to use secure_forward as
   # described in https://github.com/openshift/origin-aggregated-logging/pull/264/files
 
-  # mux hardcodes USE_JOURNAL=true to force the k8s-meta plugin to look for
-  # CONTAINER_NAME instead of the tag to extract the k8s metadata - logs coming
-  # from a fluentd using json-file will usually not have these fields, so add them
-  <filter kubernetes.var.log.containers.**>
-    @type record_transformer
-    enable_ruby
-    <record>
-      CONTAINER_NAME ${record['CONTAINER_NAME'] || (md = /var\.log\.containers\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$/.match(tag); "k8s_" + md["container_name"] + ".0_" + md["pod_name"] + "_" + md["namespace"] + "_0_01234567")}
-      CONTAINER_ID_FULL ${record['CONTAINER_ID_FULL'] || (md = /var\.log\.containers\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$/.match(tag); md["docker_id"])
-    </record>
-  </filter>
-
-  # just redirect these to their standard processing/filtering
-  <match journal system.var.log.messages system.var.log.messages.** kubernetes.var.log.containers.**>
+  # raw record from fluentd MUX_CLIENT_MODE=minimal - redirect to normal processing
+  <match journal>
     @type relabel
     @label @INGRESS
   </match>
 
-  # Records with these tags are operations logs and have already been processed
-  # and formatted by an openshift fluentd, so we can skip any additional
-  # processing
-  <match journal.container** journal.system>
+  # mux hardcodes USE_JOURNAL=true to force the k8s-meta plugin to look for
+  # CONTAINER_NAME instead of the tag to extract the k8s metadata - logs coming
+  # from a fluentd using json-file will usually not have this field, so add it
+  <filter kubernetes.var.log.containers.**>
+    @type record_transformer
+    enable_ruby
+    <record>
+      CONTAINER_NAME ${record['CONTAINER_NAME'] || (md = /var\.log\.containers\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]+)\.log$/.match(tag); "k8s_" + md["container_name"] + ".0_" + md["pod_name"] + "_" + md["namespace"] + "_0_01234567")}
+      CONTAINER_ID_FULL ${record['CONTAINER_ID_FULL'] || (md = /var\.log\.containers\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]+)\.log$/.match(tag); md["docker_id"])}
+    </record>
+  </filter>
+
+  # If this record has already been processed by fluentd e.g. in MUX_CLIENT_MODE=maximal
+  # then tag it so that it will be processed by the k8s plugin (if kubernetes.**)
+  # and have an index name created for it, but it will not be processed in any other way.
+  # Assume that if the record has the @timestamp field then it has already been
+  # processed, and tag it with ".mux".  Otherwise, assume it is a raw record, tag
+  # it with ".raw", and redirect to INGRESS processing.
+  <match system.var.log.messages** kubernetes.** journal.container** journal.system**>
     @type rewrite_tag_filter
     @label @INGRESS
-    rewriterule1 message .+ mux.ops
+    rewriterule1 @timestamp .+ ${tag}.mux
+    rewriterule2 @timestamp !.+ ${tag}.raw
   </match>
 
-  # If we got here, then either these are k8s container logs read from the journal by
-  # an openshift fluentd, or are external logs
-  # If they are k8s container logs, they should have a CONTAINER_NAME field which will
-  # be used by filter-pre-mux.conf.  If they are external logs, the namespace to use
+  # If we got here, then these are external logs.  The namespace to use
   # will be encoded in either the namespace_name field, or in the tag.  The filter below
   # will set the values/tag needed in filter-pre-mux.conf.
-  # If the record already has k8s metadata, there will be a kubernetes.namespace_uuid
+  # If the record already has k8s metadata, there will be a kubernetes.namespace_id
   # field.  If not, then the record will be tagged that k8s metadata processing is needed.
   # This filter will also ensure that the record has some sort of time field.
   <filter **>
@@ -61,8 +62,8 @@
     enable_ruby
     <record>
       mux_namespace_name ${record['namespace_name'] || (tag_parts[0] == "project" && tag_parts[1]) || ENV["MUX_UNDEFINED_NAMESPACE"] || "mux-undefined"}
-      mux_need_k8s_meta ${(record['namespace_uuid'] || record.fetch('kubernetes', {})['namespace_id'].nil?) ? "true" : "false"}
-      kubernetes {"namespace_name":"${record['namespace_name'] || (tag_parts[0] == 'project' && tag_parts[1]) || ENV['MUX_UNDEFINED_NAMESPACE'] || 'mux-undefined'}","namespace_id":"${record['namespace_uuid'] || record.fetch('kubernetes', {})['namespace_id']}"}
+      mux_need_k8s_meta ${(record['namespace_uuid'] || record.fetch('kubernetes', Hash.new)['namespace_id'].nil?) ? "true" : "false"}
+      kubernetes {"namespace_name":"${record['namespace_name'] || (tag_parts[0] == 'project' && tag_parts[1]) || ENV['MUX_UNDEFINED_NAMESPACE'] || 'mux-undefined'}","namespace_id":"${record['namespace_uuid'] || record.fetch('kubernetes', Hash.new)['namespace_id']}"}
       time ${record['@timestamp'] || record['time'] || time.utc.to_datetime.rfc3339(6)}
     </record>
   </filter>
@@ -78,6 +79,6 @@
     @type rewrite_tag_filter
     @label @INGRESS
     rewriterule1 mux_need_k8s_meta ^false$ mux
-    rewriterule2 mux_namespace_name (.+) kubernetes.mux.var.log.containers.mux-mux.mux-mux_$1_mux-0123456789012345678901234567890123456789012345678901234567890123.log
+    rewriterule2 mux_namespace_name (.+) kubernetes.var.log.containers.mux-mux.mux-mux_$1_mux-0123456789012345678901234567890123456789012345678901234567890123.log.mux
   </match>
 </label>

--- a/fluentd/configs.d/openshift/filter-retag-journal.conf
+++ b/fluentd/configs.d/openshift/filter-retag-journal.conf
@@ -52,6 +52,8 @@
 
 <match journal>
   @type rewrite_tag_filter
+  # skip to @INGRESS label section
+  @label @INGRESS
   # see if this is a kibana container for special log handling
   # looks like this:
   # k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2

--- a/fluentd/configs.d/openshift/filter-viaq-data-model.conf
+++ b/fluentd/configs.d/openshift/filter-viaq-data-model.conf
@@ -11,6 +11,13 @@
   dest_time_name "#{ENV['CDM_DEST_TIME_NAME'] || '@timestamp'}"
   pipeline_type "#{ENV['PIPELINE_TYPE'] || 'collector'}"
   <formatter>
+    # already processed - just do index_name
+    enabled false
+    tag "**mux"
+    # type doesn't matter because it will be skipped
+    type sys_var_log
+  </formatter>
+  <formatter>
     tag "system.var.log**"
     type sys_var_log
     remove_keys host,pid,ident
@@ -28,11 +35,11 @@
   <formatter>
     tag "kubernetes.var.log.containers**"
     type k8s_json_file
-    remove_keys log,stream
+    remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
   </formatter>
   <elasticsearch_index_name>
     enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
-    tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+    tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_**"
     name_type operations_full
   </elasticsearch_index_name>
   <elasticsearch_index_name>


### PR DESCRIPTION
When mux receives logs from fluentd, look for the `@timestamp` field
to mean that the logs have already been processed in the viaq data
model format, so they need no further processing, just k8s meta if
necessary, and construct the index name.  Records that have already
been processed by fluentd get a ".mux" tag suffix, and "raw"
unprocessed records get a ".raw" tag suffix.
Also, remove the `docker` and `kubernetes` fields from records sent
externally.  These fields are added by the k8s meta to when getting
the id for the namespace but are not needed for external records
once the index name is created.

When using the json-file container logs, the mux test will add
CONTAINER_NAME in the same places where it is implicitly added by
the journald log driver logs.

The test creates indices like `project.testproj.*` and `project.default.*`
which are not normally present, so make sure these are removed.

(cherry picked from commit 0c0ddce486380819a5ad12d10efa12a248be573c)
/test