### PR TITLE
Bug 1490647 - logging-fluentd deployed with openshift_logging_use_mux=false fails to start due to missing

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -42,10 +42,15 @@ if [ -z "${USE_MUX:-}" -o "${USE_MUX:-}" = "false" ] ; then
     else
         export USE_JOURNAL=false
     fi
+    unset MUX_FILE_BUFFER_STORAGE_TYPE
 else
     # mux requires USE_JOURNAL=true so that the k8s meta plugin will look
     # for CONTAINER_NAME instead of the kubernetes.var.log.containers.* tag
     export USE_JOURNAL=true
+fi
+
+if [ ! -d /etc/fluent/muxkeys ]; then
+    unset MUX_CLIENT_MODE
 fi
 
 IPADDR4=`/usr/sbin/ip -4 addr show dev eth0 | grep inet | sed -e "s/[ \t]*inet \([0-9.]*\).*/\1/"`
@@ -222,7 +227,7 @@ mkdir -p $FILE_BUFFER_PATH
 # Get the available disk size.
 DF_LIMIT=$(df -B1 $FILE_BUFFER_PATH | grep -v Filesystem | awk '{print $2}')
 DF_LIMIT=${DF_LIMIT:-0}
-if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "hostmount" ]; then
+if [ "${MUX_FILE_BUFFER_STORAGE_TYPE:-}" = "hostmount" ]; then
     # Use 1/4 of the disk space for hostmount.
     DF_LIMIT=$(expr $DF_LIMIT / 4) || :
 fi


### PR DESCRIPTION
(3.6 backport of pr#705)

If openshift_logging_use_mux=False and openshift_logging_mux_allow_external=False,
then all other mux related parameters should be set to False (if boolean) or
removed (e.g. openshift_logging_mux_client_mode should be undefined).

To determine if mux is configured in run.sh, check whether the directory
/etc/fluent/muxkeys exits or not.  If it does not exist, MUX_CLIENT_MODE
is unset.

(cherry picked from commit 9954e962e62c8ef512ce6c7a0af7974f2afdbaf9)