### PR TITLE
Bug - forward docker build image exit status

### DIFF
--- a/hack/lib/build/images.sh
+++ b/hack/lib/build/images.sh
@@ -127,8 +127,10 @@ function os::build::image::internal::docker() {
 	local extra_tag="${3-}"
 	local options=()
 
-	if ! docker build ${OS_BUILD_IMAGE_ARGS:-} -t "${tag}" "${directory}"; then
-		return "$?"
+	docker build ${OS_BUILD_IMAGE_ARGS:-} -t "${tag}" "${directory}"
+	local ret="$?"
+	if [[ $ret -ne 0 ]]; then
+		return "$ret"
 	fi
 
 	if [[ -n "${extra_tag}" ]]; then


### PR DESCRIPTION
The '!' is a reserved word and if it precedes a pipeline, it reverses the exit status of the pipeline. In this case, 'return "$?"' was always 0 inside of the 'if' statement.

https://linux.die.net/man/1/bash - section about pipelines
http://tldp.org/LDP/abs/html/exit-status.html#EXITSTATUSREF