### PR TITLE
Fix references to cpu-limits and test environment

### DIFF
--- a/docs/mux-logging-service.md
+++ b/docs/mux-logging-service.md
@@ -99,7 +99,7 @@ There are several new Ansible parameters which can be used with the
   to listen for `secure_forward` protocol log messages
 
 Other parameters are similar to parameters for the other components, for
-example `openshift_logging_mux_cpu_limit`,
+example `openshift_logging_mux_cpu_request`,
 `openshift_logging_mux_memory_limit`, `openshift_logging_mux_replica_count`,
 `openshift_logging_mux_nodeselector`
 


### PR DESCRIPTION
This patch is a required sibling to the openshift-ansible PR
https://github.com/openshift/openshift-ansible/pull/5748.

Without this patch landing first, that PR will not past its regression
tests, due to a behavior of the test environment provided by this repo
where it attempts to remove a CPU limit resource path, but fails when it
is not found.  That failure is now always the case with the changes in
PR https://github.com/openshift/openshift-ansible/pull/5748.

(cherry picked from commit 6b6fe9e696add4d30cd5528e7418a9412ea296d2)