### PR TITLE
Bug 1513254 - logging-fluentd performance regression between 3.7.0-0.158.0 and 3.7.7 + message loss.

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -268,6 +268,11 @@ else
     touch $CFG_DIR/openshift/filter-pre-a-audit-exclude.conf
 fi
 
+if [ "${ENABLE_UTF8_FILTER:-}" != true ] ; then
+    rm -f $CFG_DIR/openshift/filter-pre-force-utf8.conf
+    touch $CFG_DIR/openshift/filter-pre-force-utf8.conf
+fi
+
 if [[ $DEBUG ]] ; then
     exec fluentd $fluentdargs > /var/log/fluentd.log 2>&1
 else


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1513254
The utf8 filter causes the peformance to be cut in half.  Disable
it by default.  If you need to use it, and can pay the performance
penalty,

    oc set env ds/logging-fluentd ENABLE_UTF8_FILTER=true

see also https://github.com/openshift/origin-aggregated-logging/pull/622

/test