### PR TITLE
Vendor origin/hack/lib at c21a470

### DIFF
--- a/hack/lib/build/constants.sh
+++ b/hack/lib/build/constants.sh
@@ -7,7 +7,7 @@ readonly OS_BUILD_ENV_IMAGE="${OS_BUILD_ENV_IMAGE:-openshift/origin-release:gola
 
 readonly OS_OUTPUT_BASEPATH="${OS_OUTPUT_BASEPATH:-_output}"
 readonly OS_BASE_OUTPUT="${OS_ROOT}/${OS_OUTPUT_BASEPATH}"
-readonly OS_OUTPUT_SCRIPTPATH="${OS_BASE_OUTPUT}/scripts"
+readonly OS_OUTPUT_SCRIPTPATH="${OS_OUTPUT_SCRIPTPATH:-"${OS_BASE_OUTPUT}/scripts"}"
 
 readonly OS_OUTPUT_SUBPATH="${OS_OUTPUT_SUBPATH:-${OS_OUTPUT_BASEPATH}/local}"
 readonly OS_OUTPUT="${OS_ROOT}/${OS_OUTPUT_SUBPATH}"
@@ -19,18 +19,18 @@ readonly OS_OUTPUT_PKGDIR="${OS_OUTPUT}/pkgdir"
 readonly OS_GO_PACKAGE=github.com/openshift/origin
 
 readonly OS_SDN_COMPILE_TARGETS_LINUX=(
-  pkg/sdn/plugin/sdn-cni-plugin
+  pkg/network/sdn-cni-plugin
   vendor/github.com/containernetworking/cni/plugins/ipam/host-local
   vendor/github.com/containernetworking/cni/plugins/main/loopback
 )
 readonly OS_IMAGE_COMPILE_TARGETS_LINUX=(
-  images/pod
   cmd/dockerregistry
   cmd/gitserver
   vendor/k8s.io/kubernetes/cmd/hyperkube
   "${OS_SDN_COMPILE_TARGETS_LINUX[@]}"
 )
 readonly OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX=(
+  images/pod
   examples/hello-openshift
 )
 readonly OS_IMAGE_COMPILE_BINARIES=("${OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX[@]##*/}" "${OS_IMAGE_COMPILE_TARGETS_LINUX[@]##*/}")
@@ -39,6 +39,7 @@ readonly OS_CROSS_COMPILE_TARGETS=(
   cmd/openshift
   cmd/oc
   cmd/kubefed
+  cmd/template-service-broker
 )
 readonly OS_CROSS_COMPILE_BINARIES=("${OS_CROSS_COMPILE_TARGETS[@]##*/}")
 

