### PR TITLE
bz1515715 -- remote syslog hostname

### DIFF
--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -92,11 +92,11 @@ module Fluent
                           tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
                       end
         packet = @packet.dup
-        if @use_record && (record.key?('kubernetes'))
-            packet.content = @payload_key + "=" + record[@payload_key] + \
-                             (((record["kubernetes"]).key?('namespace_name')) ? ", namespace_name=" + record["kubernetes"]["namespace_name"] : "" ) + \
-                             (((record["kubernetes"]).key?('container_name')) ? ", container_name=" + record["kubernetes"]["container_name"] : "" ) + \
-                             (((record["kubernetes"]).key?('pod_name')) ? ", pod_name=" + record["kubernetes"]["pod_name"] : "" )
+        if @use_record && (record.key?('kubernetes')) && @payload_key && record[@payload_key]
+            packet.content = (((record['kubernetes']).key?('namespace_name')) ? 'namespace_name=' + record['kubernetes']['namespace_name'] + ', ' : '' ) + \
+                             (((record['kubernetes']).key?('container_name')) ? 'container_name=' + record['kubernetes']['container_name'] + ', ' : '' ) + \
+                             (((record['kubernetes']).key?('pod_name')) ? 'pod_name=' + record['kubernetes']['pod_name'] + ', ' : '' ) + \
+                             @payload_key + '=' + record[@payload_key]
         else
             packet.content = record[@payload_key]
         end

--- a/fluentd/out_syslog_buffered.rb
+++ b/fluentd/out_syslog_buffered.rb
@@ -116,11 +116,11 @@ module Fluent
                         tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
                     end
       packet = @packet.dup
-      if @use_record && (record.key?('kubernetes'))
-          packet.content = @payload_key + "=" + record[@payload_key] + \
-                           (((record["kubernetes"]).key?('namespace_name')) ? ", namespace_name=" + record["kubernetes"]["namespace_name"] : "" ) + \
-                           (((record["kubernetes"]).key?('container_name')) ? ", container_name=" + record["kubernetes"]["container_name"] : "" ) + \
-                           (((record["kubernetes"]).key?('pod_name')) ? ", pod_name=" + record["kubernetes"]["pod_name"] : "" )
+      if @use_record && (record.key?('kubernetes')) && @payload_key && record[@payload_key]
+          packet.content = (((record['kubernetes']).key?('namespace_name')) ? 'namespace_name=' + record['kubernetes']['namespace_name'] + ', ' : '' ) + \
+                           (((record['kubernetes']).key?('container_name')) ? 'container_name=' + record['kubernetes']['container_name'] + ', ' : '' ) + \
+                           (((record['kubernetes']).key?('pod_name')) ? 'pod_name=' + record['kubernetes']['pod_name'] + ', ' : '' ) + \
+                           @payload_key + '=' + record[@payload_key]
       else
           packet.content = record[@payload_key]
       end

--- a/fluentd/out_syslog_buffered.rb
+++ b/fluentd/out_syslog_buffered.rb
@@ -91,11 +91,12 @@ module Fluent
 
     def send_to_syslog(tag, time, record)
       tag = tag.sub(@remove_tag_prefix, '') if @remove_tag_prefix
-      @packet.hostname = hostname
       if @use_record
+        @packet.hostname = record['hostname'] || hostname
         @packet.facility = record['facility'] || @facilty
         @packet.severity = record['severity'] || @severity
       else
+        @packet.hostname = hostname
         @packet.facility = @facilty
         @packet.severity = @severity
       end
@@ -115,7 +116,14 @@ module Fluent
                         tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
                     end
       packet = @packet.dup
-      packet.content = record[@payload_key]
+      if @use_record && (record.key?('kubernetes'))
+          packet.content = @payload_key + "=" + record[@payload_key] + \
+                           (((record["kubernetes"]).key?('namespace_name')) ? ", namespace_name=" + record["kubernetes"]["namespace_name"] : "" ) + \
+                           (((record["kubernetes"]).key?('container_name')) ? ", container_name=" + record["kubernetes"]["container_name"] : "" ) + \
+                           (((record["kubernetes"]).key?('pod_name')) ? ", pod_name=" + record["kubernetes"]["pod_name"] : "" )
+      else
+          packet.content = record[@payload_key]
+      end
       begin
         if not @socket
           @socket = create_tcp_socket(@remote_syslog, @port)

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -235,8 +235,8 @@ cleanup() {
     cat $extra_artifacts
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
-    exit $return_code
   fi
+  exit $return_code
 }
 trap "cleanup" EXIT
 

--- a/test/remote-syslog.sh
+++ b/test/remote-syslog.sh
@@ -9,8 +9,17 @@ source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::util::environment::use_sudo
 
 FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
+MUX_WAIT_TIME=$(( 5 * minute ))
+ALTPORT=601
 
 os::test::junit::declare_suite_start "Remote Syslog Configuration Tests"
