### PR TITLE
do not remove es-containers.log.pos; wait for journal.pos

### DIFF
--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -167,11 +167,6 @@ function add_test_message() {
 
 function flush_fluentd_pos_files() {
     os::cmd::expect_success "sudo rm -f /var/log/journal.pos"
-    if docker_uses_journal ; then
-        : # done
-    else
-        os::cmd::expect_success "sudo rm -f /var/log/es-containers.log.pos"
-    fi
 }
 
 # $1 - command to call to pass the uuid_es
@@ -189,6 +184,7 @@ function wait_for_fluentd_to_catch_up() {
     local timeout=${TIMEOUT:-600}
     local project=${4:-logging}
 
+    wait_for_fluentd_ready
     add_test_message $uuid_es
     os::log::debug added es message $uuid_es
     logger -i -p local6.info -t $uuid_es_ops $uuid_es_ops

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -128,11 +128,9 @@ os::log::info Starting fluentd-forward test at $( date )
 # make sure fluentd is working normally
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
-wait_for_fluentd_ready
 os::cmd::expect_success wait_for_fluentd_to_catch_up
 
 create_forwarding_fluentd
 update_current_fluentd
 
-wait_for_fluentd_ready
 os::cmd::expect_success wait_for_fluentd_to_catch_up

--- a/test/json-parsing.sh
+++ b/test/json-parsing.sh
@@ -39,7 +39,6 @@ os::log::info Starting json-parsing test at $( date )
 get_uuid_es() {
     json_test_uuid=$1
 }
-wait_for_fluentd_ready
 wait_for_fluentd_to_catch_up get_uuid_es
 
 es_pod=$( get_es_pod es )

--- a/test/mux-client-mode.sh
+++ b/test/mux-client-mode.sh
@@ -69,7 +69,6 @@ os::cmd::expect_success flush_fluentd_pos_files
 os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
-wait_for_fluentd_ready
 wait_for_fluentd_to_catch_up
 
 # configure fluentd to use MUX_CLIENT_MODE=maximal - verify logs get through
@@ -82,5 +81,4 @@ os::cmd::expect_success flush_fluentd_pos_files
 os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
-wait_for_fluentd_ready
 wait_for_fluentd_to_catch_up

--- a/test/viaq-data-model.sh
+++ b/test/viaq-data-model.sh
@@ -120,7 +120,6 @@ get_logmessage2() {
 
 # TEST 1
 # default - undefined fields are passed through untouched
-wait_for_fluentd_ready
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
 fullmsg="GET /${logmessage} 404 "
 qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
@@ -139,9 +138,9 @@ keep_fields="method,statusCode,type,@timestamp,req,res,CONTAINER_NAME,CONTAINER_
 # TEST 2
 # cdm - undefined fields are stored in 'undefined' field
 os::log::debug "$( oc set env daemonset/logging-fluentd CDM_USE_UNDEFINED=true CDM_EXTRA_KEEP_FIELDS=$keep_fields )"
+os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
-wait_for_fluentd_ready
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
 fullmsg="GET /${logmessage} 404 "
 qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
@@ -154,9 +153,9 @@ os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '
 # TEST 3
 # user specifies extra fields to keep
 os::log::debug "$( oc set env daemonset/logging-fluentd CDM_EXTRA_KEEP_FIELDS=undefined4,undefined5,$keep_fields )"
+os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
-wait_for_fluentd_ready
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
 fullmsg="GET /${logmessage} 404 "
 qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
@@ -170,9 +169,9 @@ os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '
 # TEST 4
 # user specifies alternate undefined name to use
 os::log::debug "$( oc set env daemonset/logging-fluentd CDM_UNDEFINED_NAME=myname )"
+os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
-wait_for_fluentd_ready
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
 fullmsg="GET /${logmessage} 404 "
 qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
@@ -186,6 +185,7 @@ os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '
 # TEST 5
 # preserve specified empty field as empty
 os::log::debug "$( oc set env daemonset/logging-fluentd CDM_EXTRA_KEEP_FIELDS=undefined4,undefined5,empty1,undefined3,$keep_fields CDM_KEEP_EMPTY_FIELDS=undefined4,undefined5,empty1,undefined3 )"
+os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 # if using MUX_CLIENT_MODE=maximal, also have to tell mux to keep the empty fields
 is_maximal=$( oc set env daemonset/logging-fluentd --list | grep ^MUX_CLIENT_MODE=maximal ) || :
@@ -196,7 +196,6 @@ if [ -n "$is_maximal" ] ; then
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
 fi
 fpod=$( get_running_pod fluentd )
-wait_for_fluentd_ready
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
 fullmsg="GET /${logmessage} 404 "
 qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'


### PR DESCRIPTION
Do not remove es-containers.log.pos - by default, fluentd will
read from the head of this file.  If the pos file is removed,
all of the container json-file log files will be read in their
entirety again.
https://github.com/openshift/origin-aggregated-logging/blob/master/fluentd/generate_throttle_configs.rb#L109

After journal.pos has been removed, wait for fluentd to create it
again before writing test data to be traced.  Otherwise, fluentd will
never see it, and it will never show up in Elasticsearch.

Call wait_for_fluentd_ready from wait_for_fluentd_to_catch_up, and
do not call wait_for_fluentd_ready when using wait_for_fluentd_to_catch_up

Clean up the utf8 test.

Add additional debug information to the mux test which is dumped to
an artifact file.
/test