### PR TITLE
Bug 1531157 logging-fluentd v3.9.0-0.16.0.2 immediately starts flooding " missing namespace" errors on startup

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -18,8 +18,6 @@ ENV DATA_VERSION=1.6.0 \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/libexec/fluentd/bin:$PATH \
     RUBY_VERSION=2.0
 
-ARG TEST_REPO
-
 LABEL io.k8s.description="Fluentd container for collecting of docker container logs" \
       io.k8s.display-name="Fluentd ${FLUENTD_VERSION}" \
       io.openshift.tags="logging,elk,fluentd" \
@@ -29,9 +27,10 @@ LABEL io.k8s.description="Fluentd container for collecting of docker container l
       release="1" \
       architecture=x86_64
 
-USER 0
-
-RUN test -n "${TEST_REPO}" && curl -s -o /etc/yum.repos.d/test.repo ${TEST_REPO}
+# uncomment to build with a specific repo file
+# docker build --build-arg=TEST_REPO=http://server.test/aos-unsigned-latest.repo ....
+#ARG TEST_REPO
+#RUN test -n "${TEST_REPO}" && curl -s -o /etc/yum.repos.d/test.repo ${TEST_REPO}
 
 RUN yum-config-manager --enable rhel-7-server-ose-3.9-rpms && \
   INSTALL_PKGS="fluentd-${FLUENTD_VERSION} \

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -39,7 +39,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
      'elasticsearch:<5' \
       fluentd:${FLUENTD_VERSION} \
      'fluent-plugin-elasticsearch:~>1.0' \
-      fluent-plugin-kubernetes_metadata_filter \
+     'fluent-plugin-kubernetes_metadata_filter:<1.0' \
       'fluent-plugin-record-modifier:<1.0.0' \
       'fluent-plugin-rewrite-tag-filter:<1.6.0' \
       fluent-plugin-secure-forward \

--- a/fluentd/configs.d/openshift/filter-k8s-meta.conf
+++ b/fluentd/configs.d/openshift/filter-k8s-meta.conf
@@ -6,5 +6,6 @@
   bearer_token_file /var/run/secrets/kubernetes.io/serviceaccount/token
   ca_file /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
   use_journal "#{ENV['USE_JOURNAL'] || 'false'}"
+  include_namespace_metadata true
   container_name_to_kubernetes_regexp '^(?<name_prefix>[^_]+)_(?<container_name>[^\._]+)(\.(?<container_hash>[^_]+))?_(?<pod_name>[^_]+)_(?<namespace>[^_]+)_[^_]+_[^_]+$'
 </filter>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1531157
We're still using k8s filter version 0.33 which still requires
include_namespace_metadata true
/test