+
+# switch pods type depending on the mux configuration
+fluentdtype="fluentd"
+if oc get dc/logging-mux > /dev/null 2>&1 ; then
+    os::log::debug "$( oc get dc/logging-mux )"
+    fluentdtype="mux"
+fi
 
 # save daemonset
 saveds=$( mktemp )
@@ -18,180 +27,268 @@ oc export ds/logging-fluentd -o yaml > $saveds
 
 # restore configs back to how it was before we ran our tests
 function reset_fluentd_daemonset() {
-  os::log::info Restoring original fluentd daemonset environment variable
+  os::log::info Restoring original fluentd daemonset / mux deploymentconfig environment variable
   os::log::debug "$( oc replace -f $saveds )"
 }
 
-# bz1515715 -- check if mux is enabled.
-savemuxdc=""
-if oc get dc/logging-mux > /dev/null 2>&1 ; then
-  savemuxdc=$( mktemp )
-  oc export dc/logging-mux -o yaml > $savemuxdc
+artifact_log Starting fluentd-plugin-remote-syslog tests on $fluentdtype at "$( date )"
+
+os::log::info Starting fluentd-plugin-remote-syslog tests on $fluentdtype at $( date )
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    my_remote_syslog_host=$( oc set env ds/logging-fluentd --list | grep REMOTE_SYSLOG_HOST | awk -F'=' '{print $2}' || : )
+else
+    my_remote_syslog_host=$( oc set env dc/logging-mux --list | grep REMOTE_SYSLOG_HOST | awk -F'=' '{print $2}' || : )
 fi
 
-function reset_mux_deployconfig() {
-  if [ "$savemuxdc" != "" ]; then
-    os::log::info Restoring original mux deployconfig environment variable
-    os::log::debug "$( oc replace -f $savemuxdc )"
-  fi
-}
+if [ -n "$my_remote_syslog_host" ]; then
+    title="Test 0, checking user configured REMOTE_SYSLOG_HOST is respected"
+    os::log::info $title
 
