### PR TITLE
Removing unnecessary "oc rollout" accidentally added by pr #716

### DIFF
--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -46,7 +46,6 @@ update_current_fluentd() {
     # redeploy fluentd
     os::cmd::expect_success flush_fluentd_pos_files
     os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
-    os::cmd::try_until_success "oc rollout status -w ds/logging-fluentd"
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     fpod=$( get_running_pod fluentd )
 }

--- a/test/mux.sh
+++ b/test/mux.sh
@@ -469,13 +469,13 @@ if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" -o "$MUX_FILE_BUFFER_STORAGE_TYPE" 
     mymessage="GET /${uuid_es} 404 "
     qs='{"query":{"match_phrase":{"message":"'"${mymessage}"'"}}}'
     os::log::debug "Check kibana log - message \"${mymessage}\""
-    os::cmd::try_until_success "curl_es $es_pod /${myproject}.*/_count -XPOST -d '$qs' | get_count_from_json | grep -q 1" "$(( 10*minute ))"
+    os::cmd::try_until_success "curl_es $es_pod /${myproject}.*/_count -XPOST -d '$qs' | get_count_from_json | egrep -q '^1$'" "$(( 10*minute ))"
 
     myproject=.operations
     mymessage=$uuid_es_ops
     qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${mymessage}"'"}}}'
     os::log::debug "Check system log - SYSLOG_IDENTIFIER \"${mymessage}\""
-    os::cmd::try_until_success "curl_es $es_ops_pod /${myproject}.*/_count -XPOST -d '$qs' | get_count_from_json | grep -q 1" "$(( 10*minute ))"
+    os::cmd::try_until_success "curl_es $es_ops_pod /${myproject}.*/_count -XPOST -d '$qs' | get_count_from_json | egrep -q '^1$'" "$(( 10*minute ))"
 fi
 
 os::log::info "------- Test case $SET_CONTAINER_VALS -------"


### PR DESCRIPTION
- Removing unnecessary "oc rollout" for fluentd in fluentd-forward.sh
- Checking the search result count strictly with '^1$' in mux.sh.

Note: no need backport/3.6.  It's already removed.