### PR TITLE
remove dashes in ident values used for term searches to avoid test flakes

### DIFF
--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -189,8 +189,8 @@ function wait_for_fluentd_to_catch_up() {
     local es_pod=$( get_es_pod es )
     local es_ops_pod=$( get_es_pod es-ops )
     es_ops_pod=${es_ops_pod:-$es_pod}
-    local uuid_es=$( uuidgen )
-    local uuid_es_ops=$( uuidgen )
+    local uuid_es=$( uuidgen | sed 's/[-]//g' )
+    local uuid_es_ops=$( uuidgen | sed 's/[-]//g' )
     local expected=${3:-1}
     local timeout=${TIMEOUT:-600}
     local project=${4:-logging}

--- a/test/mux.sh
+++ b/test/mux.sh
@@ -206,8 +206,8 @@ write_and_verify_logs() {
     local mismatch_namespace=${4:-0}
     local no_project_tag=${5:-0}
 
-    local uuid_es=$( uuidgen )
-    local uuid_es_ops=$( uuidgen )
+    local uuid_es=$( uuidgen | sed 's/[-]//g' )
+    local uuid_es_ops=$( uuidgen | sed 's/[-]//g' )
 
     wait_for_fluentd_ready
 
@@ -427,8 +427,8 @@ if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" -o "$MUX_FILE_BUFFER_STORAGE_TYPE" 
         reset_ES_HOST ES_HOST=bogus OPS_HOST=bogus
     fi
 
-    uuid_es=$( uuidgen )
-    uuid_es_ops=$( uuidgen )
+    uuid_es=$( uuidgen | sed 's/[-]//g' )
+    uuid_es_ops=$( uuidgen | sed 's/[-]//g' )
 
     logger -i -p local6.info -t $uuid_es_ops $uuid_es_ops
     add_test_message $uuid_es

--- a/test/utf8-characters.sh
+++ b/test/utf8-characters.sh
@@ -33,7 +33,7 @@ os::log::info "Starting utf8-characters test at $( date )"
 
 wait_for_fluentd_ready
 
-message_uuid="$( uuidgen )"
+message_uuid="$( uuidgen | sed 's/[-]//g' )"
 message="$(printf '%s-\xC2\xB5' "$message_uuid" )"
 logger -p local6.info -t "$message_uuid" "$message"
 


### PR DESCRIPTION
Searches like this are failing randomly and often:

    message_uuid=$( uuidgen )
    qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${message_uuid}"'"}}}'
    curl_es $espod /.operations.*/_search -X POST -d $qs

it seems as if Elasticsearch is analyzing the systemd.u.SYSLOG_IDENTIFIER
field which causes exact matches to fail, even though it is defined as
a non_analyzed field.
See https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-term-query.html

Until we can figure this out, remove the dashes from the uuidgen output
so that there will be no analysis of the string.