### PR TITLE
[3.6] escaping "." for regex

### DIFF
--- a/test/mux.sh
+++ b/test/mux.sh
@@ -308,8 +308,8 @@ write_and_verify_logs() {
         sudo journalctl -o export -t $uuid_es_ops | mux_out || :
         exit 1
     fi
-    os::cmd::expect_success_and_not_text "curl_es $es_pod /_cat/indices" "project.default"
-    os::cmd::expect_success_and_not_text "curl_es $es_ops_pod /_cat/indices" "project.default"
+    os::cmd::expect_success_and_not_text "curl_es $es_pod /_cat/indices" "project\.default"
+    os::cmd::expect_success_and_not_text "curl_es $es_ops_pod /_cat/indices" "project\.default"
 }
 
 reset_ES_HOST() {
@@ -326,7 +326,7 @@ cleanup() {
     local return_code="$?"
     set +e
 
-    # In case test failed in Test case FILE_BUFFER_STORAGE_TYPE: $MUX_FILE_BUFFER_STORAGE_TYPE 
+    # In case test failed in Test case FILE_BUFFER_STORAGE_TYPE: $MUX_FILE_BUFFER_STORAGE_TYPE
     # reset ES_HOST and OPS_HOST
     reset_ES_HOST $ES_HOST_BAK $OPS_HOST_BAK
 

--- a/test/zzz-correct-index-names.sh
+++ b/test/zzz-correct-index-names.sh
@@ -26,11 +26,11 @@ es_ops_pod=${es_ops_pod:-$es_pod}
 
 for project in default openshift openshift-infra ; do
     qs='{"query":{"term":{"kubernetes.namespace_name":"'"${project}"'"}}}'
-    os::cmd::expect_success_and_not_text "curl_es $es_pod /_cat/indices" "project.${project}."
+    os::cmd::expect_success_and_not_text "curl_es $es_pod /_cat/indices" "project\.${project}\."
     os::cmd::expect_success_and_text "curl_es $es_pod /project.${project}.*/_count | get_count_from_json" "^0\$"
     os::cmd::expect_success_and_text "curl_es $es_pod /project.*/_count -X POST -d '$qs' | get_count_from_json" "^0\$"
     if [ "$es_pod" != "$es_ops_pod" ] ; then
-        os::cmd::expect_success_and_not_text "curl_es $es_ops_pod /_cat/indices" "project.${project}."
+        os::cmd::expect_success_and_not_text "curl_es $es_ops_pod /_cat/indices" "project\.${project}\."
         os::cmd::expect_success_and_text "curl_es $es_ops_pod /project.${project}.*/_count | get_count_from_json" "^0\$"
         os::cmd::expect_success_and_text "curl_es $es_ops_pod /project.*/_count -X POST -d '$qs' | get_count_from_json" "^0\$"
     fi


### PR DESCRIPTION
Backport of https://github.com/openshift/origin-aggregated-logging/pull/771

our logging test isn't escaping regex characters for `os::cmd::expect_success_and_not_text` which is causing it to fail as below:

```
FAILURE after 0.436s: test/zzz-correct-index-names.sh:29: executing 'curl_es logging-es-data-master-1mn7xrgj-1-2lvwp /_cat/indices' expecting success and not text 'project.openshift.': the output content test failed
Standard output from the command:
green open .kibana.95c4a1f66e0e565b219bbd5ba5bad200116351c3                                          1 0    3 0 35.3kb 35.3kb 
green open .kibana                                                                                   1 0    1 0  3.1kb  3.1kb 
green open project.logging.44059e9a-c4c0-11e7-9de3-0e79b72cd796.2017.11.08                           1 0 2179 0  1.6mb  1.6mb 
green open project.mux-undefined.8d3953d4-c4c1-11e7-9de3-0e79b72cd796.2017.11.08                     1 0   34 0 62.8kb 62.8kb 
green open project.openshift-template-service-broker.cdba30b1-c4c0-11e7-9de3-0e79b72cd796.2017.11.08 1 0  168 0  216kb  216kb 
green open .kibana.d033e22ae348aeb5660fc2140aec35850c4da997                                          1 0    6 1 59.7kb 59.7kb 
green open project.kube-service-catalog.a57bff2e-c4c0-11e7-9de3-0e79b72cd796.2017.11.08              1 0 6614 0  6.7mb  6.7mb 
green open project.openshift-ansible-service-broker.c2d1db49-c4c0-11e7-9de3-0e79b72cd796.2017.11.08  1 0   13 0 80.1kb 80.1kb 
green open .kibana.d5675a53ada6b361fb95c821bf35696b926d5acf                                          1 0    3 0 35.3kb 35.3kb 
green open .searchguard.logging-es-data-master-1mn7xrgj  
```