### PR TITLE
if only 1 output, just remove output-operations.conf so it will not match ops logs

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -134,7 +134,7 @@ if [ -n "${MUX_CLIENT_MODE:-}" ] ; then
     # A fluentd collector configured as a mux client has just one output: sending to a mux.
     NUM_OUTPUTS=1
     rm -f $CFG_DIR/openshift/filter-post-z-retag-*.conf
-    if [ "$output_label" != "" ]; then
+    if [ -n "$output_label" ]; then
         cp $CFG_DIR/{,openshift}/filter-post-z-mux-client.conf
     fi
 else
@@ -142,10 +142,11 @@ else
     if [ "$ES_HOST" = ${OPS_HOST:-""} -a $ES_PORT -eq ${OPS_PORT:-0} ]; then
         # There is one output Elasticsearch
         NUM_OUTPUTS=1
-        # Disable "output-es-ops-config.conf in output-operations.conf"
-        echo > $CFG_DIR/dynamic/output-es-ops-config.conf
+        # Disable "output-operations.conf"
+        rm -f $CFG_DIR/openshift/output-operations.conf
+        touch $CFG_DIR/openshift/output-operations.conf
         rm -f $CFG_DIR/openshift/filter-post-z-retag-*.conf $CFG_DIR/openshift/filter-post-mux-client.conf
-        if [ "$output_label" != "" ]; then
+        if [ -n "$output_label"  ]; then
             cp $CFG_DIR/{,openshift}/filter-post-z-retag-one.conf
         fi
     else
@@ -153,7 +154,7 @@ else
         # Enable "output-es-ops-config.conf in output-operations.conf"
         cp $CFG_DIR/{openshift,dynamic}/output-es-ops-config.conf
         rm -f $CFG_DIR/openshift/filter-post-z-retag-*.conf $CFG_DIR/openshift/filter-post-mux-client.conf
-        if [ "$output_label" != "" ]; then
+        if [ -n "$output_label" ]; then
             cp $CFG_DIR/{,openshift}/filter-post-z-retag-two.conf
         fi
     fi


### PR DESCRIPTION
If there is no @OUTPUT tag in fluent.conf, and
if there is only one output (i.e. not using ops cluster), then we need
all of the output logs to go to the `match **` in output-applications.conf
instead of the matches for the various types of operations logs in
output-operations.conf.  So, just remove output-operations.conf in that
case.

NOTE WELL: This means that if you want to send operations logs and
applications logs to different destinations, out of the box, it will
not work.  There will be some customization of fluent.conf in the
configmap required.
/test