### PR TITLE
Add three simple, well used, ES cli commands

### DIFF
--- a/elasticsearch/utils/check
+++ b/elasticsearch/utils/check
@@ -1,0 +1,15 @@
+#!/bin/bash -eu
+#
+# Utility to check the overall state of the cluster via various _cat APIs.
+#
+source es_util_env
+
+date
+$curl_get "$ES_BASE/_cat/health?v"
+$curl_get "$ES_BASE/_cat/nodes?v"
+$curl_get "$ES_BASE/_cat/indices?v" 2>&1 | grep -vE "^green"
+$curl_get "$ES_BASE/_cat/indices?v" 2>&1 | grep "searchguard"
+$curl_get "$ES_BASE/_cat/count?v"
+sleep 5
+$curl_get "$ES_BASE/_cat/count?v"
+date

--- a/elasticsearch/utils/es_util_env
+++ b/elasticsearch/utils/es_util_env
@@ -5,3 +5,4 @@ if [[ ! -z "${DEBUG:-}" ]]; then
 fi
 
 ES_BASE=${ES_BASE:-https://localhost:9200}
+curl_get='curl -s -X GET --cacert /etc/elasticsearch/secret/admin-ca --cert /etc/elasticsearch/secret/admin-cert --key /etc/elasticsearch/secret/admin-key'

--- a/elasticsearch/utils/health
+++ b/elasticsearch/utils/health
@@ -1,0 +1,8 @@
+#!/bin/bash -eu
+#
+# Utility to grab the health of the cluster via the _cat APIs.
+#
+source es_util_env
+
+date
+$curl_get "$ES_BASE/_cat/health?v"

--- a/elasticsearch/utils/indices
+++ b/elasticsearch/utils/indices
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+#
+# Utility to dump the indices of the cluster via the _cat APIs. The
+# size of the indices is reported in MBs.
+#
+source es_util_env
+
+date
+$curl_get "$ES_BASE/_cat/indices?v&bytes=m"


### PR DESCRIPTION
We add the `check` command, which displays health, problem indices, and a quick 5 second document count to show that logs are flowing.

We also add a simple `health` command to show the over health of the cluster and the state of the individual nodes.

Finally, we add the `indices` command, which dumps the list of indices using MBs as the size unit.