### PR TITLE
[release-3.6] Bug 1465039 - fluentd crashes when reading from journald after 3.4 to 3.5 upgrade

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -24,7 +24,8 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
       libcurl-devel \
       make \
       bc \
-      iproute && \
+      iproute \
+      autoconf automake libtool m4 && \
     yum clean all
 RUN mkdir -p ${HOME} && \
     gem install -N --conservative --minimal-deps --no-ri \

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
+fluentdargs="--no-supervisor"
 if [[ $VERBOSE ]]; then
   set -ex
-  fluentdargs="-vv"
+  fluentdargs="$fluentdargs -vv"
   echo ">>>>>> ENVIRONMENT VARS <<<<<"
   env | sort
   echo ">>>>>>>>>>>>><<<<<<<<<<<<<<<<"
 else
   set -e
-  fluentdargs=
 fi
 
 docker_uses_journal() {


### PR DESCRIPTION
Disabling fluentd supervisor mode to avoid forking the fluentd process.