### PR TITLE
Bug 1502744 - [3.5] Fluentd strips away timestamp milliseconds

### DIFF
--- a/fluentd/configs.d/openshift/filter-k8s-record-transform.conf
+++ b/fluentd/configs.d/openshift/filter-k8s-record-transform.conf
@@ -31,7 +31,7 @@
     hostname ${(record['kubernetes']['host'] rescue nil) || File.open('/etc/docker-hostname') { |f| f.readline }.rstrip}
     message ${(message rescue nil) || log}
     pipeline_metadata {"collector":{"ipaddr4":"${ENV['IPADDR4']}","ipaddr6":"${ENV['IPADDR6']}","inputname":"fluent-plugin-in_tail","name":"fluentd openshift","received_at":"${record['time'].to_s}","version":"0.12.29 1.4.0"}}
-    time ${time.utc.to_datetime.rfc3339(6)}
+    time ${record['@timestamp'] || record['time'] || time.utc.to_datetime.rfc3339(6)}
   </record>
   remove_keys log,stream
 </filter>


### PR DESCRIPTION
Adding "record['@timestamp'] || record['time']" to the time directive in the
record transformer filter for json-file (filter-k8s-record-transform.conf).
The patch was proposed and tested by Steven Walter <stwalter@redhat.com>.
https://bugzilla.redhat.com/show_bug.cgi?id=1502744#c12