### PR TITLE
Bug 1500086 - no authentication required to access elasticsearch

### DIFF
--- a/deployer/scripts/util.sh
+++ b/deployer/scripts/util.sh
@@ -170,6 +170,26 @@ function get_curator_dcs() {
     oc get dc --selector logging-infra=curator -o name
 }
 
+function get_es_pod() {
+    # $1 - cluster name postfix
+    if [ -z $(oc get dc -l cluster-name=logging-${1},es-node-role=clientdata --no-headers | awk '{print $1}') ] ; then
+      oc get pods -l component=${1} --no-headers | awk '$3 == "Running" {print $1}'
+    else
+      oc get pods -l cluster-name=logging-${1},es-node-role=clientdata --no-headers | awk '$3 == "Running" {print $1}'
+    fi
+}
+
+# set the test_token, test_name, and test_ip for token auth
+function get_test_user_token() {
+    local current_project; current_project="$( oc project -q )"
+    oc login --username=${1:-${LOG_ADMIN_USER:-admin}} --password=${2:-${LOG_ADMIN_PW:-admin}} > /dev/null
+    test_token="$(oc whoami -t)"
+    test_name="$(oc whoami)"
+    test_ip="127.0.0.1"
+    oc login --username=system:admin > /dev/null
+    oc project "${current_project}" > /dev/null
+}
+
 function extract_nodeselector() {
     local inputstring="${1//\"/}"  # remove any errant double quotes in the inputs
     local selectors=()
@@ -319,6 +339,92 @@ function get_latest_pod() {
   echo $pod
 }
 
+# $1 - kibana pod name
+# $2 - es hostname (e.g. logging-es or logging-es-ops)
+# $3 - endpoint (e.g. /projects.*/_search)
+# $4 - username
+# $5 - token
+# stdout is the JSON output from Elasticsearch
+# stderr is curl errors
+curl_es_from_kibana() {
+    local pod="$1"
+    local eshost="$2"
+    local endpoint="$3"
+    local test_name="$4"
+    local test_token="$5"
+    shift; shift; shift; shift; shift
+    local args=( "${@:-}" )
+
+    local secret_dir="/etc/kibana/keys/"
+    oc exec "${pod}" -c kibana -- curl --connect-timeout 1 --silent --insecure "${args[@]}" \
+       --cert "${secret_dir}cert" \
+       --key "${secret_dir}key" \
+       -H "X-Proxy-Remote-User: $test_name" \
+       -H "Authorization: Bearer $test_token" \
+       -H "X-Forwarded-For: 127.0.0.1" \
+       "https://${eshost}:9200${endpoint}"
+}
+
+# $1 - es pod name
+# $2 - es endpoint
+# rest - any args to pass to curl
+function curl_es() {
+    local pod="$1"
+    local endpoint="$2"
+    shift; shift
+    local args=( "${@:-}" )
+
+    local secret_dir="/etc/elasticsearch/secret/"
+    oc exec "${pod}" -- curl --silent --insecure "${args[@]}" \
+                             --key "${secret_dir}admin-key"   \
+                             --cert "${secret_dir}admin-cert" \
+                             "https://localhost:9200${endpoint}"
+}
+
+# $1 - es pod name
+# $2 - es endpoint
+# rest - any args to pass to curl
+function curl_es_input() {
+    local pod="$1"
+    local endpoint="$2"
+    shift; shift
+    local args=( "${@:-}" )
+
+    local secret_dir="/etc/elasticsearch/secret/"
+    oc exec -i "${pod}" -- curl --silent --insecure "${args[@]}" \
+                                --key "${secret_dir}admin-key"   \
+                                --cert "${secret_dir}admin-cert" \
+                                "https://localhost:9200${endpoint}"
+}
+
+function curl_es_with_token() {
+    local pod="$1"
+    local endpoint="$2"
+    local test_name="$3"
+    local test_token="$4"
+    shift; shift; shift; shift
+    local args=( "${@:-}" )
+    oc exec "${pod}" -- curl --silent --insecure "${args[@]}" \
+                             -H "X-Proxy-Remote-User: $test_name" \
+                             -H "Authorization: Bearer $test_token" \
+                             -H "X-Forwarded-For: 127.0.0.1" \
+                             "https://localhost:9200${endpoint}"
+}
+
+function curl_es_with_token_and_input() {
+    local pod="$1"
+    local endpoint="$2"
+    local test_name="$3"
+    local test_token="$4"
+    shift; shift; shift; shift
+    local args=( "${@:-}" )
+    oc exec -i "${pod}" -- curl --silent --insecure "${args[@]}" \
+                                -H "X-Proxy-Remote-User: $test_name" \
+                                -H "Authorization: Bearer $test_token" \
+                                -H "X-Forwarded-For: 127.0.0.1" \
+                                "https://localhost:9200${endpoint}"
+}
+
 # $1 - es pod name
 # $2 - es hostname (e.g. logging-es or logging-es-ops)
 # $3 - index name (e.g. project.logging, project.test, .operations, etc.)
@@ -362,7 +468,7 @@ function wait_for_es_ready() {
 }
 
 function get_count_from_json() {
-    python -c 'import json, sys; print json.loads(sys.stdin.read())["count"]'
+    python -c 'import json, sys; print json.loads(sys.stdin.read()).get("count", 0)'
 }
 
 # $1 - unique value to search for in es

--- a/hack/testing/signing.conf
+++ b/hack/testing/signing.conf
@@ -1,0 +1,103 @@
+# Simple Signing CA
+
+# The [default] section contains global constants that can be referred to from
+# the entire configuration file. It may also hold settings pertaining to more
+# than one openssl command.
+
+#[ default ]
+#dir                     = _output               # Top dir
+
+# The next part of the configuration file is used by the openssl req command.
+# It defines the CA's key pair, its DN, and the desired extensions for the CA
+# certificate.
+
+[ req ]
+default_bits            = 2048                  # RSA key size
+encrypt_key             = yes                   # Protect private key
+default_md              = sha1                  # MD to use
+utf8                    = yes                   # Input is UTF-8
+string_mask             = utf8only              # Emit UTF-8 strings
+prompt                  = no                    # Don't prompt for DN
+distinguished_name      = ca_dn                 # DN section
+req_extensions          = ca_reqext             # Desired extensions
+
+[ ca_dn ]
+0.domainComponent       = "io"
+1.domainComponent       = "openshift"
+organizationName        = "OpenShift Origin"
+organizationalUnitName  = "Logging Signing CA"
+commonName              = "Logging Signing CA"
+
+[ ca_reqext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true,pathlen:0
+subjectKeyIdentifier    = hash
+
+# The remainder of the configuration file is used by the openssl ca command.
+# The CA section defines the locations of CA assets, as well as the policies
+# applying to the CA.
+
+[ ca ]
+default_ca              = signing_ca            # The default CA section
+
+[ signing_ca ]
+certificate             = $dir/ca.crt       # The CA cert
+private_key             = $dir/ca.key # CA private key
+new_certs_dir           = $dir/           # Certificate archive
+serial                  = $dir/ca.serial.txt # Serial number file
+crlnumber               = $dir/ca.crl.srl # CRL number file
+database                = $dir/ca.db # Index file
+unique_subject          = no                    # Require unique subject
+default_days            = 730                   # How long to certify for
+default_md              = sha1                  # MD to use
+policy                  = any_pol             # Default naming policy
+email_in_dn             = no                    # Add email to cert DN
+preserve                = no                    # Keep passed DN ordering
+name_opt                = ca_default            # Subject DN display options
+cert_opt                = ca_default            # Certificate display options
+copy_extensions         = copy                  # Copy extensions from CSR
+x509_extensions         = client_ext             # Default cert extensions
+default_crl_days        = 7                     # How long before next CRL
+crl_extensions          = crl_ext               # CRL extensions
+
+# Naming policies control which parts of a DN end up in the certificate and
+# under what circumstances certification should be denied.
+
+[ match_pol ]
+domainComponent         = match                 # Must match 'simple.org'
+organizationName        = match                 # Must match 'Simple Inc'
+organizationalUnitName  = optional              # Included if present
+commonName              = supplied              # Must be present
+
+[ any_pol ]
+domainComponent         = optional
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = optional
+emailAddress            = optional
+
+# Certificate extensions define what types of certificates the CA is able to
+# create.
+
+[ client_ext ]
+keyUsage                = critical,digitalSignature,keyEncipherment
+basicConstraints        = CA:false
+extendedKeyUsage        = clientAuth
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid
+
+[ server_ext ]
+keyUsage                = critical,digitalSignature,keyEncipherment
+basicConstraints        = CA:false
+extendedKeyUsage        = serverAuth,clientAuth
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid
+
+# CRL extensions exist solely to point to the CA certificate that has issued
+# the CRL.
+
+[ crl_ext ]
+authorityKeyIdentifier  = keyid

--- a/hack/testing/test-access-control.sh
+++ b/hack/testing/test-access-control.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+
+# test access control
+# test access control
+if ! type get_running_pod > /dev/null 2>&1 ; then
+    . ${OS_O_A_L_DIR:-../..}/deployer/scripts/util.sh
+fi
+# include all the origin test libs we need
+if [ -f ${OS_ROOT}/hack/lib/init.sh ] ; then
+    # disallow init.sh from calling setup_tmpdir_vars
+    export OS_TMP_ENV_SET=origin-aggregated-logging
+    source ${OS_ROOT}/hack/lib/init.sh # one stop shopping
+else
+    for lib in "${OS_ROOT}"/hack/{util.sh,text.sh} \
+               "${OS_ROOT}"/hack/lib/*.sh "${OS_ROOT}"/hack/lib/**/*.sh
+    do source "$lib"; done
+fi
+trap os::test::junit::reconcile_output EXIT
+os::util::environment::use_sudo
+
+os::test::junit::declare_suite_start "test/access_control"
+
+espod=$( get_es_pod es )
+esopspod=$( get_es_pod es-ops )
+esopspod=${esopspod:-$espod}
+
+delete_users=""
+REUSE=${REUSE:-false}
+
+function cleanup() {
+    local result_code="$?"
+    set +e
+    if [ "${REUSE:-false}" = false ] ; then
+        for user in $delete_users ; do
+            os::log::debug "$( oc delete user $user )"
+        done
+    fi
+    if [ -n "${espod:-}" ] ; then
+        curl_es $espod /project.access-control-* -XDELETE > /dev/null
+    fi
+    for proj in access-control-1 access-control-2 access-control-3 ; do
+        oc delete project $proj 2>&1 | artifact_out
+        os::cmd::try_until_failure "oc get project $proj" 2>&1 | artifact_out
+    done
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $result_code
+}
+
+trap cleanup EXIT
+
+function create_user_and_assign_to_projects() {
+    local current_project; current_project="$( oc project -q )"
+    local user=$1; shift
+    local pw=$1; shift
+    if oc get users $user > /dev/null 2>&1 ; then
+        os::log::info Using existing user $user
+    else
+        os::log::info Creating user $user with password $pw
+        oc login --username=$user --password=$pw 2>&1 | artifact_out
+        delete_users="$delete_users $user"
+    fi
+    os::log::debug "$( oc login --username=system:admin 2>&1 )"
+    os::log::info Assigning user to projects "$@"
+    while [ -n "${1:-}" ] ; do
+        os::log::debug "$( oc project $1 2>&1 )"
+        os::log::debug "$( oc adm policy add-role-to-user view $user 2>&1 )"
+        shift
+    done
+    oc project "${current_project}" > /dev/null
+}
+
+function add_message_to_index() {
+    # project is $1
+    # message is $2
+    # espod is $3
+    local project_uuid=$( oc get project $1 -o jsonpath='{ .metadata.uid }' )
+    local index="project.$1.$project_uuid.$(date -u +'%Y.%m.%d')"
+    os::log::debug $( curl_es "$3" "/$index/access-control-test/" -XPOST -d '{"message":"'${2:-"access-control message"}'"}' | python -mjson.tool 2>&1 )
+}
+
+# test the following
+# - regular user can access with username/token
+#   - directly against es
+#   - via kibana pod with kibana cert/key
+# - regular user cannot access unavailable indices
+#   - directly against es
+#   - via kibana pod with kibana cert/key
+# - regular user cannot access .operations
+#   - via es or kibana
+#   - with username admin and no token
+#   - with username admin and bogus token
+# - username without token fails
+#   - via es or kibana
+# - token without username fails
+#   - via es or kibana
+function test_user_has_proper_access() {
+    local user=$1; shift
+    local pw=$1; shift
+    # rest - indices to which access should be granted, followed by --,
+    # followed by indices to which access should not be granted
+    local expected=1
+    local verb=cannot
+    local negverb=can
+    local nrecs=0
+    local kpod=$( get_running_pod kibana )
+    eshost=logging-es
+    esopshost=logging-es-ops
+    if [ "$espod" = "$esopspod" ] ; then
+        esopshost=$eshost
+    fi
+    get_test_user_token $user $pw
+    for proj in "$@" ; do
+        if [ "$proj" = "--" ] ; then
+            expected=0
+            verb=can
+            negverb=cannot
+            continue
+        fi
+        os::log::info See if user $user $negverb read /project.$proj.*
+        nrecs=$( curl_es_with_token $espod "/project.$proj.*/_count" $test_name $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from es
+            curl_es_with_token $espod "/project.$proj.*/_count" $test_name $test_token | python -mjson.tool
+            exit 1
+        fi
+        nrecs=$( curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" $test_name $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from kibana
+            curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" $test_name $test_token | python -mjson.tool
+            exit 1
+        fi
+        # no user name - allow it - look up username corresponding to token
+        nrecs=$( curl_es_with_token $espod "/project.$proj.*/_count" "" $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from es
+            curl_es_with_token $espod "/project.$proj.*/_count" "" $test_token | python -mjson.tool
+            exit 1
+        fi
+        nrecs=$( curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" "" $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from kibana
+            curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" "" $test_token | python -mjson.tool
+            exit 1
+        fi
+        # if wrong user name is given, allow it - server will look up and use correct user name, so
+        # not possible to specify a privileged username to use for access with an unprivileged token
+        nrecs=$( curl_es_with_token $espod "/project.$proj.*/_count" $LOG_ADMIN_USER $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from es
+            curl_es_with_token $espod "/project.$proj.*/_count" $LOG_ADMIN_USER $test_token | python -mjson.tool
+            exit 1
+        fi
+        nrecs=$( curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" $LOG_ADMIN_USER $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from kibana
+            curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" $LOG_ADMIN_USER $test_token | python -mjson.tool
+            exit 1
+        fi
+        if [ "$expected" = 1 ] ; then
+            # make sure no access with incorrect auth
+            # username with no token
+            os::cmd::expect_success_and_text "curl_es_with_token $espod '/project.$proj.*/_count' '$test_name' '' -w '%{response_code}\n'" '^401$'
+            os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $eshost '/project.$proj.*/_count' '$test_name' '' -w '%{response_code}\n'" '^401$'
+            # username and bogus token
+            os::cmd::expect_success_and_text "curl_es_with_token $espod '/project.$proj.*/_count' '$test_name' BOGUS -w '%{response_code}\n'" '^401$'
+            os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $eshost '/project.$proj.*/_count' '$test_name' BOGUS -w '%{response_code}\n'" '^401$'
+            # no username, no token
+            os::cmd::expect_success_and_text "curl_es_with_token $espod '/project.$proj.*/_count' '' '' -w '%{response_code}\n'" '^401$'
+            os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $eshost '/project.$proj.*/_count' '' '' -w '%{response_code}\n' -o /dev/null" '^403$'
+        fi
+    done
+
+    os::log::info See if user $user is denied /.operations.*
+    nrecs=$( curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | \
+                 get_count_from_json )
+    if ! os::cmd::expect_success "test $nrecs = 0" ; then
+        os::log::error $LOG_NORMAL_USER has improper access to .operations.* indices from es
+        curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | python -mjson.tool
+        exit 1
+    fi
+    esopshost=logging-es-ops
+    if [ "$espod" = "$esopspod" ] ; then
+        esopshost=logging-es
+    fi
+    nrecs=$( curl_es_from_kibana "$kpod" "$esopshost" "/.operations.*/_count" $test_name $test_token | \
+                 get_count_from_json )
+    if ! os::cmd::expect_success "test $nrecs = 0" ; then
+        os::log::error $LOG_NORMAL_USER has improper access to .operations.* indices from kibana
+        curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | python -mjson.tool
+        exit 1
+    fi
+
+    os::log::info See if user $user is denied /.operations.* with no token
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' $user '' -w '%{response_code}\n'" '^401$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' $user '' -w '%{response_code}\n'" '^401$'
+
+    os::log::info See if user $user is denied /.operations.* with no username
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' '' $test_token -w '%{response_code}\n'" '}403$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' '' $test_token -w '%{response_code}\n'" '}403$'
+
+    os::log::info See if user $user is denied /.operations.* with no token using $LOG_ADMIN_USER
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' $LOG_ADMIN_USER '' -w '%{response_code}\n'" '^401$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' $LOG_ADMIN_USER '' -w '%{response_code}\n'" '^401$'
+
+    os::log::info See if user $user is denied /.operations.* with a bogus token using $LOG_ADMIN_USER
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' $LOG_ADMIN_USER BOGUS -w '%{response_code}\n'" '^401$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' $LOG_ADMIN_USER BOGUS -w '%{response_code}\n'" '^401$'
+
+    os::log::info See if access is denied to /.operations.* with no username and no token
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' '' '' -w '%{response_code}\n'" '^401$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' '' '' -w '%{response_code}\n' -o /dev/null" '^403$'
+
+    os::log::info See if user $user is denied /.operations.* with username that does not correspond to token
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' $LOG_ADMIN_USER $test_token -w '%{response_code}\n'" '}403$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' $LOG_ADMIN_USER $test_token -w '%{response_code}\n'" '}403$'
+}
+
+os::log::debug "$( curl_es $espod /project.access-control-* -XDELETE )"
+
+for proj in access-control-1 access-control-2 access-control-3 ; do
+    os::log::info Creating project $proj
+    oc adm new-project $proj --node-selector='' 2>&1 | artifact_out
+    os::cmd::try_until_success "oc get project $proj" 2>&1 | artifact_out
+
+    os::log::info Creating test index and entry for $proj
+    add_message_to_index $proj "" $espod
+done
+
+LOG_ADMIN_USER=${LOG_ADMIN_USER:-admin}
+LOG_ADMIN_PW=${LOG_ADMIN_PW:-admin}
+
+if oc get users "$LOG_ADMIN_USER" > /dev/null 2>&1 ; then
+    os::log::debug Using existing admin user $LOG_ADMIN_USER
+else
+    os::log::info Creating cluster-admin user $LOG_ADMIN_USER
+    current_project="$( oc project -q )"
+    os::log::debug "$( oc login --username=$LOG_ADMIN_USER --password=$LOG_ADMIN_PW )"
+    os::log::debug "$( oc login --username=system:admin )"
+    os::log::debug "$( oc project $current_project )"
+fi
+os::log::debug "$( oc adm policy add-cluster-role-to-user cluster-admin $LOG_ADMIN_USER )"
+
+# if you ever want to run this test again on the same machine, you'll need to
+# use different usernames, otherwise you'll get this odd error:
+# # oc login --username=loguser --password=loguser
+# error: The server was unable to respond - verify you have provided the correct host and port and that the server is currently running.
+# or - set REUSE=true
+LOG_NORMAL_USER=${LOG_NORMAL_USER:-loguserac}
+LOG_NORMAL_PW=${LOG_NORMAL_PW:-loguserac}
+
+LOG_USER2=${LOG_USER2:-loguser2ac}
+LOG_PW2=${LOG_PW2:-loguser2ac}
+
+create_user_and_assign_to_projects $LOG_NORMAL_USER $LOG_NORMAL_PW access-control-1 access-control-2
+create_user_and_assign_to_projects $LOG_USER2 $LOG_PW2 access-control-2 access-control-3
+
+oc login --username=system:admin > /dev/null
+oc project logging > /dev/null
+
+test_user_has_proper_access $LOG_NORMAL_USER $LOG_NORMAL_PW access-control-1 access-control-2 -- access-control-3
+test_user_has_proper_access $LOG_USER2 $LOG_PW2 access-control-2 access-control-3 -- access-control-1
+
+os::log::info now auth using admin + token
+get_test_user_token $LOG_ADMIN_USER $LOG_ADMIN_PW
+nrecs=$( curl_es_with_token $espod "/project.logging.*/_count" $test_name $test_token | \
+         get_count_from_json )
+os::cmd::expect_success "test $nrecs -gt 1"
+nrecs=$( curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | \
+         get_count_from_json )
+os::cmd::expect_success "test $nrecs -gt 1"
+
+os::log::info now see if regular users have access
+
+test_user_has_proper_access $LOG_NORMAL_USER $LOG_NORMAL_PW access-control-1 access-control-2 -- access-control-3
+test_user_has_proper_access $LOG_USER2 $LOG_PW2 access-control-2 access-control-3 -- access-control-1
+
+# create a dummy client cert/key - see if we can impersonate kibana with a cert
+certdir=$( mktemp -d )
+# if oc has the adm ca command then use it
+if oc adm --help | grep -q ' ca .*Manage certificates and keys' ; then
+    openshift_admin="oc adm"
+elif type -p openshift > /dev/null && openshift --help | grep -q '^  admin ' ; then
+    openshift_admin="openshift admin"
+else
+    openshift_admin="oc adm"
+fi
+$openshift_admin ca create-signer-cert  \
+    --key="${certdir}/ca.key" \
+    --cert="${certdir}/ca.crt" \
+    --serial="${certdir}/ca.serial.txt" \
+    --name="logging-signer-$(date +%Y%m%d%H%M%S)" 2>&1 | artifact_out
+cat - ${OS_O_A_L_DIR}/hack/testing/signing.conf > $certdir/signing.conf <<CONF
+[ default ]
+dir                     = ${certdir}               # Top dir
+CONF
+touch $certdir/ca.db
+openssl req -out "$certdir/test.csr" -new -newkey rsa:2048 -keyout "$certdir/test.key" \
+    -subj "/CN=system.logging.kibana/OU=OpenShift/O=Logging" -days 712 -nodes 2>&1 | artifact_out
+openssl ca \
+    -in "$certdir/test.csr" \
+    -notext \
+    -out "$certdir/test.crt" \
+    -config $certdir/signing.conf \
+    -extensions v3_req \
+    -batch \
+    -extensions server_ext 2>&1 | artifact_out
+oc rsync -c elasticsearch $certdir $espod:/tmp 2>&1 | artifact_out
+if [ "$espod" != "$esopspod" ] ; then
+    oc rsync -c elasticsearch $certdir $esopspod:/tmp 2>&1 | artifact_out
+fi
+
+os::cmd::expect_failure "oc exec -c elasticsearch $espod -- \
+    curl -s -k --cert $certdir/test.crt --key $certdir/test.key \
+    https://localhost:9200/.kibana/_count"
+os::cmd::expect_failure "oc exec -c elasticsearch $espod -- \
+    curl -s -k --cert $certdir/test.crt --key $certdir/test.key \
+    https://localhost:9200/project.*/_count"
+os::cmd::expect_failure "oc exec -c elasticsearch $esopspod -- \
+    curl -s -k --cert $certdir/test.crt --key $certdir/test.key \
+    https://localhost:9200/.operations.*/_count"
+rm -rf $certdir


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1500086
Test access control in many different ways, both against
Elasticsearch directly and via Kibana.
- proper token and username has access to correct projects
- proper token and username is denied access to disallowed projects
- admin has access to all indices
- username with no token is an error
- username with bogus token is an error
- username with wrong token is an error
- no username and no token is an error
- admin with no token is an error
- admin with bogus token is an error
- client cert auth with kibana cert issued by unknown CA is an error

(cherry picked from commit 6ccfa9d19d8ce579868cf0809cec3b25873211bd)