### PR TITLE
fluent-plugin-secure-forward needs automake libtool m4

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -27,7 +27,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
       make \
       bc \
       iproute \
-      autoconf \
+      autoconf automake libtool m4 \
       redhat-rpm-config && \
     yum clean all
 


### PR DESCRIPTION
This should fix recent fluentd build issues
/test