### PR TITLE
jemalloc support - vendored in - source built in Dockerfile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "eventrouter"]
 	path = eventrouter
 	url = https://github.com/openshift/eventrouter
+[submodule "fluentd/jemalloc"]
+	path = fluentd/jemalloc
+	url = https://github.com/jemalloc/jemalloc

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -20,12 +20,15 @@ LABEL io.k8s.description="Fluentd container for collecting of docker container l
       io.openshift.tags="logging,elk,fluentd"
 
 USER 0
+
 # activesupport version 5.x requires ruby 2.2
 # iproute needed for ip command to get ip addresses
 RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum install -y --setopt=tsflags=nodocs \
-      bc iproute && \
+      bc iproute \
+      autoconf redhat-rpm-config && \
     yum clean all
+
 RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
     scl enable ${SCL_VERSION} -- \
      gem install -N --conservative --minimal-deps --no-ri --no-doc \
@@ -60,6 +63,15 @@ RUN scl enable ${SCL_VERSION} -- \
 RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
     chmod 777 /etc/fluent/configs.d/dynamic && \
     ln -s /etc/fluent/configs.d/user/fluent.conf /etc/fluent/fluent.conf
+
+ADD jemalloc/ ${HOME}/jemalloc/
+# note - make dist "fails" here
+# false -o doc/jemalloc.html doc/html.xsl doc/jemalloc.xml
+# so cannot use &&
+# cannot use make install - will try to install docs - not only does that fail
+# for some reason, but we also don't want them here - use install_lib install_bin
+RUN cd ${HOME}/jemalloc && EXTRA_CFLAGS="$( rpm --eval '%{optflags}' )" ./autogen.sh && \
+    make dist ; make && make install_lib install_bin && cd .. && rm -rf jemalloc
 
 WORKDIR ${HOME}
 USER 0

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
+fluentdargs="--no-supervisor"
 if [[ $VERBOSE ]]; then
   set -ex
-  fluentdargs="-vv"
+  fluentdargs="$fluentdargs -vv"
   echo ">>>>>> ENVIRONMENT VARS <<<<<"
   env | sort
   echo ">>>>>>>>>>>>><<<<<<<<<<<<<<<<"
 else
   set -e
-  fluentdargs=
 fi
 
 docker_uses_journal() {
@@ -271,6 +271,10 @@ fi
 if [ "${ENABLE_UTF8_FILTER:-}" != true ] ; then
     rm -f $CFG_DIR/openshift/filter-pre-force-utf8.conf
     touch $CFG_DIR/openshift/filter-pre-force-utf8.conf
+fi
+
+if type -p jemalloc-config > /dev/null 2>&1 && [ "${USE_JEMALLOC:-}" = true ] ; then
+    export LD_PRELOAD=$( jemalloc-config --libdir )/libjemalloc.so.$( jemalloc-config --revision )
 fi
 
 if [[ $DEBUG ]] ; then


### PR DESCRIPTION
jemalloc support
docker build will pull down the released tarball, configure, and
make install
If you want to use jemalloc:

    oc set env ds/logging-fluentd USE_JEMALLOC=true

This will cause fluentd to run with jemalloc.  It is off by default.

This also disables fluentd supervisor mode so that we
are only running the one fluentd process with jemalloc.

You can set jemalloc options by

    oc set env ds/logging-fluentd MALLOC_CONF="stats_print:true,prof:true,...."

see https://github.com/jemalloc/jemalloc/wiki/Getting-Started for more
information
/test