### PR TITLE
Bug 1500086 - no authentication required to access elasticsearch

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -295,6 +295,11 @@ else
     umount /var/lib/docker/containers/*/shm || :
 fi
 
+if [ "${ENABLE_UTF8_FILTER:-}" != true ] ; then
+    rm -f $CFG_DIR/openshift/filter-pre-force-utf8.conf
+    touch $CFG_DIR/openshift/filter-pre-force-utf8.conf
+fi
+
 if [[ $DEBUG ]] ; then
     exec fluentd $fluentdargs > /var/log/fluentd.log 2>&1
 else

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -30,12 +30,9 @@ source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 # fluentd to keep up with when it has 100m cpu (default), on a aws m4.xlarge
 # system for now, remove the limits on fluentd to unblock the tests
 oc get -n logging daemonset/logging-fluentd -o yaml > "${ARTIFACT_DIR}/logging-fluentd-orig.yaml"
-if [ -z "${USE_DEFAULT_FLUENTD_CPU_LIMIT:-}" ] && [ -n "$(oc get -n logging ds logging-fluentd -o jsonpath='{.spec.template.spec.containers[0].resources.limits.cpu}')" ] ; then
+if [[ -z "${USE_DEFAULT_FLUENTD_CPU_LIMIT:-}" && -n "$(oc get ds logging-fluentd -o jsonpath={.spec.template.spec.containers[0].resources.limits.cpu})" ]] ; then
     oc patch -n logging daemonset/logging-fluentd --type=json --patch '[
           {"op":"remove","path":"/spec/template/spec/containers/0/resources/limits/cpu"}]'
-else
-    os::log::info Not removing fluentd cpu limit: USE_DEFAULT_FLUENTD_CPU_LIMIT ${USE_DEFAULT_FLUENTD_CPU_LIMIT:-}
-    oc get -n logging ds logging-fluentd -o jsonpath='{.spec.template.spec.containers[0].resources.limits.cpu}'
 fi
 
 # start a fluentd performance monitor

--- a/hack/testing/signing.conf
+++ b/hack/testing/signing.conf
@@ -1,0 +1,103 @@
+# Simple Signing CA
+
+# The [default] section contains global constants that can be referred to from
+# the entire configuration file. It may also hold settings pertaining to more
+# than one openssl command.
+
+#[ default ]
+#dir                     = _output               # Top dir
+
+# The next part of the configuration file is used by the openssl req command.
+# It defines the CA's key pair, its DN, and the desired extensions for the CA
+# certificate.
+
+[ req ]
+default_bits            = 2048                  # RSA key size
+encrypt_key             = yes                   # Protect private key
+default_md              = sha1                  # MD to use
+utf8                    = yes                   # Input is UTF-8
+string_mask             = utf8only              # Emit UTF-8 strings
+prompt                  = no                    # Don't prompt for DN
+distinguished_name      = ca_dn                 # DN section
+req_extensions          = ca_reqext             # Desired extensions
+
+[ ca_dn ]
+0.domainComponent       = "io"
+1.domainComponent       = "openshift"
+organizationName        = "OpenShift Origin"
+organizationalUnitName  = "Logging Signing CA"
+commonName              = "Logging Signing CA"
+
+[ ca_reqext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true,pathlen:0
+subjectKeyIdentifier    = hash
+
+# The remainder of the configuration file is used by the openssl ca command.
+# The CA section defines the locations of CA assets, as well as the policies
+# applying to the CA.
+
+[ ca ]
+default_ca              = signing_ca            # The default CA section
+
+[ signing_ca ]
+certificate             = $dir/ca.crt       # The CA cert
+private_key             = $dir/ca.key # CA private key
+new_certs_dir           = $dir/           # Certificate archive
+serial                  = $dir/ca.serial.txt # Serial number file
+crlnumber               = $dir/ca.crl.srl # CRL number file
+database                = $dir/ca.db # Index file
+unique_subject          = no                    # Require unique subject
+default_days            = 730                   # How long to certify for
+default_md              = sha1                  # MD to use
+policy                  = any_pol             # Default naming policy
+email_in_dn             = no                    # Add email to cert DN
+preserve                = no                    # Keep passed DN ordering
+name_opt                = ca_default            # Subject DN display options
+cert_opt                = ca_default            # Certificate display options
+copy_extensions         = copy                  # Copy extensions from CSR
+x509_extensions         = client_ext             # Default cert extensions
+default_crl_days        = 7                     # How long before next CRL
+crl_extensions          = crl_ext               # CRL extensions
+
+# Naming policies control which parts of a DN end up in the certificate and
+# under what circumstances certification should be denied.
+
+[ match_pol ]
+domainComponent         = match                 # Must match 'simple.org'
+organizationName        = match                 # Must match 'Simple Inc'
+organizationalUnitName  = optional              # Included if present
+commonName              = supplied              # Must be present
+
+[ any_pol ]
+domainComponent         = optional
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = optional
+emailAddress            = optional
+
+# Certificate extensions define what types of certificates the CA is able to
+# create.
+
+[ client_ext ]
+keyUsage                = critical,digitalSignature,keyEncipherment
+basicConstraints        = CA:false
+extendedKeyUsage        = clientAuth
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid
+
+[ server_ext ]
+keyUsage                = critical,digitalSignature,keyEncipherment
+basicConstraints        = CA:false
+extendedKeyUsage        = serverAuth,clientAuth
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid
+
+# CRL extensions exist solely to point to the CA certificate that has issued
+# the CRL.
+
+[ crl_ext ]
+authorityKeyIdentifier  = keyid

--- a/hack/testing/test-access-control.sh
+++ b/hack/testing/test-access-control.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/access_control.sh

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -206,7 +206,7 @@ function wait_for_fluentd_to_catch_up() {
             os::log::debug "$( sudo journalctl | grep "$fullmsg" )"
         elif sudo grep -q "$fullmsg" /var/log/containers/* ; then
             os::log::error "Found '$fullmsg' in /var/log/containers/*"
-            os::log::debug "$( sudo grep "$fullmsg" /var/log/containers/* )"
+            os::log::debug "$( sudo grep -q "$fullmsg" /var/log/containers/* )"
         else
             os::log::error "Unable to find '$fullmsg' in journal or /var/log/containers/*"
         fi

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -39,17 +39,28 @@ function get_test_user_token() {
 
 # $1 - kibana pod name
 # $2 - es hostname (e.g. logging-es or logging-es-ops)
-# $3 - project name (e.g. logging, test, .operations, etc.)
-# $4 - _count or _search
-# $5 - field to search
-# $6 - search string
+# $3 - endpoint (e.g. /projects.*/_search)
+# $4 - username
+# $5 - token
 # stdout is the JSON output from Elasticsearch
 # stderr is curl errors
 curl_es_from_kibana() {
-    oc exec $1 -c kibana -- curl --connect-timeout 1 -s -k \
-       --cert /etc/kibana/keys/cert --key /etc/kibana/keys/key \
-       -H "X-Proxy-Remote-User: $test_name" -H "Authorization: Bearer $test_token" -H "X-Forwarded-For: 127.0.0.1" \
-       "https://${2}:9200/${3}*/${4}\?q=${5}:${6}"
+    local pod="$1"
+    local eshost="$2"
+    local endpoint="$3"
+    local test_name="$4"
+    local test_token="$5"
+    shift; shift; shift; shift; shift
+    local args=( "${@:-}" )
+
+    local secret_dir="/etc/kibana/keys/"
+    oc exec "${pod}" -c kibana -- curl --connect-timeout 1 --silent --insecure "${args[@]}" \
+       --cert "${secret_dir}cert" \
+       --key "${secret_dir}key" \
+       -H "X-Proxy-Remote-User: $test_name" \
+       -H "Authorization: Bearer $test_token" \
+       -H "X-Forwarded-For: 127.0.0.1" \
+       "https://${eshost}:9200${endpoint}"
 }
 
 # $1 - es pod name
