### PR TITLE
Added fluentd fbstorage and _nodes/stats call

### DIFF
--- a/hack/README-dump.md
+++ b/hack/README-dump.md
@@ -52,6 +52,7 @@ Examples:
     |   │   ├── indices
     |   │   ├── latest_documents.json
     |   │   ├── nodes
+    |   │   ├── nodes_stats
     |   │   ├── thread_pool    
     |   │   ├── pending_tasks
     |   │   ├── recovery
@@ -63,6 +64,7 @@ Examples:
     |   │   ├── indices
     |   │   ├── latest_documents.json
     |   │   ├── nodes
+    |   │   ├── nodes_stats
     |   │   ├── thread_pool
     |   │   ├── pending_tasks
     |   │   ├── recovery
@@ -129,7 +131,8 @@ Examples:
 * Secrets (Only the name of the files included, not its content)
 
 ### Fluentd
-* Connectivity with Elasticsearch Servicewith Elasticsearch Service
+* Connectivity with Elasticsearch Service
+* If filebuffer is used the available storage and current files will be listed
 
 ### Curator
 * Connectivity with Elasticsearch Service
@@ -146,6 +149,7 @@ Examples:
 * Check 0/1 node folders
 * Elasticsearch internal log files
 * Latest documents persisted
+* Nodes status. Shows thorough information about OS, JVM, Filesystem, etc. [More info](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html)
 * Conditional based on cluster health
   * Pending tasks `/_cluster/pending_tasks`
   * Recovery status `/_cat/recovery`


### PR DESCRIPTION
I think the `_nodes/stats` call will add a lot of useful information we sometimes need for troubleshooting. An example is the available disk space or the Garbage Collector collection time.
Besides as the filebuffer storage has been added recently for 3.6, the fs usage and existing files would also be helpful.