### PR TITLE
fluentd minor fixes

### DIFF
--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -1,7 +1,7 @@
 <match **>
   @type secure_forward
   log_level "#{ENV['FORWARD_INPUT_LOG_LEVEL'] || ENV['LOG_LEVEL'] || 'warn'}"
-  self_hostname ${HOSTNAME}                   
+  self_hostname ${HOSTNAME}
   shared_key "#{File.open('/etc/fluent/muxkeys/shared_key') do |f| f.readline end.rstrip}"
   secure yes
   ca_cert_path /etc/fluent/muxkeys/ca

--- a/fluentd/configs.d/openshift/filter-kibana-transform.conf
+++ b/fluentd/configs.d/openshift/filter-kibana-transform.conf
@@ -2,7 +2,7 @@
   @type record_transformer
   enable_ruby
   <record>
-    log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}   
+    log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
   </record>
   remove_keys req,res,msg,name,level,v,pid,err
 </filter>

--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -83,7 +83,7 @@ module Fluent
         @packet.time = time
         @packet.tag = if @tag_key
                         begin
-                          record[@tag_key][0..31].gsub(/[\[\]]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
+                          record[@tag_key][0..31].gsub(/[\[\]\s]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
                         rescue
                           tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
                         end

--- a/fluentd/out_syslog_buffered.rb
+++ b/fluentd/out_syslog_buffered.rb
@@ -107,7 +107,7 @@ module Fluent
       @packet.time = time
       @packet.tag = if @tag_key
                       begin
-                        record[@tag_key][0..31].gsub(/[\[\]]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
+                        record[@tag_key][0..31].gsub(/[\[\]\s]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
                       rescue
                         tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
                       end
@@ -139,7 +139,7 @@ module Fluent
 
   end
 
-  class Time
+  class Time < Time
     def timezone(timezone = 'UTC')
       old = ENV['TZ']
       utc = self.dup.utc

--- a/fluentd/out_syslog_buffered.rb
+++ b/fluentd/out_syslog_buffered.rb
@@ -135,19 +135,6 @@ module Fluent
         end
       end
     end
-
-
-  end
-
-  class Time < Time
-    def timezone(timezone = 'UTC')
-      old = ENV['TZ']
-      utc = self.dup.utc
-      ENV['TZ'] = timezone
-      output = utc.localtime
-      ENV['TZ'] = old
-      output
-    end
   end
 end
 


### PR DESCRIPTION
fluent-plugin-remote-syslog: class Time in out_syslog_buffer.rb should
    inherit the standard class Time as done in out_syslog.rb.

fluent-plugin-remote-syslog: out_syslog.rb, out_syslog_buffered.rb
    Adding '\s' to record[@tag_key][0..31].gsub(/[\[\]]/,'') to get rid
    of spaces to avoid an argument error "Tag may not contain spaces"
    raised in syslog_protocol. (bz 1519213)

fluentd config files: removed trailing spaces