### PR TITLE
CI test improvement

### DIFF
--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -128,13 +128,16 @@ function run_suite() {
 	fi
 }
 
-suite_selector="${SUITE:-".*"}"
-for test in $( find "${OS_O_A_L_DIR}/hack/testing" -type f -name 'check-*.sh' | grep -E "${suite_selector}" | sort ); do
+for suite_selector in ${SUITE:-".*"} ; do
+  for test in $( find "${OS_O_A_L_DIR}/hack/testing" -type f -name 'check-*.sh' | grep -E "${suite_selector}" | sort ); do
 	run_suite "${test}"
+  done
 done
 
-for test in $( find "${OS_O_A_L_DIR}/hack/testing" -type f -name 'test-*.sh' | grep -E "${suite_selector}" | sort ); do
+for suite_selector in ${SUITE:-".*"} ; do
+  for test in $( find "${OS_O_A_L_DIR}/hack/testing" -type f -name 'test-*.sh' | grep -E "${suite_selector}" | sort ); do
 	run_suite "${test}"
+  done
 done
 
 if [[ -n "${failed:-}" ]]; then

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::util::environment::use_sudo
 
-FLUENTD_WAIT_TIME=$(( 2 * minute ))
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
 
 os::test::junit::declare_suite_start "test/fluentd-forward"
 
@@ -43,6 +43,7 @@ update_current_fluentd() {
     # redeploy fluentd
     os::cmd::expect_success flush_fluentd_pos_files
     os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+    os::cmd::try_until_success "oc rollout status -w ds/logging-fluentd"
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     fpod=$( get_running_pod fluentd )
 }

--- a/test/mux-client-mode.sh
+++ b/test/mux-client-mode.sh
@@ -15,7 +15,7 @@ else
     exit 0
 fi
 
-FLUENTD_WAIT_TIME=$(( 2 * minute ))
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
 
 os::test::junit::declare_suite_start "test/mux-client-mode"
 

--- a/test/read-throttling.sh
+++ b/test/read-throttling.sh
@@ -13,7 +13,7 @@ fi
 trap os::test::junit::reconcile_output EXIT
 os::util::environment::use_sudo
 
-FLUENTD_WAIT_TIME=$(( 2 * minute ))
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
 
 os::test::junit::declare_suite_start "test/read-throttling"
 

--- a/test/remote-syslog.sh
+++ b/test/remote-syslog.sh
@@ -8,7 +8,7 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::util::environment::use_sudo
 
-FLUENTD_WAIT_TIME=$(( 2 * minute ))
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
 
 os::test::junit::declare_suite_start "Remote Syslog Configuration Tests"
 


### PR DESCRIPTION
```
    entrypoint.sh - Allowing SUITE to have multiple tests. E.g.,
                    SUITE="test-mux.sh test-viaq-data-model.sh"
    
    viaq-data-model.sh - Checking MUX_CLIENT_MODE=maximal as a string.
    
    mux.sh - In the file buffer's persistency test, replacing "sleep ##"
             with the code checking the file buffers' existency.
             When ops_cluster is enabled, ES_HOST and OPS_HOST should not
             have the same temporary test name.
```