@@ -270,4 +281,20 @@ wait_for_fluentd_ready() {
     else
         os::cmd::try_until_success "sudo test -f /var/log/es-containers.log.pos" $(( timeout * second ))
     fi
+}
+
+extra_artifacts_testname=$( basename $0 )
+extra_artifacts=$ARTIFACT_DIR/${extra_artifacts_testname}-artifacts.txt
+internal_artifact_log() {
+    local ts=$1 ; shift
+    echo \[${ts}\] "$@" >> $extra_artifacts
+}
+artifact_log() {
+    internal_artifact_log "$( date --rfc-3339=ns )" "$@"
+}
+artifact_out() {
+    local ts="$( date --rfc-3339=ns )"
+    while read line ; do
+        internal_artifact_log "${ts}" "$line"
+    done
 }

--- a/test/access_control.sh
+++ b/test/access_control.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+
+# test access control
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+trap os::test::junit::reconcile_output EXIT
+os::util::environment::use_sudo
+
+os::test::junit::declare_suite_start "test/access_control"
+
+espod=$( get_es_pod es )
+esopspod=$( get_es_pod es-ops )
+esopspod=${esopspod:-$espod}
+
+delete_users=""
+REUSE=${REUSE:-false}
+
+function cleanup() {
+    local result_code="$?"
+    set +e
+    if [ "${REUSE:-false}" = false ] ; then
+        for user in $delete_users ; do
+            os::log::debug "$( oc delete user $user )"
+        done
+    fi
+    if [ -n "${espod:-}" ] ; then
+        curl_es $espod /project.access-control-* -XDELETE > /dev/null
+    fi
+    for proj in access-control-1 access-control-2 access-control-3 ; do
+        oc delete project $proj 2>&1 | artifact_out
+        os::cmd::try_until_failure "oc get project $proj" 2>&1 | artifact_out
+    done
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $result_code
+}
+
+trap cleanup EXIT
+
+function create_user_and_assign_to_projects() {
+    local current_project; current_project="$( oc project -q )"
+    local user=$1; shift
+    local pw=$1; shift
+    if oc get users $user > /dev/null 2>&1 ; then
+        os::log::info Using existing user $user
+    else
+        os::log::info Creating user $user with password $pw
+        oc login --username=$user --password=$pw 2>&1 | artifact_out
+        delete_users="$delete_users $user"
+    fi
+    os::log::debug "$( oc login --username=system:admin 2>&1 )"
+    os::log::info Assigning user to projects "$@"
+    while [ -n "${1:-}" ] ; do
+        os::log::debug "$( oc project $1 2>&1 )"
+        os::log::debug "$( oc adm policy add-role-to-user view $user 2>&1 )"
+        shift
+    done
+    oc project "${current_project}" > /dev/null
+}
+
+function add_message_to_index() {
+    # project is $1
+    # message is $2
+    # espod is $3
+    local project_uuid=$( oc get project $1 -o jsonpath='{ .metadata.uid }' )
+    local index="project.$1.$project_uuid.$(date -u +'%Y.%m.%d')"
+    os::log::debug $( curl_es "$3" "/$index/access-control-test/" -XPOST -d '{"message":"'${2:-"access-control message"}'"}' | python -mjson.tool 2>&1 )
+}
+
+# test the following
+# - regular user can access with username/token
+#   - directly against es
+#   - via kibana pod with kibana cert/key
+# - regular user cannot access unavailable indices
+#   - directly against es
+#   - via kibana pod with kibana cert/key
+# - regular user cannot access .operations
+#   - via es or kibana
+#   - with username admin and no token
+#   - with username admin and bogus token
+# - username without token fails
+#   - via es or kibana
+# - token without username fails
+#   - via es or kibana
+function test_user_has_proper_access() {
+    local user=$1; shift
+    local pw=$1; shift
+    # rest - indices to which access should be granted, followed by --,
+    # followed by indices to which access should not be granted
+    local expected=1
+    local verb=cannot
+    local negverb=can
+    local nrecs=0
+    local kpod=$( get_running_pod kibana )
+    eshost=logging-es
+    esopshost=logging-es-ops
+    if [ "$espod" = "$esopspod" ] ; then
+        esopshost=$eshost
+    fi
+    get_test_user_token $user $pw
+    for proj in "$@" ; do
+        if [ "$proj" = "--" ] ; then
+            expected=0
+            verb=can
+            negverb=cannot
+            continue
+        fi
+        os::log::info See if user $user $negverb read /project.$proj.*
+        nrecs=$( curl_es_with_token $espod "/project.$proj.*/_count" $test_name $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from es
+            curl_es_with_token $espod "/project.$proj.*/_count" $test_name $test_token | python -mjson.tool
+            exit 1
+        fi
+        nrecs=$( curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" $test_name $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from kibana
+            curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" $test_name $test_token | python -mjson.tool
+            exit 1
+        fi
+        # no user name - allow it - look up username corresponding to token
+        nrecs=$( curl_es_with_token $espod "/project.$proj.*/_count" "" $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from es
+            curl_es_with_token $espod "/project.$proj.*/_count" "" $test_token | python -mjson.tool
+            exit 1
+        fi
+        nrecs=$( curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" "" $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from kibana
+            curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" "" $test_token | python -mjson.tool
+            exit 1
+        fi
+        # if wrong user name is given, allow it - server will look up and use correct user name, so
+        # not possible to specify a privileged username to use for access with an unprivileged token
+        nrecs=$( curl_es_with_token $espod "/project.$proj.*/_count" $LOG_ADMIN_USER $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from es
+            curl_es_with_token $espod "/project.$proj.*/_count" $LOG_ADMIN_USER $test_token | python -mjson.tool
+            exit 1
+        fi
+        nrecs=$( curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" $LOG_ADMIN_USER $test_token | \
+                     get_count_from_json )
+        if ! os::cmd::expect_success "test $nrecs = $expected" ; then
+            os::log::error $user $verb access project.$proj.* indices from kibana
+            curl_es_from_kibana "$kpod" logging-es "/project.$proj.*/_count" $LOG_ADMIN_USER $test_token | python -mjson.tool
+            exit 1
+        fi
+        if [ "$expected" = 1 ] ; then
+            # make sure no access with incorrect auth
+            # username with no token
+            os::cmd::expect_success_and_text "curl_es_with_token $espod '/project.$proj.*/_count' '$test_name' '' -w '%{response_code}\n'" '^401$'
+            os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $eshost '/project.$proj.*/_count' '$test_name' '' -w '%{response_code}\n'" '^401$'
+            # username and bogus token
+            os::cmd::expect_success_and_text "curl_es_with_token $espod '/project.$proj.*/_count' '$test_name' BOGUS -w '%{response_code}\n'" '^401$'
+            os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $eshost '/project.$proj.*/_count' '$test_name' BOGUS -w '%{response_code}\n'" '^401$'
+            # no username, no token
+            os::cmd::expect_success_and_text "curl_es_with_token $espod '/project.$proj.*/_count' '' '' -w '%{response_code}\n'" '^401$'
+            os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $eshost '/project.$proj.*/_count' '' '' -w '%{response_code}\n' -o /dev/null" '^403$'
+        fi
+    done
+
+    os::log::info See if user $user is denied /.operations.*
+    nrecs=$( curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | \
+                 get_count_from_json )
+    if ! os::cmd::expect_success "test $nrecs = 0" ; then
+        os::log::error $LOG_NORMAL_USER has improper access to .operations.* indices from es
+        curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | python -mjson.tool
+        exit 1
+    fi
+    esopshost=logging-es-ops
+    if [ "$espod" = "$esopspod" ] ; then
+        esopshost=logging-es
+    fi
+    nrecs=$( curl_es_from_kibana "$kpod" "$esopshost" "/.operations.*/_count" $test_name $test_token | \
+                 get_count_from_json )
+    if ! os::cmd::expect_success "test $nrecs = 0" ; then
+        os::log::error $LOG_NORMAL_USER has improper access to .operations.* indices from kibana
+        curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | python -mjson.tool
+        exit 1
+    fi
+
+    os::log::info See if user $user is denied /.operations.* with no token
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' $user '' -w '%{response_code}\n'" '^401$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' $user '' -w '%{response_code}\n'" '^401$'
+
+    os::log::info See if user $user is denied /.operations.* with no username
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' '' $test_token -w '%{response_code}\n'" '}403$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' '' $test_token -w '%{response_code}\n'" '}403$'
+
+    os::log::info See if user $user is denied /.operations.* with no token using $LOG_ADMIN_USER
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' $LOG_ADMIN_USER '' -w '%{response_code}\n'" '^401$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' $LOG_ADMIN_USER '' -w '%{response_code}\n'" '^401$'
+
+    os::log::info See if user $user is denied /.operations.* with a bogus token using $LOG_ADMIN_USER
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' $LOG_ADMIN_USER BOGUS -w '%{response_code}\n'" '^401$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' $LOG_ADMIN_USER BOGUS -w '%{response_code}\n'" '^401$'
+
+    os::log::info See if access is denied to /.operations.* with no username and no token
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' '' '' -w '%{response_code}\n'" '^401$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' '' '' -w '%{response_code}\n' -o /dev/null" '^403$'
+
+    os::log::info See if user $user is denied /.operations.* with username that does not correspond to token
+    os::cmd::expect_success_and_text "curl_es_with_token $esopspod '/.operations.*/_count' $LOG_ADMIN_USER $test_token -w '%{response_code}\n'" '}403$'
+    os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' $LOG_ADMIN_USER $test_token -w '%{response_code}\n'" '}403$'
+}
+
+os::log::debug "$( curl_es $espod /project.access-control-* -XDELETE )"
+
+for proj in access-control-1 access-control-2 access-control-3 ; do
+    os::log::info Creating project $proj
+    oc adm new-project $proj --node-selector='' 2>&1 | artifact_out
+    os::cmd::try_until_success "oc get project $proj" 2>&1 | artifact_out
+
+    os::log::info Creating test index and entry for $proj
+    add_message_to_index $proj "" $espod
+done
+
+LOG_ADMIN_USER=${LOG_ADMIN_USER:-admin}
+LOG_ADMIN_PW=${LOG_ADMIN_PW:-admin}
+
+if oc get users "$LOG_ADMIN_USER" > /dev/null 2>&1 ; then
+    os::log::debug Using existing admin user $LOG_ADMIN_USER
+else
+    os::log::info Creating cluster-admin user $LOG_ADMIN_USER
+    current_project="$( oc project -q )"
+    os::log::debug "$( oc login --username=$LOG_ADMIN_USER --password=$LOG_ADMIN_PW )"
+    os::log::debug "$( oc login --username=system:admin )"
+    os::log::debug "$( oc project $current_project )"
+fi
+os::log::debug "$( oc adm policy add-cluster-role-to-user cluster-admin $LOG_ADMIN_USER )"
+
+# if you ever want to run this test again on the same machine, you'll need to
+# use different usernames, otherwise you'll get this odd error:
+# # oc login --username=loguser --password=loguser
+# error: The server was unable to respond - verify you have provided the correct host and port and that the server is currently running.
+# or - set REUSE=true
+LOG_NORMAL_USER=${LOG_NORMAL_USER:-loguserac}
+LOG_NORMAL_PW=${LOG_NORMAL_PW:-loguserac}
+
+LOG_USER2=${LOG_USER2:-loguser2ac}
+LOG_PW2=${LOG_PW2:-loguser2ac}
+
+create_user_and_assign_to_projects $LOG_NORMAL_USER $LOG_NORMAL_PW access-control-1 access-control-2
+create_user_and_assign_to_projects $LOG_USER2 $LOG_PW2 access-control-2 access-control-3
+
+oc login --username=system:admin > /dev/null
+oc project logging > /dev/null
+
+test_user_has_proper_access $LOG_NORMAL_USER $LOG_NORMAL_PW access-control-1 access-control-2 -- access-control-3
+test_user_has_proper_access $LOG_USER2 $LOG_PW2 access-control-2 access-control-3 -- access-control-1
+
+os::log::info now auth using admin + token
+get_test_user_token $LOG_ADMIN_USER $LOG_ADMIN_PW
+nrecs=$( curl_es_with_token $espod "/project.logging.*/_count" $test_name $test_token | \
+         get_count_from_json )
+os::cmd::expect_success "test $nrecs -gt 1"
+nrecs=$( curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | \
+         get_count_from_json )
+os::cmd::expect_success "test $nrecs -gt 1"
+
+os::log::info now see if regular users have access
+
+test_user_has_proper_access $LOG_NORMAL_USER $LOG_NORMAL_PW access-control-1 access-control-2 -- access-control-3
+test_user_has_proper_access $LOG_USER2 $LOG_PW2 access-control-2 access-control-3 -- access-control-1
+
+# create a dummy client cert/key - see if we can impersonate kibana with a cert
+certdir=$( mktemp -d )
+# if oc has the adm ca command then use it
+if oc adm --help | grep -q ' ca .*Manage certificates and keys' ; then
+    openshift_admin="oc adm"
+elif type -p openshift > /dev/null && openshift --help | grep -q '^  admin ' ; then
+    openshift_admin="openshift admin"
+else
+    openshift_admin="oc adm"
+fi
+$openshift_admin ca create-signer-cert  \
+    --key="${certdir}/ca.key" \
+    --cert="${certdir}/ca.crt" \
+    --serial="${certdir}/ca.serial.txt" \
+    --name="logging-signer-$(date +%Y%m%d%H%M%S)" 2>&1 | artifact_out
+cat - ${OS_O_A_L_DIR}/hack/testing/signing.conf > $certdir/signing.conf <<CONF
+[ default ]
+dir                     = ${certdir}               # Top dir
+CONF
+touch $certdir/ca.db
+openssl req -out "$certdir/test.csr" -new -newkey rsa:2048 -keyout "$certdir/test.key" \
+    -subj "/CN=system.logging.kibana/OU=OpenShift/O=Logging" -days 712 -nodes 2>&1 | artifact_out
+openssl ca \
+    -in "$certdir/test.csr" \
+    -notext \
+    -out "$certdir/test.crt" \
+    -config $certdir/signing.conf \
+    -extensions v3_req \
+    -batch \
+    -extensions server_ext 2>&1 | artifact_out
+oc rsync -c elasticsearch $certdir $espod:/tmp 2>&1 | artifact_out
+if [ "$espod" != "$esopspod" ] ; then
+    oc rsync -c elasticsearch $certdir $esopspod:/tmp 2>&1 | artifact_out
+fi
+
+os::cmd::expect_failure "oc exec -c elasticsearch $espod -- \
+    curl -s -k --cert $certdir/test.crt --key $certdir/test.key \
+    https://localhost:9200/.kibana/_count"
+os::cmd::expect_failure "oc exec -c elasticsearch $espod -- \
+    curl -s -k --cert $certdir/test.crt --key $certdir/test.key \
+    https://localhost:9200/project.*/_count"
+os::cmd::expect_failure "oc exec -c elasticsearch $esopspod -- \
+    curl -s -k --cert $certdir/test.crt --key $certdir/test.key \
+    https://localhost:9200/.operations.*/_count"
+rm -rf $certdir

--- a/test/kibana_dashboards.sh
+++ b/test/kibana_dashboards.sh
@@ -33,9 +33,9 @@ else
     current_project="$( oc project -q )"
     os::log::debug "$( oc login --username=$LOG_ADMIN_USER --password=$LOG_ADMIN_PW )"
     os::log::debug "$( oc login --username=system:admin )"
-    os::log::debug "$( oc adm policy add-cluster-role-to-user cluster-admin $LOG_ADMIN_USER )"
     os::log::debug "$( oc project $current_project )"
 fi
+os::log::debug "$( oc adm policy add-cluster-role-to-user cluster-admin $LOG_ADMIN_USER )"
 
 function cleanup() {
     set +e

--- a/test/multi_tenancy.sh
+++ b/test/multi_tenancy.sh
@@ -16,21 +16,6 @@ os::util::environment::use_sudo
 
 os::test::junit::declare_suite_start "test/multi_tenancy"
 
-extra_artifacts=$ARTIFACT_DIR/multi_tenancy-artifacts.txt
-internal_artifact_log() {
-    local ts=$1 ; shift
-    echo \[${ts}\] "$@" >> $extra_artifacts
-}
-artifact_log() {
-    internal_artifact_log "$( date --rfc-3339=ns )" "$@"
-}
-artifact_out() {
-    local ts="$( date --rfc-3339=ns )"
-    while read line ; do
-        internal_artifact_log "${ts}" "$line"
-    done
-}
-
 espod=$( get_es_pod es )
 esopspod=$( get_es_pod es-ops )
 esopspod=${esopspod:-$espod}

--- a/test/mux.sh
+++ b/test/mux.sh
@@ -29,21 +29,6 @@ else
   es_ops_pod=$es_pod
 fi
 
-extra_mux_artifacts=$ARTIFACT_DIR/mux-artifacts.txt
-internal_mux_log() {
-    local ts=$1 ; shift
-    echo \[${ts}\] "$@" >> $extra_mux_artifacts
-}
-mux_log() {
-    internal_mux_log "$( date --rfc-3339=ns )" "$@"
-}
-mux_out() {
-    local ts="$( date --rfc-3339=ns )"
-    while read line ; do
-        internal_mux_log "${ts}" "$line"
-    done
-}
-
 reset_fluentd_daemonset() {
   # this test only works with MUX_CLIENT_MODE=minimal for now
   os::log::debug "$( oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=minimal )"
@@ -63,17 +48,17 @@ update_current_fluentd() {
   local myoption=${1:-0}
 
   # undeploy fluentd
-  oc label node --all logging-infra-fluentd- 2>&1 | mux_out
+  oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
   os::cmd::try_until_failure "oc get pod $fpod" $FLUENTD_WAIT_TIME
-  oc get pods |grep fluentd | mux_out || :
+  oc get pods |grep fluentd | artifact_out || :
   # edit so we don't filter or send to ES
   oc get configmap/logging-fluentd -o yaml | sed '/## filters/ a\
-      @include configs.d/user/filter-pre-mux-test-client.conf' | oc replace -f - 2>&1 | mux_out
+      @include configs.d/user/filter-pre-mux-test-client.conf' | oc replace -f - 2>&1 | artifact_out
 
   # if configmap filter-pre-mux-test-client.conf isn't present, add one so replace will work
   local exists=$( oc get configmap/logging-fluentd --template='{{index .data "filter-pre-mux-test-client.conf" }}' )
   if [ "$exists" = '<no value>' ] ; then
-      oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "add", "path": "/data/filter-pre-mux-test-client.conf", "value": "empty" }]' 2>&1 | mux_out
+      oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "add", "path": "/data/filter-pre-mux-test-client.conf", "value": "empty" }]' 2>&1 | artifact_out
   fi
   # update configmap filter-pre-mux-test-client.conf
   if [ $myoption -eq $NO_CONTAINER_VALS ]; then
@@ -105,7 +90,7 @@ update_current_fluentd() {
         <record>\n\
         @timestamp ${time.strftime(\"%Y-%m-%dT%H:%M:%S%z\")}\n\
         </record>\n\
-      </filter>"}]' 2>&1 | mux_out
+      </filter>"}]' 2>&1 | artifact_out
   elif [ $myoption -eq $SET_CONTAINER_VALS ]; then
       oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "replace", "path": "/data/filter-pre-mux-test-client.conf", "value": "\
       <match kubernetes.var.log.containers.**kibana**>\n\
@@ -129,7 +114,7 @@ update_current_fluentd() {
         CONTAINER_NAME k8s_mux.01234567_logging-mux_testproj_00000000-1111-2222-3333-444444444444_55555555\n\
         CONTAINER_ID_FULL 0123456789012345678901234567890123456789012345678901234567890123\n\
         </record>\n\
-      </filter>"}]' 2>&1 | mux_out
+      </filter>"}]' 2>&1 | artifact_out
   elif [ $myoption -eq $MISMATCH_NAMESPACE_TAG ]; then
       oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "replace", "path": "/data/filter-pre-mux-test-client.conf", "value": "\
       <filter kubernetes.var.log.containers.**kibana**>\n\
@@ -161,7 +146,7 @@ update_current_fluentd() {
         CONTAINER_NAME k8s_mux.01234567_logging-mux_testproj_00000000-1111-2222-3333-444444444444_55555555\n\
         CONTAINER_ID_FULL 0123456789012345678901234567890123456789012345678901234567890123\n\
         </record>\n\
-      </filter>"}]' 2>&1 | mux_out
+      </filter>"}]' 2>&1 | artifact_out
   elif [ $myoption -eq $NO_PROJECT_TAG ]; then
       oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "replace", "path": "/data/filter-pre-mux-test-client.conf", "value": "\
       <filter kubernetes.var.log.containers.**kibana**>\n\
@@ -191,7 +176,7 @@ update_current_fluentd() {
         <record>\n\
         @timestamp ${time.strftime(\"%Y-%m-%dT%H:%M:%S%z\")}\n\
         </record>\n\
-      </filter>"}]' 2>&1 | mux_out
+      </filter>"}]' 2>&1 | artifact_out
   else
       os::log::info "Enabling secure forward"
   fi
@@ -226,21 +211,21 @@ write_and_verify_logs() {
 
     wait_for_fluentd_ready
 
-    oc get pods | grep fluentd | mux_out
+    oc get pods | grep fluentd | artifact_out
 
     add_test_message $uuid_es
     local fcursor_before=$( sudo cat /var/log/journal.pos )
-    oc get pods | grep fluentd | mux_out
+    oc get pods | grep fluentd | artifact_out
     logger -i -p local6.info -t $uuid_es_ops $uuid_es_ops
     # get the cursor of this record - compare to the fluentd journal cursor position
     local reccursor=$( sudo journalctl -o export -t $uuid_es_ops | awk -F__CURSOR= '/^__CURSOR=/ {print $2}' )
-    oc get pods | grep fluentd | mux_out
+    oc get pods | grep fluentd | artifact_out
     local fcursor_after=$( sudo cat /var/log/journal.pos )
-    mux_log Cursors:
-    mux_log "  " before $fcursor_before
-    mux_log "  " record $reccursor
-    mux_log "  " after $fcursor_after
-    oc get pods | grep fluentd | mux_out
+    artifact_log Cursors:
+    artifact_log "  " before $fcursor_before
+    artifact_log "  " record $reccursor
+    artifact_log "  " after $fcursor_after
+    oc get pods | grep fluentd | artifact_out
 
     local rc=0
 
@@ -252,7 +237,7 @@ write_and_verify_logs() {
         # kibana logs with project.testproj tag and given container/pod values
         local myproject=project.testproj
         # make sure this namespace exists
-        os::cmd::try_until_success "oc get project testproj" 2>&1 | mux_out
+        os::cmd::try_until_success "oc get project testproj" 2>&1 | artifact_out
     else
         # kibana logs with kibana container/pod values
         local myproject=project.logging
@@ -270,24 +255,24 @@ write_and_verify_logs() {
     done
     local qs="${startqs}]}}}"
     os::log::debug "query string is $qs"
-    mux_log start $( date ) $( date +%s )
+    artifact_log start $( date ) $( date +%s )
     if ! os::cmd::try_until_text "curl_es $espod /${myproject}.*/_count -XPOST -d '$qs' | get_count_from_json" "^${expected}\$" "$(( 10*minute ))" ; then
-        mux_log end $( date ) $( date +%s )
+        artifact_log end $( date ) $( date +%s )
         qs='{"query":{"bool":{"filter":{"match_phrase":{"_all":"'"${mymessage}"'"}}}}}'
-        curl_es $espod /${myproject}.*/_count -XPOST -d "$qs" | python -mjson.tool | mux_out
-        curl_es $espod /project.*/_count -XPOST -d "$qs" | python -mjson.tool | mux_out
-        curl_es $espod /fluentd/_count -XPOST -d "$qs" | python -mjson.tool | mux_out
+        curl_es $espod /${myproject}.*/_count -XPOST -d "$qs" | python -mjson.tool | artifact_out
+        curl_es $espod /project.*/_count -XPOST -d "$qs" | python -mjson.tool | artifact_out
+        curl_es $espod /fluentd/_count -XPOST -d "$qs" | python -mjson.tool | artifact_out
         # grab the first and last records in the index
-        curl_es $espod /${myproject}.*/_search?sort=@timestamp:asc\&size=1 | python -mjson.tool | mux_out
-        curl_es $espod /${myproject}.*/_search?sort=@timestamp:desc\&size=1 | python -mjson.tool | mux_out
+        curl_es $espod /${myproject}.*/_search?sort=@timestamp:asc\&size=1 | python -mjson.tool | artifact_out
+        curl_es $espod /${myproject}.*/_search?sort=@timestamp:desc\&size=1 | python -mjson.tool | artifact_out
         if docker_uses_journal ; then
-            mux_log First matching record:
-            sudo journalctl | grep -m 1 "${mymessage}" | mux_out || :
-            mux_log Last matching record:
-            sudo journalctl -r | grep -m 1 "${mymessage}" | mux_out || :
+            artifact_log First matching record:
+            sudo journalctl | grep -m 1 "${mymessage}" | artifact_out || :
+            artifact_log Last matching record:
+            sudo journalctl -r | grep -m 1 "${mymessage}" | artifact_out || :
         else
-            mux_log matching records:
-            sudo find /var/log/containers -name \*.log -exec grep "${mymessage}" {} /dev/null \; | mux_out || :
+            artifact_log matching records:
+            sudo find /var/log/containers -name \*.log -exec grep "${mymessage}" {} /dev/null \; | artifact_out || :
         fi
         exit 1
     fi
@@ -298,28 +283,28 @@ write_and_verify_logs() {
         myproject=project.testproj
         espod=$es_pod
         # make sure this namespace exists
-        os::cmd::try_until_success "oc get project testproj" 2>&1 | mux_out
+        os::cmd::try_until_success "oc get project testproj" 2>&1 | artifact_out
     elif [ $no_project_tag -eq 1 ]; then
         local myfield="SYSLOG_IDENTIFIER"
         myproject=project.mux-undefined
         espod=$es_pod
         # make sure this namespace exists
-        os::cmd::try_until_success "oc get project mux-undefined" 2>&1 | mux_out
+        os::cmd::try_until_success "oc get project mux-undefined" 2>&1 | artifact_out
     else
         local myfield="systemd.u.SYSLOG_IDENTIFIER"
         myproject=".operations"
         espod=$es_ops_pod
     fi
     mymessage=$uuid_es_ops
-    mux_log start $( date ) $( date +%s )
+    artifact_log start $( date ) $( date +%s )
     if ! os::cmd::try_until_text "curl_es $espod /${myproject}.*/_count?q=${myfield}:$mymessage | get_count_from_json" "^${expected}\$" "$(( 10*minute ))" ; then
-        mux_log end $( date ) $( date +%s )
-        curl_es $espod /${myproject}.*/_count?q=${myfield}:$mymessage | python -mjson.tool | mux_out
+        artifact_log end $( date ) $( date +%s )
+        curl_es $espod /${myproject}.*/_count?q=${myfield}:$mymessage | python -mjson.tool | artifact_out
         # grab the first and last records in the index
-        curl_es $espod /${myproject}.*/_search?sort=@timestamp:asc\&size=1 | python -mjson.tool | mux_out
-        curl_es $espod /${myproject}.*/_search?sort=@timestamp:desc\&size=1 | python -mjson.tool | mux_out
+        curl_es $espod /${myproject}.*/_search?sort=@timestamp:asc\&size=1 | python -mjson.tool | artifact_out
+        curl_es $espod /${myproject}.*/_search?sort=@timestamp:desc\&size=1 | python -mjson.tool | artifact_out
         # find the record in the journal
-        sudo journalctl -o export -t $uuid_es_ops | mux_out || :
+        sudo journalctl -o export -t $uuid_es_ops | artifact_out || :
         exit 1
     fi
     os::cmd::expect_success_and_not_text "curl_es $es_pod /_cat/indices" "project\.default"
@@ -331,7 +316,7 @@ reset_ES_HOST() {
     os::cmd::expect_success "oc set env dc logging-mux $1 $2"
     os::cmd::try_until_failure "oc get pod $muxpod"
     os::log::debug $( oc get pods -l component=mux )
-    oc rollout status -w dc/logging-mux 2>&1 | mux_out # wait for mux to be redeployed
+    oc rollout status -w dc/logging-mux 2>&1 | artifact_out # wait for mux to be redeployed
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
     muxpod=$( get_running_pod mux )
 }
@@ -348,19 +333,18 @@ cleanup() {
         mycmd=os::log::info
     else
         mycmd=os::log::error
-        muxout=$ARTIFACT_DIR/mux-artifacts.txt
-        oc projects >> $muxout 2>&1
-        oc get pods >> $muxout 2>&1
+        oc projects 2>&1 | artifact_out
+        oc get pods 2>&1 | artifact_out
         if [ -n "$fpod" ]; then
             oc get configmap/logging-fluentd -o yaml > $ARTIFACT_DIR/mux.fluentd.configmap.yaml
-            oc exec $fpod -- ls -alrtF /etc/fluent/configs.d/openshift >> $muxout 2>&1
-            oc exec $fpod -- ls -alrtF /etc/fluent/configs.d/user >> $muxout 2>&1
+            oc exec $fpod -- ls -alrtF /etc/fluent/configs.d/openshift 2>&1 | artifact_out
+            oc exec $fpod -- ls -alrtF /etc/fluent/configs.d/user 2>&1 | artifact_out
         fi
         if [ -n "${muxpod:-}" ]; then
             oc logs $muxpod > $ARTIFACT_DIR/mux.mux.pod.log
             oc get configmap/logging-mux -o yaml > $ARTIFACT_DIR/mux.mux.configmap.yaml
-            oc exec $muxpod -- ls -alrtF /etc/fluent/configs.d/openshift >> $muxout 2>&1
-            oc exec $muxpod -- ls -alrtF /etc/fluent/configs.d/user >> $muxout 2>&1
+            oc exec $muxpod -- ls -alrtF /etc/fluent/configs.d/openshift 2>&1 | artifact_out
+            oc exec $muxpod -- ls -alrtF /etc/fluent/configs.d/user 2>&1 | artifact_out
             oc exec $muxpod -- cat /var/log/fluentd.log > $ARTIFACT_DIR/mux.mux.pod.int.log
         fi
     fi
@@ -388,8 +372,8 @@ cleanup() {
     sudo rm -f /var/lib/fluentd/buffer*.log
     os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-    oc delete project testproj 2>&1 | mux_out
-    os::cmd::try_until_failure "oc get project testproj" 2>&1 | mux_out
+    oc delete project testproj 2>&1 | artifact_out
+    os::cmd::try_until_failure "oc get project testproj" 2>&1 | artifact_out
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
     exit $return_code
@@ -409,8 +393,8 @@ os::log::info Starting mux test at $( date )
 if oc get project testproj > /dev/null 2>&1 ; then
     os::log::info using existing project testproj
 else
-    oc adm new-project testproj --node-selector='' 2>&1 | mux_out
-    os::cmd::try_until_success "oc get project testproj" 2>&1 | mux_out
+    oc adm new-project testproj --node-selector='' 2>&1 | artifact_out
+    os::cmd::try_until_success "oc get project testproj" 2>&1 | artifact_out
 fi
 
 # save indices at the start
@@ -550,8 +534,8 @@ os::log::info "fluentd forwards kibana and system logs with tag test.bogus.exter
 if oc get project mux-undefined > /dev/null 2>&1 ; then
     os::log::info using existing project mux-undefined
 else
-    oc adm new-project mux-undefined --node-selector='' 2>&1 | mux_out
-    os::cmd::try_until_success "oc get project mux-undefined" 2>&1 | mux_out
+    oc adm new-project mux-undefined --node-selector='' 2>&1 | artifact_out
+    os::cmd::try_until_success "oc get project mux-undefined" 2>&1 | artifact_out
 fi
 
 update_current_fluentd $NO_PROJECT_TAG


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1500086 Test access control in
many different ways, both against Elasticsearch directly and via Kibana.
- proper token and username has access to correct projects
- proper token and username is denied access to disallowed projects
- admin has access to all indices
- username with no token is an error
- username with bogus token is an error
- username with wrong token is an error
- no username and no token is an error
- admin with no token is an error
- admin with bogus token is an error
- client cert auth with kibana cert issued by unknown CA is an error

(cherry picked from commit 6ccfa9d19d8ce579868cf0809cec3b25873211bd)

Bug 1513254 - logging-fluentd performance regression between 3.7.0-0.158.0
and 3.7.7 + message loss.

https://bugzilla.redhat.com/show_bug.cgi?id=1513254 The utf8 filter causes
the peformance to be cut in half.  Disable it by default.  If you need to
use it, and can pay the performance penalty,

    oc set env ds/logging-fluentd ENABLE_UTF8_FILTER=true

(cherry picked from commit 98e8e99b3e5b56c18939716faf578b2fe9d292c6)

increase rsyslog rate limits for json-file; add debugging for json-file

When using json-file on 3.6, the number of messages exceeds the rsyslog
imjournal limit, so test messages are dropped.  This increases the limits
for rsyslog. This also adds some debugging when using json-file. Also added
some sudos

(cherry picked from commit b7a8f4b0cefa9b3560334bfffbc6078ab649d59b)