### PR TITLE
host openshift-elasticsearch-plugin on github instead of building

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "fluentd/jemalloc"]
 	path = fluentd/jemalloc
 	url = https://github.com/jemalloc/jemalloc
-[submodule "elasticsearch/lib/openshift-elasticsearch-plugin"]
-	path = elasticsearch/lib/openshift-elasticsearch-plugin
-	url = https://github.com/fabric8io/openshift-elasticsearch-plugin

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -39,10 +39,8 @@ LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging sto
 ADD elasticsearch.repo /etc/yum.repos.d/elasticsearch.repo
 # install the RPMs in a separate step so it can be cached
 RUN rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch && \
-    yum install -y centos-release-scl
-RUN yum install -y --setopt=tsflags=nodocs \
+    yum install -y --setopt=tsflags=nodocs \
                 java-${JAVA_VER}-openjdk-headless \
-                rh-maven33 \
                 elasticsearch-${ES_VER} \
                 PyYAML && \
     yum clean all
@@ -57,7 +55,6 @@ ADD run.sh prep-install.${RELEASE_STREAM} install.sh ${HOME}/
 COPY utils/** /usr/local/bin/
 RUN ln -s /usr/local/bin/logging ${HOME}/logging && \
     ${HOME}/install.sh && \
-    yum erase -y rh-maven33 && \
     rm -rf /tmp/lib
 
 WORKDIR ${HOME}

--- a/elasticsearch/prep-install.origin
+++ b/elasticsearch/prep-install.origin
@@ -7,19 +7,7 @@ if [ -z "${ES_CLOUD_K8S_URL:-}" ] ; then
     ES_CLOUD_K8S_URL=io.fabric8/elasticsearch-cloud-kubernetes/${ES_CLOUD_K8S_VER}
 fi
 if [ -z "${OSE_ES_URL:-}" ] ; then
-    MANPATH="" source /opt/rh/rh-maven33/enable
-    set +e
-    mvn dependency:get -Dartifact=io.fabric8.elasticsearch:openshift-elasticsearch-plugin:${OSE_ES_VER}
-    res=$?
-    set -e
-    if [ 0 -eq $res ]; then
-      OSE_ES_URL=io.fabric8.elasticsearch/openshift-elasticsearch-plugin/${OSE_ES_VER}
-    else
-      pushd /tmp/lib/openshift-elasticsearch-plugin
-        mvn clean verify -DskipTests 
-        OSE_ES_URL=file:///tmp/lib/openshift-elasticsearch-plugin/target/releases/openshift-elasticsearch-plugin-${OSE_ES_VER}.zip
-      popd
-    fi
+    OSE_ES_URL=https://github.com/fabric8io/openshift-elasticsearch-plugin/releases/download/openshift-elasticsearch-plugin-${OSE_ES_VER}/openshift-elasticsearch-plugin-${OSE_ES_VER}.zip
 fi
 if [ -z "${PROMETHEUS_EXPORTER_URL:-}" ] ; then
     PROMETHEUS_EXPORTER_URL=file:///tmp/lib/elasticsearch-prometheus-exporter/elasticsearch-prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip


### PR DESCRIPTION
This PR removes the vendoring of the multi-tenant plugin in favor of hosting on github release

@ewolinetz @richm Do you think we should backport?