### PR TITLE
Es2 ci fixes for multi-node deployment

### DIFF
--- a/elasticsearch/probe/readiness.sh
+++ b/elasticsearch/probe/readiness.sh
@@ -43,13 +43,13 @@ function check_if_ready() {
 }
 
 check_if_ready "/" "Elasticsearch node is not ready to accept HTTP requests yet"
-check_if_ready "/.searchguard.$DC_NAME" "Searchguard index '.searchguard.$DC_NAME' is missing in ES cluster"
+check_if_ready "/.searchguard.$NODE_NAME" "Searchguard index '.searchguard.$NODE_NAME' is missing in ES cluster"
 sg_doc_count=$(curl -s --get \
   --cacert $secret_dir/admin-ca \
   --cert $secret_dir/admin-cert \
   --key  $secret_dir/admin-key \
   --max-time $max_time \
-  "${ES_REST_BASEURL}/.searchguard.$DC_NAME/_search?size=0" \
+  "${ES_REST_BASEURL}/.searchguard.$NODE_NAME/_search?size=0" \
   | python -c "import sys, json; print json.load(sys.stdin)['hits']['total']")
 
 if [ "$sg_doc_count" != $EXPECTED_SG_DOCUMENT_COUNT ]; then

--- a/elasticsearch/utils/es_seed_acl
+++ b/elasticsearch/utils/es_seed_acl
@@ -15,10 +15,10 @@ loginterval=${SG_ADMIN_LOG_INTERVAL:-100}
 while ! ${ES_HOME}/plugins/openshift-elasticsearch/sgadmin.sh \
     -cd ${HOME}/sgconfig \
     -i $index \
-    -ks /etc/elasticsearch/secret/searchguard.key \
+    -ks /etc/elasticsearch/secret/admin.jks \
     -kst JKS \
     -kspass kspass \
-    -ts /etc/elasticsearch/secret/searchguard.truststore \
+    -ts /etc/elasticsearch/secret/truststore \
     -tst JKS \
     -tspass tspass \
     -nhnv \

--- a/hack/testing/check-EFK-running.sh
+++ b/hack/testing/check-EFK-running.sh
@@ -22,10 +22,10 @@ fi
 
 function get_es_dc() {
   # $1 - cluster name postfix
-  if [ -z $(oc get dc -l cluster-name=logging-${1},es-node-role=clientdata --no-headers | awk '{print $1}') ] ; then
+  if [ -z $(oc get dc -l cluster-name=logging-${1},es-node-data=true --no-headers | awk '{print $1}') ] ; then
     oc get deploymentconfigs --namespace logging --selector component=${1} -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-${1}-(data-)?(master|client)-[a-zA-Z0-9]{8}"
   else
-    oc get deploymentconfigs --namespace logging --selector cluster-name=logging-${1},es-node-role=clientdata -o jsonpath='{.items[*].metadata.name}' | grep -E "^logging-${1}-clientdata-[0-9]"
+    oc get deploymentconfigs --namespace logging --selector cluster-name=logging-${1},es-node-data=true -o jsonpath='{.items[*].metadata.name}'
   fi
 }
 


### PR DESCRIPTION
CI fixes for elasticsearch multi-role deployment https://github.com/openshift/openshift-ansible/pull/5001
Searchguard sgadmin script must use client certs, rather than server certs - this causes problem in ES5.
Readiness probe changed to use NODE_NAME, rather than DC_NAME

This is for 3.8, not for 3.7