### PR TITLE
parse log field for mux minimal mode for json-file logs

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -118,8 +118,12 @@ if [ -n "${MUX_CLIENT_MODE:-}" ] ; then
         cp -f $CFG_DIR/user/filter-pre-mux-client.conf $CFG_DIR/openshift/$mux_client_filename
     fi
     # rm k8s meta plugin - do not hit the API server - just do json parsing
-    if [ "${MUX_CLIENT_MODE:-}" = maximal -o "${MUX_CLIENT_MODE:-}" = minimal ] ; then
+    if [ "${MUX_CLIENT_MODE:-}" = maximal ] ; then
         cp -f $CFG_DIR/filter-k8s-meta-for-mux-client.conf $CFG_DIR/openshift/filter-k8s-meta.conf
+    elif [ "${MUX_CLIENT_MODE:-}" = minimal -a "${USE_JOURNAL:-}" = false ] ; then
+        # have to do this before shipping record to mux so embedded "log" field
+        # will be json parsed correctly
+        cp -f $CFG_DIR/filter-k8s-meta-for-mux-client.conf $CFG_DIR/openshift/filter-pre-k8s-meta.conf
     fi
     # mux clients do not create elasticsearch index names
     ENABLE_ES_INDEX_NAME=false


### PR DESCRIPTION
When using MUX_CLIENT_MODE=minimal and json-file logs, we have to
parse the `log` field - mux only runs in journald mode so expects
the `MESSAGE` field to contain the JSON value to parse.
In the mux tests, make sure the `MESSAGE` field is populated with
the contents of the `log` field so that it will be parsed.
There appears to be a new behavior with the internal openshift
logging which is causing test flakes in the mux test - query the
`message` field only instead of `_all` (all fields) for the test
data.