### PR TITLE
Fluentd - one output tag per plugin (3.6 version of #714)

### DIFF
--- a/fluentd/configs.d/filter-post-z-retag-one.conf
+++ b/fluentd/configs.d/filter-post-z-retag-one.conf
@@ -8,6 +8,5 @@
   @type rewrite_tag_filter
   @label @OUTPUT
   rewriterule1 message .+ output_tag
-  rewriterule2 MESSAGE .+ output_tag
-  rewriterule3 log .+ output_tag
+  rewriterule2 message !.+ output_tag
 </match>

--- a/fluentd/configs.d/filter-post-z-retag-two.conf
+++ b/fluentd/configs.d/filter-post-z-retag-two.conf
@@ -8,14 +8,12 @@
   @type rewrite_tag_filter
   @label @OUTPUT
   rewriterule1 message .+ output_ops_tag
-  rewriterule2 MESSAGE .+ output_ops_tag
-  rewriterule3 log .+ output_tag_tag
+  rewriterule2 message !.+ output_ops_tag
 </match>
 
 <match **>
   @type rewrite_tag_filter
   @label @OUTPUT
   rewriterule1 message .+ output_tag
-  rewriterule2 MESSAGE .+ output_tag
-  rewriterule3 log .+ output_tag
+  rewriterule2 message !.+ output_tag
 </match>


### PR DESCRIPTION
All the logs match the tag are to be retag'ed.

(cherry picked from commit cbf72a65d3a7320897efc849a10cea3b588a3caf)

All the logs match the tag are to be retag'ed. Thanks to @josefkarasek for finding out the bugs.  This PR separates the "one output tag per plugin" related fixes from "A Collect docker audit log (#708)".


