### PR TITLE
bug 1503404. Turn of api watch to reduce fluentd memory

### DIFF
--- a/fluentd/configs.d/openshift/filter-k8s-meta.conf
+++ b/fluentd/configs.d/openshift/filter-k8s-meta.conf
@@ -1,9 +1,11 @@
 <filter kubernetes.**>
   type kubernetes_metadata
   kubernetes_url "#{ENV['K8S_HOST_URL']}"
+  cache_size "#{ENV['K8S_METADATA_CACHE_SIZE'] || '1000'}"
+  watch "#{ENV['K8S_METADATA_WATCH'] || 'false'}"
   bearer_token_file /var/run/secrets/kubernetes.io/serviceaccount/token
   ca_file /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  include_namespace_id true
+  include_namespace_metadata true
   use_journal "#{ENV['USE_JOURNAL'] || 'false'}"
   container_name_to_kubernetes_regexp '^(?<name_prefix>[^_]+)_(?<container_name>[^\._]+)(\.(?<container_hash>[^_]+))?_(?<pod_name>[^_]+)_(?<namespace>[^_]+)_[^_]+_[^_]+$'
 </filter>


### PR DESCRIPTION
This PR:

* Turns off watch completely of pod and namespaces
* Allows configuration of watch enablement via env var
* Allows configuration of cache size via env var