### PR TITLE
[3.6] CI test improvements/stabilization (backport #716)

### DIFF
--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -130,13 +130,16 @@ function run_suite() {
 	fi
 }
 
-suite_selector="${SUITE:-".*"}"
-for test in $( find "${OS_O_A_L_DIR}/hack/testing" -type f -name 'check-*.sh' | grep -E "${suite_selector}" | sort ); do
+for suite_selector in ${SUITE:-".*"} ; do
+  for test in $( find "${OS_O_A_L_DIR}/hack/testing" -type f -name 'check-*.sh' | grep -E "${suite_selector}" | sort ); do
 	run_suite "${test}"
+  done
 done
 
-for test in $( find "${OS_O_A_L_DIR}/hack/testing" -type f -name 'test-*.sh' | grep -E "${suite_selector}" | sort ); do
+for suite_selector in ${SUITE:-".*"} ; do
+  for test in $( find "${OS_O_A_L_DIR}/hack/testing" -type f -name 'test-*.sh' | grep -E "${suite_selector}" | sort ); do
 	run_suite "${test}"
+  done
 done
 
 if [[ -n "${failed:-}" ]]; then

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::util::environment::use_sudo
 
-FLUENTD_WAIT_TIME=$(( 2 * minute ))
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
 
 os::test::junit::declare_suite_start "test/fluentd-forward"
 

--- a/test/mux-client-mode.sh
+++ b/test/mux-client-mode.sh
@@ -15,7 +15,7 @@ else
     exit 0
 fi
 
-FLUENTD_WAIT_TIME=$(( 2 * minute ))
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
 
 os::test::junit::declare_suite_start "test/mux-client-mode"
 

--- a/test/mux.sh
+++ b/test/mux.sh
@@ -16,7 +16,7 @@ else
     exit 0
 fi
 
-FLUENTD_WAIT_TIME=$(( 2 * minute ))
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
 
 os::test::junit::declare_suite_start "test/mux"
 
@@ -312,7 +312,9 @@ write_and_verify_logs() {
 }
 
 reset_ES_HOST() {
+    muxpod=$( get_running_pod mux )
     os::cmd::expect_success "oc set env dc logging-mux $1 $2"
+    os::cmd::try_until_failure "oc get pod $muxpod"
     os::log::debug $( oc get pods -l component=mux )
     oc rollout status -w dc/logging-mux # wait for mux to be redeployed
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
@@ -322,6 +324,11 @@ reset_ES_HOST() {
 cleanup() {
     local return_code="$?"
     set +e
+
+    # In case test failed in Test case FILE_BUFFER_STORAGE_TYPE: $MUX_FILE_BUFFER_STORAGE_TYPE 
+    # reset ES_HOST and OPS_HOST
+    reset_ES_HOST $ES_HOST_BAK $OPS_HOST_BAK
+
     if [ $return_code = 0 ] ; then
         mycmd=os::log::info
     else
@@ -399,6 +406,9 @@ if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" ]; then
     os::log::debug "$( oc get pvc )"
 fi
 
+ES_HOST_BAK=$( oc set env --list dc/logging-mux | grep \^ES_HOST= )
+OPS_HOST_BAK=$( oc set env --list dc/logging-mux | grep \^OPS_HOST= )
+
 # make sure fluentd is working normally
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up
@@ -408,11 +418,12 @@ if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" -o "$MUX_FILE_BUFFER_STORAGE_TYPE" 
 
     update_current_fluentd $ENABLE_SECURE_FORWARD
 
-    ES_HOST_BAK=$( oc set env --list dc/logging-mux | grep \^ES_HOST= )
-    OPS_HOST_BAK=$( oc set env --list dc/logging-mux | grep \^OPS_HOST= )
-
-    # set ES_HOST and OPS_HOST to bogus
-    reset_ES_HOST ES_HOST=bogus OPS_HOST=bogus
+    # set ES_HOST and OPS_HOST to non-existing hostname
+    if [ "$ops_cluster" = "true" ]; then
+        reset_ES_HOST ES_HOST=bogus OPS_HOST=bogus_ops
+    else
+        reset_ES_HOST ES_HOST=bogus OPS_HOST=bogus
+    fi
 
     uuid_es=$( uuidgen )
     uuid_es_ops=$( uuidgen )
@@ -420,23 +431,51 @@ if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" -o "$MUX_FILE_BUFFER_STORAGE_TYPE" 
     logger -i -p local6.info -t $uuid_es_ops $uuid_es_ops
     add_test_message $uuid_es
 
-    # wait long enough to make the test messages are in the buffer
-    sleep 10
-    muxpod=$( oc get pods -l component=mux -o name | awk -F'/' '{print $2}' )
+    # wait for the test messages are in the buffer
+    muxpod=$( get_running_pod mux )
+    if [ "$ops_cluster" = "true" ]; then
+       ops_filename="output-es-ops-config.output_ops_tag"
+    else
+       ops_filename="output-es-config.output_tag"
+    fi
+    retry="true"
+    while [ "$retry" = "true" ]; do
+        ops_logs=$( oc exec $muxpod -- ls /var/lib/fluentd/ | egrep $ops_filename ) || :
+        if [ -z "$ops_logs" ]; then
+            sleep 1
+            continue
+        fi
+        for ops_log in $ops_logs; do
+            found=$( oc exec $muxpod -- strings /var/lib/fluentd/$ops_log | egrep $uuid_es_ops ) || :
+            if [ -n "$found" ]; then
+                retry="false"
+                break
+            fi
+        done
+    done
     os::log::debug "$( oc exec $muxpod -- ls -l /var/lib/fluentd )"
     os::log::debug "$( oc logs $muxpod )"
 
     # set ES_HOST and OPS_HOST to original
     reset_ES_HOST $ES_HOST_BAK $OPS_HOST_BAK
 
+    # wait for the file buffer disappears once
+    os::cmd::try_until_text "oc exec $muxpod -- ls -l /var/lib/fluentd" "total 0" $FLUENTD_WAIT_TIME
+    os::log::debug "$( oc exec $muxpod -- ls -l /var/lib/fluentd )"
+    os::log::debug "$( oc logs $muxpod )"
+
     # kibana logs with kibana container/pod values
     myproject=project.logging
-    mymessage=$uuid_es
-    os::cmd::try_until_success "curl_es $es_pod /${myproject}.*/_count?q=message:$mymessage | get_count_from_json | grep -q 1" "$(( 10*minute ))"
+    mymessage="GET /${uuid_es} 404 "
+    qs='{"query":{"match_phrase":{"message":"'"${mymessage}"'"}}}'
+    os::log::debug "Check kibana log - message \"${mymessage}\""
+    os::cmd::try_until_success "curl_es $es_pod /${myproject}.*/_count -XPOST -d '$qs' | get_count_from_json | egrep -q '^1$'" "$(( 10*minute ))"
 
     myproject=.operations
     mymessage=$uuid_es_ops
-    os::cmd::try_until_success "curl_es $es_ops_pod /${myproject}.*/_count?q=message:$mymessage | get_count_from_json | grep -q 1" "$(( 10*minute ))"
+    qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${mymessage}"'"}}}'
+    os::log::debug "Check system log - SYSLOG_IDENTIFIER \"${mymessage}\""
+    os::cmd::try_until_success "curl_es $es_ops_pod /${myproject}.*/_count -XPOST -d '$qs' | get_count_from_json | egrep -q '^1$'" "$(( 10*minute ))"
 fi
 
 os::log::info "------- Test case $SET_CONTAINER_VALS -------"

--- a/test/read-throttling.sh
+++ b/test/read-throttling.sh
@@ -13,7 +13,7 @@ fi
 trap os::test::junit::reconcile_output EXIT
 os::util::environment::use_sudo
 
-FLUENTD_WAIT_TIME=$(( 2 * minute ))
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
 
 os::test::junit::declare_suite_start "test/read-throttling"
 

--- a/test/viaq-data-model.sh
+++ b/test/viaq-data-model.sh
@@ -8,7 +8,7 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::util::environment::use_sudo
 
-FLUENTD_WAIT_TIME=$(( 2 * minute ))
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
 
 os::test::junit::declare_suite_start "test/viaq-data-model"
 
@@ -186,7 +186,8 @@ os::log::debug "$( oc set env daemonset/logging-fluentd CDM_EXTRA_KEEP_FIELDS=un
 os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 # if using MUX_CLIENT_MODE=maximal, also have to tell mux to keep the empty fields
-if oc set env daemonset/logging-fluentd --list | grep -q ^MUX_CLIENT_MODE=maximal ; then
+is_maximal=$( oc set env daemonset/logging-fluentd --list | grep ^MUX_CLIENT_MODE=maximal ) || :
+if [ -n "$is_maximal" ] ; then
     muxpod=$( get_running_pod mux )
     oc set env dc/logging-mux CDM_KEEP_EMPTY_FIELDS=undefined4,undefined5,empty1,undefined3
     os::cmd::try_until_failure "oc get pod $muxpod"
@@ -203,7 +204,7 @@ qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
 os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test5 allow_empty"
 
-if oc set env daemonset/logging-fluentd --list | grep -q ^MUX_CLIENT_MODE=maximal ; then
+if [ -n "$is_maximal" ] ; then
     muxpod=$( get_running_pod mux )
     oc set env dc/logging-mux CDM_KEEP_EMPTY_FIELDS-
     os::cmd::try_until_failure "oc get pod $muxpod"


### PR DESCRIPTION
entrypoint.sh - Allowing SUITE to have multiple tests. E.g.,
                SUITE="test-mux.sh test-viaq-data-model.sh"

viaq-data-model.sh - Checking MUX_CLIENT_MODE=maximal as a string.

mux.sh - In the file buffer's persistency test, replacing "sleep ##"
         with the code checking the file buffers' existency.
         When ops_cluster is enabled, ES_HOST and OPS_HOST should not
         have the same temporary test name.
         Plus making sure the mux pod is up after restarted.

Making FLUENTD_WAIT_TIME configurable.

(cherry picked from commit 1383952db2df4e0f51efc7f02863932479bcf159)