-os::log::info Starting fluentd-plugin-remote-syslog tests at $( date )
-
-my_remote_syslog_host=$( oc set env ds/logging-fluentd --list | grep REMOTE_SYSLOG_HOST | awk -F'=' '{print $2}' || : )
-if [ -n "${my_remote_syslog_host:-}" ] ; then
-  os::log::info Test 0, checking user configured REMOTE_SYSLOG_HOST is respected.
-  os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-  os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-  os::log::debug "$( oc set env ds/logging-fluentd USE_REMOTE_SYSLOG=true )"
-  os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-  os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-  fpod=$( get_running_pod fluentd )
-  os::cmd::try_until_success "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-  os::cmd::expect_success_and_text "oc exec $fpod grep 'remote_syslog' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" "remote_syslog ${my_remote_syslog_host}"
-fi
-
-os::log::info Test 1, expecting generate_syslog_config.rb to have created configuration file
-
-# make sure fluentd is running after previous test
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-fpod=$( get_running_pod fluentd )
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-
-os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 )"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
-fpod=$( get_running_pod fluentd )
-os::cmd::try_until_success "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-
-
-os::log::info Test 2, expecting generate_syslog_config.rb to not create a configuration file
-
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-
-os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST- )"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
-fpod=$( get_running_pod fluentd )
-os::cmd::try_until_failure "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-
-
-os::log::info Test 3, expecting generate_syslog_config.rb to generate multiple stores
-
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-
-os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_HOST2=127.0.0.1 )"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
-fpod=$( get_running_pod fluentd )
-os::cmd::try_until_text "oc exec $fpod grep '<store>' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf | wc -l" '^2$'
-
-
-os::log::info Test 4, making sure tag_key=message does not cause remote-syslog plugin crash
-
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-
-os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=message)"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
-fpod=$( get_running_pod fluentd )
-os::cmd::try_until_success "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success "oc exec $fpod grep 'tag_key message' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success_and_not_text "oc logs $fpod" "nil:NilClass"
-
-extra_rsyslog_artifacts=$ARTIFACT_DIR/rsyslog-artifacts.txt
-if [ -n "${DEBUG:-}" ] ; then
-  echo Test 4, making sure tag_key=message does not cause remote-syslog plugin crash > $extra_rsyslog_artifacts
-  echo "$( date --rfc-3339=ns )" "Enabled REMOTE_SYSLOG: USE_REMOTE_SYSLOG=true, REMOTE_SYSLOG_HOST=127.0.0.1, REMOTE_SYSLOG_HOST2=127.0.0.1, REMOTE_SYSLOG_TAG_KEY=message" >> $extra_rsyslog_artifacts
-
-  oc logs $fpod >> $extra_rsyslog_artifacts 2>&1
-
-  echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
-
-  oc exec $fpod -- cat /etc/fluent/configs.d/dynamic/output-remote-syslog.conf >> $extra_rsyslog_artifacts
-fi
-
-os::log::info Test 5, making sure tag_key=bogus does not cause remote-syslog plugin crash
-
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-
-os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=bogus)"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
-fpod=$( get_running_pod fluentd )
-os::cmd::try_until_success "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success "oc exec $fpod grep 'tag_key bogus' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success_and_not_text "oc logs $fpod" "nil:NilClass"
-
-if [ -n "${DEBUG:-}" ] ; then
-  echo Test Test 5, making sure tag_key=bogus does not cause remote-syslog plugin crash >> $extra_rsyslog_artifacts
-  echo "$( date --rfc-3339=ns )" "Enabled REMOTE_SYSLOG: USE_REMOTE_SYSLOG=true, REMOTE_SYSLOG_HOST=127.0.0.1, REMOTE_SYSLOG_HOST2=127.0.0.1, REMOTE_SYSLOG_TAG_KEY=bogus" >> $extra_rsyslog_artifacts
-
-  oc logs $fpod >> $extra_rsyslog_artifacts 2>&1
-
-  echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
-
-  oc exec $fpod -- cat /etc/fluent/configs.d/dynamic/output-remote-syslog.conf >> $extra_rsyslog_artifacts
-fi
-
-reset_fluentd_daemonset
-
-if [ "$savemuxdc" != "" ]; then
-
-  os::log::info Test 6, verify openshift_logging_mux_remote_syslog_host is respected in the mux pod
-
-  if [ -n "${DEBUG:-}" ] ; then
-    echo Test 6, verify openshift_logging_mux_remote_syslog_host is respected in the mux pod >> $extra_rsyslog_artifacts
-  fi
-
-  # make sure mux is running.
-  os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
-
-  os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
-  os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $FLUENTD_WAIT_TIME
-
-  # bz1515715 -- is openshift_logging_mux_remote_syslog_host set?
-  my_remote_syslog_host=$( oc set env dc/logging-mux --list | grep REMOTE_SYSLOG_HOST | awk -F'=' '{print $2}' || : )
-  if [ -n "${my_remote_syslog_host:-}" ] ; then
-    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true )"
-    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
-    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
-    mpod=$( get_running_pod mux )
-    if [ -n "${DEBUG:-}" ] ; then
-      oc logs $mpod >> $extra_rsyslog_artifacts 2>&1
-      echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
-      oc exec $mpod -- cat /etc/fluent/configs.d/dynamic/output-remote-syslog.conf >> $extra_rsyslog_artifacts
+    if [ "$fluentdtype" = "fluentd" ] ; then
+        # make sure fluentd is running after previous test
+        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+        os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+        os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+        os::log::debug "$( oc set env ds/logging-fluentd USE_REMOTE_SYSLOG=true )"
+        os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+        mypod=$( get_running_pod fluentd )
+    else
+        # make sure mux is running after previous test
+        os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+        os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+        os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+        os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true )"
+        os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+        os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+        mypod=$( get_running_pod mux )
     fi
-    os::cmd::try_until_success "oc exec $mpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-    os::cmd::expect_success_and_text "oc exec $mpod grep 'remote_syslog' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" "remote_syslog ${my_remote_syslog_host}"
-    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
-    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $FLUENTD_WAIT_TIME
-  fi
-
-  os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 )"
-  os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
-  os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
-
-  mpod=$( get_running_pod mux )
-  os::cmd::try_until_success "oc exec $mpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-  os::cmd::expect_success_and_text "oc exec $mpod grep 'remote_syslog' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" "remote_syslog 127.0.0.1"
-  if [ -n "${DEBUG:-}" ] ; then
-    oc logs $mpod >> $extra_rsyslog_artifacts 2>&1
-    echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
-    oc exec $mpod -- cat /etc/fluent/configs.d/dynamic/output-remote-syslog.conf >> $extra_rsyslog_artifacts
-  fi
-
-  reset_mux_deployconfig
+    os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
+    os::cmd::expect_success_and_text "oc exec $mypod grep 'remote_syslog' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" "remote_syslog ${my_remote_syslog_host}"
+    artifact_log $title $mypod
 fi
