### PR TITLE
Stream output of docker to prevent travis timeout

### DIFF
--- a/hack/lib/build/images.sh
+++ b/hack/lib/build/images.sh
@@ -32,21 +32,17 @@ function os::build::image() {
 	fi
 
 	local result=1
-	local image_build_log
-	image_build_log="$( mktemp "${BASETMPDIR}/imagelogs.XXXXX" )"
 	for (( i = 0; i < "${OS_BUILD_IMAGE_NUM_RETRIES:-2}"; i++ )); do
 		if [[ "${i}" -gt 0 ]]; then
-			os::log::internal::prefix_lines "[${tag%:*}]" "$( cat "${image_build_log}" )"
 			os::log::warning "Retrying image build for ${tag}, attempt ${i}..."
 		fi
 
-		if os::build::image::internal::generic "${tag}" "${directory}" "${extra_tag:-}" >"${image_build_log}" 2>&1; then
+		if os::build::image::internal::generic "${tag}" "${directory}" "${extra_tag:-}" 2>&1 | os::log::internal::prefix_lines_stream "[${tag%:*}]" ; then
 			result=0
 			break
 		fi
 	done
 
-	os::log::internal::prefix_lines "[${tag%:*}]" "$( cat "${image_build_log}" )"
 	return "${result}"
 }
 readonly -f os::build::image

--- a/hack/lib/log/output.sh
+++ b/hack/lib/log/output.sh
@@ -102,3 +102,17 @@ function os::log::internal::prefix_lines() {
 	done
 	IFS="${old_ifs}"
 }
+
+# os::log::internal::prefix_lines_stream prints out the original content with 
+# the given prefix at the start of every line, usable in pipe.
+#
+# Arguments:
+#  - 1: prefix for lines
+function os::log::internal::prefix_lines_stream() {
+	local prefix="$1"
+
+	while read line; do
+		local time=$(date +%H:%M:%S.%N)
+		echo "[${time}] ${prefix} ${line}"
+	done
+}


### PR DESCRIPTION
Originally, the output of `docker build` was stored in a variable and only after the image was built, sent to STDOUT. Travis has 10 minute kill period when nothing goes to STDOUT which lead to premature test failures if building of the image took longer (occasionally happened with Elasticsearch image).

Also adds a timestamp to each output line to better evaluate time requirements of image builds.