### PR TITLE
fluent-plugin-remote-syslog: adding the license info as suggested by …

### DIFF
--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -1,3 +1,6 @@
+#  License: MIT
+#  https://github.com/docebo/fluent-plugin-remote-syslog
+
 require 'fluent/mixin/config_placeholders'
 module Fluent
 

--- a/fluentd/out_syslog_buffered.rb
+++ b/fluentd/out_syslog_buffered.rb
@@ -1,3 +1,6 @@
+#  License: MIT
+#  https://github.com/docebo/fluent-plugin-remote-syslog
+
 require 'fluent/mixin/config_placeholders'
 module Fluent
   class SyslogBufferedOutput < Fluent::BufferedOutput


### PR DESCRIPTION
…the Legal team

On 12/08/2017 12:34 PM, Richard Fontana wrote:
  I suggest adding the information somehow - for example you could add the comment
    License: MIT
    https://github.com/docebo/fluent-plugin-remote-syslog
  at the top of the source files you're including, or indicate the same
  information a README file or the like.