### PR TITLE
bump kibana request timeout to 5 minutes

### DIFF
--- a/kibana/kibana.yml
+++ b/kibana/kibana.yml
@@ -54,7 +54,7 @@ elasticsearch.ssl.ca: /etc/kibana/keys/ca
 
 # Time in milliseconds to wait for responses from the back end or elasticsearch.
 # This must be > 0
-elasticsearch.requestTimeout: 30000
+elasticsearch.requestTimeout: 300000
 
 # Time in milliseconds for Elasticsearch to wait for responses from shards.
 # Set to 0 to disable.


### PR DESCRIPTION
Change request to normalize default for starter clusters, et al.