### PR TITLE
fluentd: pick fluent-plugin-rewrite-tag-filter version

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -37,7 +37,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
       fluentd:${FLUENTD_VERSION} \
       fluent-plugin-kubernetes_metadata_filter \
       'fluent-plugin-record-modifier:<1.0.0' \
-      fluent-plugin-rewrite-tag-filter \
+      'fluent-plugin-rewrite-tag-filter:<2.0.0' \
       fluent-plugin-secure-forward \
      'fluent-plugin-systemd:<0.1.0' \
       fluent-plugin-viaq_data_model \


### PR DESCRIPTION
The fluent-plugin-rewrite-tag-filter was released today and the latest version 2.0.0 requires ruby 2.1 and fluentd 0.14.2.

Since we pack ruby 2.0 and fluentd 0.12.39, restricting the rewrite-tag plugin to <2.0.0, otherwise gem install fails with:
```
[openshift/origin-logging-fluentd] ERROR:  Error installing fluent-plugin-rewrite-tag-filter:
[openshift/origin-logging-fluentd]      serverengine requires Ruby version >= 2.1.0.
```

https://github.com/fluent/fluent-plugin-rewrite-tag-filter