### PR TITLE
Using sed -i instead of doing a mv for file security

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -10,10 +10,8 @@ for p in ${OCP_OPERATIONS_PROJECTS}; do
     OCP_FLUENTD_TAGS+=" **_${p}_**"
 done
 ocp_fluentd_files=$( grep -l %OCP_FLUENTD_TAGS% ${CFG_DIR}/* ${CFG_DIR}/*/* 2> /dev/null || : )
-tmpfile=$( mktemp )
 for file in ${ocp_fluentd_files} ; do
-    sed -e "s/%OCP_FLUENTD_TAGS%/${OCP_FLUENTD_TAGS}/" $file > $tmpfile
-    mv $tmpfile $file
+    sed -i -e "s/%OCP_FLUENTD_TAGS%/${OCP_FLUENTD_TAGS}/" $file
 done
 
 fluentdargs="--no-supervisor"


### PR DESCRIPTION
If we don't end up getting output from the sed at all we could potentially be `mv`ing a blank file onto `$file`.
When debugging I saw that my `/etc/fluent/conf.d/openshift/output-operations.conf` file was empty, which shouldn't happen since we provide it at image build time.