### PR TITLE
To avoid DEPRECATED warning, set 'fluent-plugin-rewrite-tag-filter:<1.6.0'

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -37,7 +37,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
       fluentd:${FLUENTD_VERSION} \
       fluent-plugin-kubernetes_metadata_filter \
       'fluent-plugin-record-modifier:<1.0.0' \
-      'fluent-plugin-rewrite-tag-filter:<2.0.0' \
+      'fluent-plugin-rewrite-tag-filter:<1.6.0' \
       fluent-plugin-secure-forward \
      'fluent-plugin-systemd:<0.1.0' \
       fluent-plugin-viaq_data_model \


### PR DESCRIPTION
Sample warning:
[warn]: rewrite_tag_filter: [DEPRECATED] Use <rule> section instead of rewriterule1

Discussed on:
https://github.com/openshift/origin-aggregated-logging/issues/769