--- a/hack/lib/build/environment.sh
+++ b/hack/lib/build/environment.sh
@@ -72,6 +72,11 @@ function os::build::environment::create() {
     fi
     if [[ "${cmd[0]}" == "/bin/sh" || "${cmd[0]}" == "/bin/bash" ]]; then
       additional_context+=" -it"
+    else
+      # container exit races with log collection so we
+      # need to sleep at the end but preserve the exit
+      # code of whatever the user asked for us to run
+      cmd=( '/bin/bash' '-c' "${cmd[*]}; return_code=\$?; sleep 1; exit \${return_code}" )
     fi
   fi
 
@@ -99,11 +104,22 @@ readonly -f os::build::environment::release::workingdir
 # (unless OS_BUILD_ENV_LEAVE_CONTAINER is set, in which case it will only stop the container).
 function os::build::environment::cleanup() {
   local container=$1
+  local volume=$2
+  local tmp_volume=$3
   os::log::debug "Stopping container ${container}"
   docker stop --time=0 "${container}" > /dev/null || true
   if [[ -z "${OS_BUILD_ENV_LEAVE_CONTAINER:-}" ]]; then
     os::log::debug "Removing container ${container}"
     docker rm "${container}" > /dev/null
+
+    if [[ -z "${OS_BUILD_ENV_REUSE_TMP_VOLUME:-}" ]]; then
+      os::log::debug "Removing tmp build volume"
+      os::build::environment::remove_volume "${tmp_volume}"
+    fi
+    if [[ -n "${OS_BUILD_ENV_CLEAN_BUILD_VOLUME:-}" ]]; then
+      os::log::debug "Removing build volume"
+      os::build::environment::remove_volume "${volume}"
+    fi
   fi
 }
 readonly -f os::build::environment::cleanup
@@ -252,7 +268,7 @@ function os::build::environment::run() {
 
   local container
   container="$( os::build::environment::create "$@" )"
-  trap "os::build::environment::cleanup ${container}" EXIT
+  trap "os::build::environment::cleanup ${container} ${volume} ${tmp_volume}" EXIT
 
   os::log::debug "Using container ${container}"
 

--- a/hack/lib/build/images.sh
+++ b/hack/lib/build/images.sh
@@ -25,7 +25,13 @@ function os::build::image() {
 		# available, falling back to the last commit
 		# if no release commit is recorded
 		local release_commit
-		release_commit="${OS_RELEASE_COMMIT:-"$( git log -1 --pretty=%h )"}"
+		release_commit="${OS_RELEASE_COMMIT-}"
+		if [[ -z "${release_commit}" && -f "${OS_OUTPUT_RELEASEPATH}/.commit" ]]; then
+			release_commit="$( cat "${OS_OUTPUT_RELEASEPATH}/.commit" )"
+		fi
+		if [[ -z "${release_commit}" ]]; then
+			release_commit="$( git log -1 --pretty=%h )"
+		fi
 		extra_tag="${tag}:${release_commit}"
 
 		tag="${tag}:latest"
@@ -128,7 +134,7 @@ function os::build::image::internal::docker() {
 	local options=()
 
 	if ! docker build ${OS_BUILD_IMAGE_ARGS:-} -t "${tag}" "${directory}"; then
-		return "$?"
+		return 1
 	fi
 
 	if [[ -n "${extra_tag}" ]]; then

--- a/hack/lib/build/release.sh
+++ b/hack/lib/build/release.sh
@@ -4,7 +4,7 @@
 
 # os::build::release::check_for_rpms checks that an RPM release has been built
 function os::build::release::check_for_rpms() {
-	if [[ ! -d "${OS_OUTPUT_RPMPATH}" || ! -s "${OS_OUTPUT_RELEASEPATH}/CHECKSUM" ]]; then
+	if [[ ! -d "${OS_OUTPUT_RPMPATH}" || ! -d "${OS_OUTPUT_RPMPATH}/repodata" ]]; then
 		relative_release_path="$( os::util::repository_relative_path "${OS_OUTPUT_RELEASEPATH}" )"
 		relative_bin_path="$( os::util::repository_relative_path "${OS_OUTPUT_BINPATH}" )"
 		os::log::fatal "No release RPMs have been built! RPMs are necessary to build container images.

--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -108,7 +108,7 @@ minute=$(( 60 * second ))
 function os::cmd::try_until_success() {
 	if [[ $# -lt 1 ]]; then echo "os::cmd::try_until_success expects at least one arguments, got $#"; return 1; fi
 	local cmd=$1
-	local duration=${2:-minute}
+	local duration=${2:-$minute}
 	local interval=${3:-0.2}
 
 	os::cmd::internal::run_until_exit_code "${cmd}" "os::cmd::internal::success_func" "${duration}" "${interval}"
@@ -133,7 +133,7 @@ function os::cmd::try_until_text() {
 	if [[ $# -lt 2 ]]; then echo "os::cmd::try_until_text expects at least two arguments, got $#"; return 1; fi
 	local cmd=$1
 	local text=$2
-	local duration=${3:-minute}
+	local duration=${3:-$minute}
 	local interval=${4:-0.2}
 
 	os::cmd::internal::run_until_text "${cmd}" "${text}" "os::cmd::internal::success_func" "${duration}" "${interval}"
@@ -146,7 +146,7 @@ function os::cmd::try_until_not_text() {
 	if [[ $# -lt 2 ]]; then echo "os::cmd::try_until_not_text expects at least two arguments, got $#"; return 1; fi
 	local cmd=$1
 	local text=$2
-	local duration=${3:-minute}
+	local duration=${3:-$minute}
 	local interval=${4:-0.2}
 
 	os::cmd::internal::run_until_text "${cmd}" "${text}" "os::cmd::internal::failure_func" "${duration}" "${interval}"

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -33,6 +33,8 @@ readonly -f os::util::absolute_path
 init_source="$( dirname "${BASH_SOURCE}" )/../.."
 OS_ROOT="$( os::util::absolute_path "${init_source}" )"
 export OS_ROOT
+OS_O_A_L_DIR="${OS_ROOT}"
+export OS_O_A_L_DIR
 cd "${OS_ROOT}"
 
 for library_file in $( find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -path '*/hack/lib/init.sh' ); do

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -33,8 +33,6 @@ readonly -f os::util::absolute_path
 init_source="$( dirname "${BASH_SOURCE}" )/../.."
 OS_ROOT="$( os::util::absolute_path "${init_source}" )"
 export OS_ROOT
-OS_O_A_L_DIR="${OS_ROOT}"
-export OS_O_A_L_DIR
 cd "${OS_ROOT}"
 
 for library_file in $( find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -path '*/hack/lib/init.sh' ); do
@@ -54,4 +52,9 @@ os::util::environment::update_path_var
 
 if [[ -z "${OS_TMP_ENV_SET-}" ]]; then
 	os::util::environment::setup_tmpdir_vars "$( basename "$0" ".sh" )"
+fi
+
+# Allow setting $JUNIT_REPORT to toggle output behavior
+if [[ -n "${JUNIT_REPORT:-}" ]]; then
+  export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
 fi

--- a/hack/lib/util/ensure.sh
+++ b/hack/lib/util/ensure.sh
@@ -45,11 +45,11 @@ function os::util::ensure::built_binary_exists() {
 
 	if ! os::util::find::built_binary "${binary}" >/dev/null 2>&1; then
 		if [[ -z "${target}" ]]; then
-			if [[ -d "${OS_ROOT}/cmd/${binary}" ]]; then
+			if [[ -d "${OS_ROOT}/../origin/cmd/${binary}" ]]; then
 				target="cmd/${binary}"
-			elif [[ -d "${OS_ROOT}/tools/${binary}" ]]; then
+			elif [[ -d "${OS_ROOT}/../origin/tools/${binary}" ]]; then
 				target="tools/${binary}"
-			elif [[ -d "${OS_ROOT}/tools/rebasehelpers/${binary}" ]]; then
+			elif [[ -d "${OS_ROOT}/../origin/tools/rebasehelpers/${binary}" ]]; then
 				target="tools/rebasehelpers/${binary}"
 			fi
 		fi
@@ -57,7 +57,7 @@ function os::util::ensure::built_binary_exists() {
 		if [[ -n "${target}" ]]; then
 			os::log::info "No compiled \`${binary}\` binary was found. Attempting to build one using:
   $ hack/build-go.sh ${target}"
-			"${OS_ROOT}/hack/build-go.sh" "${target}"
+			"${OS_ROOT}/../origin/hack/build-go.sh" "${target}"
 		else
 			os::log::fatal "No compiled \`${binary}\` binary was found and no build target could be determined.
 Provide the binary and try running $0 again."

--- a/hack/lib/util/ensure.sh
+++ b/hack/lib/util/ensure.sh
@@ -45,11 +45,11 @@ function os::util::ensure::built_binary_exists() {
 
 	if ! os::util::find::built_binary "${binary}" >/dev/null 2>&1; then
 		if [[ -z "${target}" ]]; then
-			if [[ -d "${OS_ROOT}/../origin/cmd/${binary}" ]]; then
+			if [[ -d "${OS_ROOT}/cmd/${binary}" ]]; then
 				target="cmd/${binary}"
-			elif [[ -d "${OS_ROOT}/../origin/tools/${binary}" ]]; then
+			elif [[ -d "${OS_ROOT}/tools/${binary}" ]]; then
 				target="tools/${binary}"
-			elif [[ -d "${OS_ROOT}/../origin/tools/rebasehelpers/${binary}" ]]; then
+			elif [[ -d "${OS_ROOT}/tools/rebasehelpers/${binary}" ]]; then
 				target="tools/rebasehelpers/${binary}"
 			fi
 		fi
@@ -57,7 +57,7 @@ function os::util::ensure::built_binary_exists() {
 		if [[ -n "${target}" ]]; then
 			os::log::info "No compiled \`${binary}\` binary was found. Attempting to build one using:
   $ hack/build-go.sh ${target}"
-			"${OS_ROOT}/../origin/hack/build-go.sh" "${target}"
+			"${OS_ROOT}/hack/build-go.sh" "${target}"
 		else
 			os::log::fatal "No compiled \`${binary}\` binary was found and no build target could be determined.
 Provide the binary and try running $0 again."


### PR DESCRIPTION
Vendor origin/hack/lib at c21a470

Changelog:
e896431 Remove the need for release tars in normal code paths
e96e8b9 Avoid compiling all of kube twice for images
e92f7d1 Bug - propagate docker build image failure
b0733ab hack/lib/cmd.sh - replacing "minute" with "$minute" in "local duration=${#:-minute}".
6520da4 catalog: add versioning for release build
fde93bc Parse $JUNIT_REPORT=true in the Bash init script
1e62b2d Allow the script output path to be overridden
2ff4749 Sleep at the end of every `hack/env` invocation for logs
aa65c60 add template-service-broker command
5a4f740 Remove build docker volumes if OS_BUILD_ENV_CLEAN_BUILD_VOLUME is set.
c3239dd Rename pkg/sdn to pkg/network, for consistency with its API
b10b42b hack/env: remove tmp volume if not user specified
4570e27 Split up SDN master/node/proxy/CNI code

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

[carry] Ensure that $OS_ROOT = $OS_O_A_L_DIR

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

[carry] Point os::util::ensure::built_binary_exists at Origin

When the Bash tooling relies on tools built out of Origin, it tries to
build them from the Origin repository. This is not a great hack as it
requires you to have Origin checked out still as a sister repository,
but we need to do more thinking for this.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


/assign @richm