### PR TITLE
fluentd: determine if openshift uses cri-o from nodeconfig

### DIFF
--- a/docs/log-drivers-and-throttling.md
+++ b/docs/log-drivers-and-throttling.md
@@ -3,15 +3,19 @@ Introduction
 
 When Fluentd is collecting node logs, the main sources are the system logs from
 the journal, and container logs, the source of which depends on the `docker
---log-driver` configuration:
+--log-driver` configuration and container runtime selection configured in
+`/etc/origin/node/node-config.yaml` mounted to fluentd container from host:
 
 * `journald` - container logs are written to the journal and denoted with the
   `CONTAINER_NAME` field
 * `json-file` - container logs are made available in `/var/log/containers`
   (through a long a complicated process of several layers of symlinks).
+* `cri-o` - container logs are made available in `/var/log/containers` similarly
+  to the `json-file` log driver but with cri-o format
 
 Fluentd will always read system logs from the journal, and will always read
-container logs from both `journald` and `json-file`.
+container logs from `journald` or `/var/log/containers`, latter formatted either
+as `json` or `cri-o`.
 
 ### JSON file container log parameters ###
 
@@ -27,6 +31,21 @@ reading from where it left off if the Fluentd pod is restarted.
 * `JSON_FILE_READ_FROM_HEAD` - default `true` - if `false`, start reading from
 the tail/end of the file.  If the `JSON_FILE_POS_FILE` exists and has an
 entry for this file, the `JSON_FILE_READ_FROM_HEAD` setting is ignored.
+
+### cri-o container log parameters ###
+
+Just like the json-file, these are provided for documentation purposes only.
+Do not set these unless you know what you are doing.
+
+* `CRIO_FILE_PATH` - default `/var/log/containers/*.log` - full path and filename
+match pattern for docker json-file log driver logs
+* `CRIO_FILE_POS_FILE` - default `/var/log/es-containers.log.pos` - full path
+and filename for the Fluentd `in_tail` position file.  This file should be on a
+persistent volume (e.g. bind mounted from the host) so that Fluentd can resume
+reading from where it left off if the Fluentd pod is restarted.
+* `CRIO_FILE_READ_FROM_HEAD` - default `true` - if `false`, start reading from
+the tail/end of the file.  If the `CRIO_FILE_POS_FILE` exists and has an
+entry for this file, the `CRIO_FILE_READ_FROM_HEAD` setting is ignored.
 
 ### journal parameters ###
 

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -7,3 +7,16 @@ Following are the environment variables that can be modified to adjust the confi
 | Environment Variable | Description |Example|
 |----------------------|-------------|---|
 | `OCP_OPERATIONS_PROJECTS`| The list of project or patterns for which messages will be sent to the operations indices|`OCP_OPERATIONS_PROJECTS="default openshift openshift-"`
+
+## Cri-o Formatted Container Logs
+In order to enable cri-o logs parsing, it is necessary to mount 
+`node-config.yaml` from the host inside the fluentd container to this path:
+```
+/etc/origin/node/node-config.yaml
+```
+If EFK stack is deployed using openshift-ansible 3.9 or later, the mount point
+is already created by ansible installer.
+
+Fluentd pod on startup automatically determines from the `node-config.yaml`
+whether to setup `in_tail` plugin to parse cri-o formatted logs in
+`/var/log/containers/*` or whether to read logs from docker driver.

--- a/fluentd/generate_throttle_configs.rb
+++ b/fluentd/generate_throttle_configs.rb
@@ -21,12 +21,16 @@ DEFAULT_OPS_PROJECTS = !ENV['OCP_OPERATIONS_PROJECTS'].nil? ? ENV['OCP_OPERATION
 DEFAULT_FILENAME = "/etc/fluent/configs.d/user/throttle-config.yaml"
 
 VALID_SETTINGS = {"read_lines_limit" => "number"}
+CONTAINER_LOG_DRIVER = ENV['USE_CRIO'] == 'true' ? "CRIO" : "JSON_FILE"
+POS_FILE = CONTAINER_LOG_DRIVER + "_POS_FILE"
+READ_FROM_HEAD = CONTAINER_LOG_DRIVER + "_READ_FROM_HEAD"
+CONT_LOGS_PATH = CONTAINER_LOG_DRIVER + "_PATH"
 
-def json_pos_file
-  ENV['JSON_FILE_POS_FILE'] || '/var/log/es-containers.log.pos'
+def cont_pos_file
+  ENV[POS_FILE] || '/var/log/es-containers.log.pos'
 end
 
-def get_json_pos_file_name(name)
+def get_cont_pos_file_name(name)
   return "/var/log/es-container-#{name}.log.pos"
 end
 
@@ -80,7 +84,7 @@ end
 
 ## This will copy the pos entries from the throttle configs back to the default pos file
 def revert_throttle()
-  get_all_throttle_files.each { |file_name| move_pos_file_project_entry(file_name, json_pos_file, '.*') }
+  get_all_throttle_files.each { |file_name| move_pos_file_project_entry(file_name, cont_pos_file, '.*') }
 end
 
 def seed_file(file_name, project)
@@ -91,10 +95,10 @@ def seed_file(file_name, project)
     ## openshift-* is a protected project prefix -- so users would not be able to create
     ## a project that starts with this. Guard taken to prevent possible collision with a
     ## user created project 'operations'
-    pos_file = get_json_pos_file_name('openshift-operations')
+    pos_file = get_cont_pos_file_name('openshift-operations')
   else
     path = get_project_pattern(project)
-    pos_file = get_json_pos_file_name(project)
+    pos_file = get_cont_pos_file_name(project)
   end
 
   File.open(file_name, 'w') { |file|
@@ -109,8 +113,8 @@ def seed_file(file_name, project)
   }
 
   # Set up the initial pos file in case we had already read from container files
-  move_pos_file_project_entry(json_pos_file, pos_file, project) unless project.eql?('.operations')
-  DEFAULT_OPS_PROJECTS.each{ |ops_project| move_pos_file_project_entry(json_pos_file, pos_file, ops_project) } if project.eql?('.operations')
+  move_pos_file_project_entry(cont_pos_file, pos_file, project) unless project.eql?('.operations')
+  DEFAULT_OPS_PROJECTS.each{ |ops_project| move_pos_file_project_entry(cont_pos_file, pos_file, ops_project) } if project.eql?('.operations')
 end
 
 def write_to_file(project, key, value)
@@ -139,7 +143,7 @@ def close_file(project)
   tag kubernetes.*
   format json
   keep_time_key true
-  read_from_head "#{ENV['JSON_FILE_READ_FROM_HEAD'] || 'true'}"
+  read_from_head "#{ENV[READ_FROM_HEAD] || 'true'}"
 </source>
     CONF
   } if File.exist?(file_name)
@@ -155,13 +159,13 @@ def create_default_docker(excluded)
 <source>
   @type tail
   @label @INGRESS
-  path "#{ENV['JSON_FILE_PATH'] || '/var/log/containers/*.log'}"
-  pos_file "#{ENV['JSON_FILE_POS_FILE'] || '/var/log/es-containers.log.pos'}"
+  path "#{ENV[CONT_LOGS_PATH] || '/var/log/containers/*.log'}"
+  pos_file "#{ENV[POS_FILE] || '/var/log/es-containers.log.pos'}"
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
   format #{ENV['USE_CRIO'] == 'true' ? '/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<message>.*)$/' : 'json'}
   keep_time_key true
-  read_from_head "#{ENV['JSON_FILE_READ_FROM_HEAD'] || 'true'}"
+  read_from_head "#{ENV[READ_FROM_HEAD] || 'true'}"
   exclude_path #{excluded}
 </source>
     CONF

--- a/fluentd/generate_throttle_configs.rb
+++ b/fluentd/generate_throttle_configs.rb
@@ -159,7 +159,7 @@ def create_default_docker(excluded)
   pos_file "#{ENV['JSON_FILE_POS_FILE'] || '/var/log/es-containers.log.pos'}"
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
-  format json
+  format #{ENV['USE_CRIO'] == 'true' ? '/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<message>.*)$/' : 'json'}
   keep_time_key true
   read_from_head "#{ENV['JSON_FILE_READ_FROM_HEAD'] || 'true'}"
   exclude_path #{excluded}


### PR DESCRIPTION
Parse `/etc/origin/node/node-config.yaml` config file for `kubeletArguments -> container-runtime-endpoint` if it contains `crio`.

Change generation of `in_tail` plugin config to don't try parsing as json but as a regex instead if crio is identified.

The regex used is:
`/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<message>.*)$/`

and is based on the parsing logic in cri-o for 1.8 and 1.9:
https://github.com/kubernetes-incubator/cri-o/blob/release-1.8/oci/oci.go#L353-L387
https://github.com/kubernetes-incubator/cri-o/blob/release-1.9/oci/oci.go#L353-L395

NOTE: the `logtag` was introduced in 1.9 so it is put as optional here, and currently doesn't appear to be working well with Elasticsearch logs so this PR doesn't try to append and reconstruct multiline logs.

NOTE2: this requires openshift to pick either docker or crio for their container runtime, fluentd settings are uniform for collecting all container logs