+
+
+title="Test 1, expecting generate_syslog_config.rb to have created configuration file"
+os::log::info $title
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    # make sure fluentd is running after previous test
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    # choosing an unrealistic REMOTE_SYSLOG_HOST
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=111.222.111.222 )"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    # make sure mux is running after previous test
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    # choosing an unrealistic REMOTE_SYSLOG_HOST
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=111.222.111.222 )"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
+artifact_log $title $mypod
+
+
+title="Test 2, expecting generate_syslog_config.rb to not create a configuration file"
+os::log::info $title
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST- )"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST- )"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_failure "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
+artifact_log $title $mypod
+
+
+title="Test 3, expecting generate_syslog_config.rb to generate multiple stores"
+os::log::info $title
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_HOST2=127.0.0.1 )"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_HOST2=127.0.0.1 )"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_text "oc exec $mypod grep '<store>' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf | wc -l" '^2$' $MUX_WAIT_TIME
+artifact_log $title $mypod
+
+
+title="Test 4, making sure tag_key=message does not cause remote-syslog plugin crash"
+os::log::info $title
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=message REMOTE_SYSLOG_HOST2-)"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=message REMOTE_SYSLOG_HOST2-)"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
+os::cmd::expect_success "oc exec $mypod grep 'tag_key message' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
+os::cmd::expect_success_and_not_text "oc logs $mypod" "nil:NilClass"
+
+artifact_log $title $mypod
+
+
+title="Test 5, making sure tag_key=bogus does not cause remote-syslog plugin crash"
+os::log::info $title
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=bogus)"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=bogus)"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
+os::cmd::expect_success "oc exec $mypod grep 'tag_key bogus' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
+os::cmd::expect_success_and_not_text "oc logs $mypod" "nil:NilClass"
+artifact_log $title $mypod
+
+
+title="Test 6, use rsyslogd on the node"
+os::log::info $title
+
+artifact_log iptables list
+sudo iptables -L 2>&1 | artifact_out || :
+
+# Make sure rsyslogd is listening on port 514 up and running
+#   Provides TCP syslog reception
+#   $ModLoad imtcp
+#   $InputTCPServerRun 514 -> 601
+rsyslogconfbakup=$( mktemp )
+artifact_log ORIGINAL /etc/rsyslog.conf
+cat /etc/rsyslog.conf 2>&1 | artifact_out
+artifact_log "--------------------------------------"
+cp /etc/rsyslog.conf $rsyslogconfbakup
+sudo sed -i -e "s/^#*\(\$ModLoad imtcp\)/\1/" -e "s/^#*\(\$InputTCPServerRun\) 514/\1 ${ALTPORT}/" /etc/rsyslog.conf
+artifact_log MODIFIED /etc/rsyslog.conf
+cat /etc/rsyslog.conf 2>&1 | artifact_out
+artifact_log "--------------------------------------"
+
+artifact_log Before restarting rsyslog
+sudo service rsyslog status 2>&1 | artifact_out || :
+os::cmd::expect_success "sudo service rsyslog restart"
+artifact_log After restarted rsyslog
+sudo service rsyslog status 2>&1 | artifact_out || :
+
+myhost=$( hostname )
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    # make sure fluentd is running after previous test
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset/logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=$myhost REMOTE_SYSLOG_PORT=${ALTPORT} REMOTE_SYSLOG_USE_RECORD=true REMOTE_SYSLOG_TAG_KEY- )"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=$myhost REMOTE_SYSLOG_PORT=${ALTPORT} REMOTE_SYSLOG_USE_RECORD=true REMOTE_SYSLOG_TAG_KEY- )"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
+artifact_log $title $mypod
+
+mymessage="rsyslogTestMessage-"$( date +%Y%m%d-%H%M%S )
+logger -i -p local6.info -t rsyslogTestTag $mymessage
+os::cmd::try_until_text "sudo grep $mymessage /var/log/messages" ".*${mymessage}.*" $MUX_WAIT_TIME
+artifact_log Log test message by logger: $mymessage
+sudo grep $mymessage /var/log/messages 2>&1 | artifact_out || :
+
+mymessage="testKibanaMessage-"$( date +%Y%m%d-%H%M%S )
+add_test_message $mymessage
+os::cmd::try_until_text "sudo grep $mymessage /var/log/messages" ".*${mymessage}.*" $MUX_WAIT_TIME
+artifact_log Log test message by kibana: $mymessage
+sudo grep $mymessage /var/log/messages 2>&1 | artifact_out || :
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    reset_fluentd_daemonset
+else
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=false REMOTE_SYSLOG_HOST- REMOTE_SYSLOG_USE_RECORD- REMOTE_SYSLOG_PORT=514 )"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+fi
+
+# Resetting rsyslogd
+#   Provides TCP syslog reception
+#   $ModLoad imtcp
+#   $InputTCPServerRun 514
+sudo cp $rsyslogconfbakup /etc/rsyslog.conf
+os::cmd::expect_success "sudo service rsyslog restart"
 
 os::test::junit::reconcile_output


### PR DESCRIPTION
Extending "use_record" to include hostname, which is going be put in the log in rsyslog.

Other changes.

- remote-syslog.sh would test mux, as well.
- remote-syslog.sh has another test case -- use rsyslogd on the node,
 in which it restarting rsyslogd enabling:
    $ModLoad imtcp
    $InputTCPServerRun 514