### PR TITLE
Bug 1534588 - Size of the emitted data exceeds buffer_chunk_limit

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -194,6 +194,20 @@ if [ $TOTAL_LIMIT -le 0 ]; then
     echo "ERROR: Invalid file buffer limit ($FILE_BUFFER_LIMIT) is given.  Failed to convert to bytes."
     exit 1
 fi
+
+# If secure-forward outputs are configured, add them to NUM_OUTPUTS.
+sec_forward_files=$( grep -l "@type *secure_forward" ${CFG_DIR}/*/* 2> /dev/null || : )
+for afile in ${sec_forward_files} ; do
+    file=$( basename $afile )
+    if [ "$file" != "${mux_client_filename:-}" ]; then
+        grep "@type *secure_forward" $afile | while read -r line; do
+            if [ $( expr "$line" : "^ *#" ) -eq 0 ]; then
+                NUM_OUTPUTS=$( expr $NUM_OUTPUTS + 1 )
+            fi
+        done
+    fi
+done
+
 TOTAL_LIMIT=$(expr $TOTAL_LIMIT \* $NUM_OUTPUTS) || :
 if [ $DF_LIMIT -lt $TOTAL_LIMIT ]; then
     echo "WARNING: Available disk space ($DF_LIMIT bytes) is less than the user specified file buffer limit ($FILE_BUFFER_LIMIT times $NUM_OUTPUTS)."

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -10,7 +10,10 @@ FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
 
 os::test::junit::declare_suite_start "test/fluentd-forward"
 
+extra_artifacts=$ARTIFACT_DIR/fluentd-forward-artifacts.txt
+
 update_current_fluentd() {
+    cnt=${FORWARDCNT:-1}
     # this will update it so the current fluentd does not send logs to an ES host
     # but instead forwards to the forwarding fluentd
 
@@ -18,18 +21,25 @@ update_current_fluentd() {
     os::log::debug "$( oc label node --all logging-infra-fluentd- )"
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
 
-    # edit so we don't send to ES
-    oc get configmap/logging-fluentd -o yaml | sed '/## matches/ a\
+    FLUENTD_FORWARD=()
+    id=0
+    while [ $id -lt $cnt ]; do
+      POD=$( oc get pods -l component=forward-fluentd${id} -o name )
+      FLUENTD_FORWARD[$id]=$( oc get $POD --template='{{.status.podIP}}' )
+      echo "update_current_fluentd .status.podIP ${FLUENTD_FORWARD[$id]}" >> $extra_artifacts
+      id=$( expr $id + 1 ) || :
+    done
+
+    # update configmap secure-forward#.conf
+    if [ $cnt -eq 1 ]; then
+      # edit so we don't send to ES
+      oc get configmap/logging-fluentd -o yaml | sed '/## matches/ a\
       <match **>\
         @type copy\
-        @include configs.d/user/secure-forward.conf\
+        @include configs.d/user/secure-forward0.conf\
       </match>' | oc replace -f -
-
-    POD=$( oc get pods -l component=forward-fluentd -o name )
-    FLUENTD_FORWARD=$( oc get $POD --template='{{.status.podIP}}' )
-
-    # update configmap secure-forward.conf
-    oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "replace", "path": "/data/secure-forward.conf", "value": "\
+        oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "add", "path": "/data/secure-forward0.conf", "#": "generated config file secure-forward0.conf" }]' 2>&1
+        oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "replace", "path": "/data/secure-forward0.conf", "value": "\
   <store>\n\
    @type secure_forward\n\
    self_hostname forwarding-${HOSTNAME}\n\
@@ -37,49 +47,138 @@ update_current_fluentd() {
    secure no\n\
    buffer_queue_limit \"#{ENV['"'BUFFER_QUEUE_LIMIT'"']}\"\n\
    buffer_chunk_limit \"#{ENV['"'BUFFER_SIZE_LIMIT'"']}\"\n\
+   buffer_type file\n\
+   buffer_path '/var/lib/fluentd/buffer-fluentd-forward0'\n\
    <server>\n\
-    host '${FLUENTD_FORWARD}'\n\
+    host '${FLUENTD_FORWARD[0]}'\n\
     port 24284\n\
    </server>\n\
-  </store>"}]'
+  </store>\n"}]'
+      else
+    # edit so we don't send to ES
+    oc get configmap/logging-fluentd -o yaml | sed '/## matches/ a\
+      <match **>\
+        @type copy\
+        @include configs.d/user/secure-forward1.conf\
+      </match>' | oc replace -f -
+        oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "add", "path": "/data/secure-forward1.conf", "#": "generated config file secure-forward1.conf" }]' 2>&1
+        oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "replace", "path": "/data/secure-forward1.conf", "value": "\
+  <store>\n\
+   @type secure_forward\n\
+   self_hostname forwarding-${HOSTNAME}\n\
+   shared_key aggregated_logging_ci_testing\n\
+   secure no\n\
+   buffer_queue_limit \"#{ENV['"'BUFFER_QUEUE_LIMIT'"']}\"\n\
+   buffer_chunk_limit \"#{ENV['"'BUFFER_SIZE_LIMIT'"']}\"\n\
+   buffer_type file\n\
+   buffer_path '/var/lib/fluentd/buffer-fluentd-forward0'\n\
+   <server>\n\
+    host '${FLUENTD_FORWARD[0]}'\n\
+    port 24284\n\
+   </server>\n\
+  </store>\n\
+  <store>\n\
+   @type secure_forward\n\
+   self_hostname forwarding-${HOSTNAME}\n\
+   shared_key aggregated_logging_ci_testing\n\
+   secure no\n\
+   buffer_queue_limit \"#{ENV['"'BUFFER_QUEUE_LIMIT'"']}\"\n\
+   buffer_chunk_limit \"#{ENV['"'BUFFER_SIZE_LIMIT'"']}\"\n\
+   buffer_type file\n\
+   buffer_path '/var/lib/fluentd/buffer-fluentd-forward1'\n\
+   <server>\n\
+    host '${FLUENTD_FORWARD[1]}'\n\
+    port 24284\n\
+   </server>\n\
+  </store>\n"}]'
+      fi
 
+    # set FILE_BUFFER_LIMIT 256Mi; BUFFER_SIZE_LIMIT 8Mi.
+    # Note: FILE_BUFFER_LIMIT size is set for each output.
+    MY_FILE_BUFFER_LIMIT=256Mi
+    MY_BUFFER_SIZE_LIMIT=8Mi
+    # 256/8
+    EXP_BUFFER_QUEUE_LIMIT=$( expr 256 / 8 )
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd FILE_BUFFER_LIMIT=${MY_FILE_BUFFER_LIMIT} BUFFER_SIZE_LIMIT=${MY_BUFFER_SIZE_LIMIT} )"
     # redeploy fluentd
     os::cmd::expect_success flush_fluentd_pos_files
     os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-    fpod=$( get_running_pod fluentd )
+    echo "update_current_fluentd $cnt" >> $extra_artifacts
+    fpod=$( get_running_pod fluentd ) || :
+    echo "update_current_fluentd $cnt (oc logs $fpod)" >> $extra_artifacts
+    if [ -n "${fpod:-}" ] ; then
+        oc logs $fpod >> $extra_artifacts 2>&1 || :
+        id=$( expr $cnt - 1 ) || :
+        echo "update_current_fluentd $cnt (/etc/fluent/configs.d/user/secure-forward${id}.conf)" >> $extra_artifacts
+        oc exec $fpod -- cat /etc/fluent/configs.d/user/secure-forward${id}.conf >> $extra_artifacts || :
+        echo "update_current_fluentd $cnt (oc get pods)" >> $extra_artifacts
+        oc get pods >> $extra_artifacts
+    fi
+
+    # check set BUFFER_QUEUE_LIMIT
+    REAL_BUFFER_QUEUE_LIMIT=$( oc set env daemonset/logging-fluentd --list | grep BUFFER_QUEUE_LIMIT ) || :
+    REAL_BUFFER_QUEUE_LIMIT=$( echo ${REAL_BUFFER_QUEUE_LIMIT:-""} | awk -F'=' '{print $2}' )
+
+    if [ -z "$REAL_BUFFER_QUEUE_LIMIT" ]; then
+        os::log::error Environment variable BUFFER_QUEUE_LIMIT is empty.
+    elif [ "$REAL_BUFFER_QUEUE_LIMIT" = "$EXP_BUFFER_QUEUE_LIMIT" ]; then
+        os::log::debug "Environment variable BUFFER_QUEUE_LIMIT is correctly set to $EXP_BUFFER_QUEUE_LIMIT."
+    else
+        os::log::error "Environment variable BUFFER_QUEUE_LIMIT is set to $REAL_BUFFER_QUEUE_LIMIT, which is suppose to be $EXP_BUFFER_QUEUE_LIMIT."
+    fi
 }
 
 create_forwarding_fluentd() {
+  cnt=${FORWARDCNT:-1}
+  id=0
+  while [ $id -lt $cnt ]; do
     # create forwarding configmap named "logging-forward-fluentd"
-    oc create configmap logging-forward-fluentd \
+    oc create configmap logging-forward-fluentd${id} \
        --from-file=fluent.conf=$OS_O_A_L_DIR/hack/templates/forward-fluent.conf
 
     # create a directory for file buffering so as not to conflict with fluentd
-    if [ ! -d /var/lib/fluentd/forward ] ; then
-        sudo mkdir -p /var/lib/fluentd/forward
+    if [ ! -d /var/lib/fluentd/forward${id} ] ; then
+        sudo mkdir -p /var/lib/fluentd/forward${id}
     fi
 
     # create forwarding daemonset
-    oc get daemonset/logging-fluentd -o yaml | \
-        sed -e 's/logging-infra-fluentd: "true"/logging-infra-forward-fluentd: "true"/' \
-            -e 's/name: logging-fluentd/name: logging-forward-fluentd/' \
-            -e 's/ fluentd/ forward-fluentd/' \
+    if [ $id -eq 0 ]; then
+      oc get daemonset/logging-fluentd -o yaml | \
+        sed -e "s/logging-infra-fluentd:/logging-infra-forward-fluentd0:/" \
+            -e "s/name: logging-fluentd/name: logging-forward-fluentd0/" \
+            -e "s/ fluentd/ forward-fluentd0/" \
             -e '/image:/ a \
         ports: \
           - containerPort: 24284' | \
         oc create -f -
+    else
+      oc get daemonset/logging-fluentd -o yaml | \
+        sed -e "s/logging-infra-fluentd:/logging-infra-forward-fluentd1:/" \
+            -e "s/name: logging-fluentd/name: logging-forward-fluentd1/" \
+            -e "s/ fluentd/ forward-fluentd1/" \
+            -e '/image:/ a \
+        ports: \
+          - containerPort: 24284' | \
+        oc create -f -
+    fi
 
     # make it use a different hostpath than fluentd
-    oc set volumes daemonset/logging-forward-fluentd --add --overwrite \
+    oc set volumes daemonset/logging-forward-fluentd${id} --add --overwrite \
        --name=filebufferstorage --type=hostPath \
-       --path=/var/lib/fluentd/forward --mount-path=/var/lib/fluentd
+       --path=/var/lib/fluentd/forward${id} --mount-path=/var/lib/fluentd
 
     os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-forward-fluentd=true )"
+    os::log::debug "$( oc label node --all logging-infra-forward-fluentd${id}=true )"
 
     # wait for forward-fluentd to start
-    os::cmd::try_until_text "oc get pods -l component=forward-fluentd" "^logging-forward-fluentd-.* Running "
+    os::cmd::try_until_text "oc get pods -l component=forward-fluentd${id}" "^logging-forward-fluentd${id}-.* Running "
+    POD=$( oc get pods -l component=forward-fluentd${id} -o name )
+    echo "create_forwarding_fluentd $cnt (oc logs $POD)" >> $extra_artifacts
+    oc logs $POD >> $extra_artifacts 2>&1 || :
+    id=$( expr $id + 1 )
+  done
 }
 
 # save current fluentd daemonset
@@ -91,37 +190,53 @@ savecm=$( mktemp )
 oc get configmap logging-fluentd -o yaml > $savecm
 
 cleanup() {
-    local return_code="$?"
-    set +e
-    if [ $return_code = 0 ] ; then
-        mycmd=os::log::info
-    else
-        mycmd=os::log::error
-    fi
-    $mycmd fluentd-forward test finished at $( date )
+  local return_code="$?"
+  set +e
+  if [ $return_code = 0 ] ; then
+    mycmd=os::log::info
+  else
+    mycmd=os::log::error
+  fi
+  cnt=${FORWARDCNT:-0}
+  # dump the pod before we restart it
+  if [ -n "${fpod:-}" ] ; then
+    echo "cleanup (oc logs $fpod)" >> $extra_artifacts
+    oc logs $fpod >> $extra_artifacts || :
+  fi
+  oc get pods >> $extra_artifacts 
+  id=0
+  while [ $id -lt $cnt ]; do
+    POD=$( oc get pods -l component=forward-fluentd${id} -o name ) || :
+    echo "cleanup $cnt (oc logs $POD)" >> $extra_artifacts
+    oc logs $POD >> $extra_artifacts || :
+    id=$( expr $id + 1 )
+  done
+  os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+  os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+  if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
+    os::log::debug "$( oc replace --force -f $savecm )"
+  fi
+  if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
+    os::log::debug "$( oc replace --force -f $saveds )"
+  fi
+  id=0
+  while [ $id -lt $cnt ]; do
+    $mycmd fluentd-forward${id} test finished at $( date )
 
     # Clean up only if it's still around
-    os::log::debug "$( oc delete daemonset/logging-forward-fluentd 2>&1 || : )"
-    os::log::debug "$( oc delete configmap/logging-forward-fluentd 2>&1 || : )"
-    os::log::debug "$( oc label node --all logging-infra-forward-fluentd- 2>&1 || : )"
-
-    # dump the pod before we restart it
-    if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod > $ARTIFACT_DIR/$fpod.log 2>&1
-    fi
-    os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
-    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-    if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
-        os::log::debug "$( oc replace --force -f $savecm )"
-    fi
-    if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
-        os::log::debug "$( oc replace --force -f $saveds )"
-    fi
-    os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+    os::log::debug "$( oc delete daemonset/logging-forward-fluentd${id} 2>&1 || : )"
+    os::log::debug "$( oc delete configmap/logging-forward-fluentd${id} 2>&1 || : )"
+    os::log::debug "$( oc label node --all logging-infra-forward-fluentd${id}- 2>&1 || : )"
+    id=$( expr $id + 1 )
+  done
+  os::cmd::expect_success flush_fluentd_pos_files
+  os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+  if [ $cnt -gt 1 ]; then
+    cat $extra_artifacts
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
     exit $return_code
+  fi
 }
 trap "cleanup" EXIT
 
@@ -132,7 +247,14 @@ os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* 
 fpod=$( get_running_pod fluentd )
 os::cmd::expect_success wait_for_fluentd_to_catch_up
 
+# FORWARDCNT must be 1 or 2
+FORWARDCNT=1
 create_forwarding_fluentd
 update_current_fluentd
-
 os::cmd::expect_success wait_for_fluentd_to_catch_up
+cleanup
+
+FORWARDCNT=2
+create_forwarding_fluentd
+update_current_fluentd
+os::cmd::expect_success "wait_for_fluentd_to_catch_up '' '' 2"


### PR DESCRIPTION
If secure-forward outputs are additionally configured, the output
count is also to be added to NUM_OUTPUTS, which is a divider to
calculate the buffer size per output.

Adding tests to cover the cases - having 1 then 2 intermediate
forwarding fluentds.