### PR TITLE
retag openshift- namespaces from journal for .operations

### DIFF
--- a/fluentd/configs.d/openshift/filter-retag-journal.conf
+++ b/fluentd/configs.d/openshift/filter-retag-journal.conf
@@ -59,11 +59,11 @@
   # k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2
   # we filter these logs through the kibana_transform.conf filter
   rewriterule1 CONTAINER_NAME ^k8s_kibana\. kubernetes.journal.container.kibana
-  # mark for processing as k8s logs but stored as system logs
+  # mark logs from default namespace for processing as k8s logs but stored as system logs
   rewriterule2 CONTAINER_NAME ^k8s_[^_]+_[^_]+_default_ kubernetes.journal.container._default_
-  # mark for processing as k8s logs but stored as system logs
-  rewriterule3 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift-infra_ kubernetes.journal.container._openshift-infra_
-  # mark for processing as k8s logs but stored as system logs
+  # mark logs from openshift-* namespaces for processing as k8s logs but stored as system logs
+  rewriterule3 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift-(.+)_ kubernetes.journal.container._openshift-$1_
+  # mark logs from openshift namespace for processing as k8s logs but stored as system logs
   rewriterule4 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift_ kubernetes.journal.container._openshift_
   # mark fluentd container logs
   rewriterule5 CONTAINER_NAME ^k8s_.*fluentd kubernetes.journal.container.fluentd


### PR DESCRIPTION
When retagging journal entries for fluentd processing, retag all
namespaces of the form `openshift-*` to have a fluentd tag like
kubernetes.journal.container._openshift-*_
/test
@jcantrill @ewolinetz