### PR TITLE
Throttle different pos

### DIFF
--- a/test/read-throttling.sh
+++ b/test/read-throttling.sh
@@ -25,6 +25,35 @@ oc get daemonset logging-fluentd -o yaml > $saveds
 savecm=$( mktemp )
 oc get configmap logging-fluentd -o yaml > $savecm
 
+stop_fluentd() {
+  os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+  os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+}
+
+start_fluentd() {
+  os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+  os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+}
+
+check_fluentd_pod_for_files() {
+  local files=$@
+
+  local fpod=$( get_running_pod fluentd )
+
+  for file in ${files}; do
+    os::cmd::expect_success "oc exec $fpod -- test -f $file"
+  done
+}
+
+check_fluentd_pod_file_content_for() {
+  local file=$1
+  local content="$2"
+
+  local fpod=$( get_running_pod fluentd )
+
+  os::cmd::expect_success_and_text "oc exec $fpod -- cat $file" "$content"
+}
+
 cleanup() {
     local return_code="$?"
     set +e
@@ -51,28 +80,35 @@ trap "cleanup" EXIT
 fpod=$( get_running_pod fluentd )
 
 # generate throttle config with invalid YAML
-os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+stop_fluentd
 os::log::debug "$( oc patch configmap/logging-fluentd --type=json \
    --patch '[{ "op": "replace", "path": "/data/throttle-config.yaml", "value": "\
     test-proj: read_lines_limit: bogus-value"}]' )"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+start_fluentd
 fpod=$( get_running_pod fluentd )
 # should have fluentd log messages like this
 os::cmd::expect_success_and_text "oc logs $fpod" "Could not parse YAML file"
 
+# generate a throttle config that properly generates different pos files
+stop_fluentd
+os::log::debug "$( oc patch configmap/logging-fluentd --type=json \
+   --patch '[{ "op": "replace", "path": "/data/throttle-config.yaml", "value": "\
+    test-proj:\n  read_lines_limit: 5\n.operations:\n  read_lines_limit: 5"}]' )"
+start_fluentd
+check_fluentd_pod_for_files '/var/log/es-container-test-proj.log.pos' '/var/log/es-container-openshift-operations.log.pos'
+check_fluentd_pod_file_content_for '/var/log/es-container-openshift-operations.log.pos' '.*_default_.*'
+
 # generate throttle config with a bogus key - verify the correct error
-os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+stop_fluentd
 os::log::debug "$( oc patch configmap/logging-fluentd --type=json \
    --patch '[{ "op": "replace", "path": "/data/throttle-config.yaml", "value": "\
     test-proj:\n  read_lines_limit: bogus-value\nbogus-project:\n  bogus-key: bogus-value"}]' )"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+start_fluentd
 fpod=$( get_running_pod fluentd )
 # should have fluentd log messages like this
 os::cmd::expect_success_and_text "oc logs $fpod" 'Unknown option "bogus-key"'
 os::cmd::expect_success_and_text "oc logs $fpod" 'Invalid key/value pair {"bogus-key":"bogus-value"} provided -- ignoring...'
 os::cmd::expect_success_and_text "oc logs $fpod" 'Invalid value type matched for "bogus-value"'
 os::cmd::expect_success_and_text "oc logs $fpod" 'Invalid key/value pair {"read_lines_limit":"bogus-value"} provided -- ignoring...'
+## Throttling should be reverted here, verify we moved our pos log entries
+check_fluentd_pod_file_content_for '/var/log/es-container-openshift-operations.log.pos' ''


### PR DESCRIPTION
When we generate our throttle config we should not be reusing the same `.pos` file for each config.
Adds test to confirm the files are being generated correctly.

To address https://bugzilla.redhat.com/show_bug.cgi?id=1496261