### PR TITLE
bz1515715 -- remote syslog hostname

### DIFF
--- a/fluentd/configs.d/openshift/output-operations.conf
+++ b/fluentd/configs.d/openshift/output-operations.conf
@@ -1,6 +1,7 @@
 <match output_ops_tag journal.** system.var.log** mux.ops audit.log** %OCP_FLUENTD_TAGS%>
   @type copy
   @include ../dynamic/output-es-ops-config.conf
+  @include ../dynamic/output-remote-syslog.conf
   @include ../user/output-ops-extra-*.conf
   @include ../user/secure-forward.conf
 </match>

--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -3,7 +3,6 @@
 
 require 'fluent/mixin/config_placeholders'
 module Fluent
-
   class SyslogOutput < Fluent::Output
     # First, register the plugin. NAME is the name of this plugin
     # and identifies the plugin in the configuration file.
@@ -11,7 +10,7 @@ module Fluent
 
     # This method is called before starting.
 
-    config_param :remote_syslog, :string, :default => nil
+    config_param :remote_syslog, :string, :default => ""
     config_param :port, :integer, :default => 25
     config_param :hostname, :string, :default => ""
     config_param :remove_tag_prefix, :string, :default => nil
@@ -26,6 +25,7 @@ module Fluent
       super
       require 'socket'
       require 'syslog_protocol'
+      require 'securerandom'
     end
 
     def configure(conf)
@@ -45,6 +45,7 @@ module Fluent
       if not @payload_key
         @payload_key = "message"
       end
+      @random_string = SecureRandom.hex
     end
 
 
@@ -73,13 +74,13 @@ module Fluent
           if @use_record && record.key?('systemd') && (record['systemd']).key?('u') && (record['systemd']['u']).key?('SYSLOG_FACILITY')
             fval = record['systemd']['u']['SYSLOG_FACILITY'].to_i
             if (1..23).include?(fval)
-                @packet.facility = fval
-            elsif record['systemd']['u']['SYSLOG_FACILITY'].eql? '0'
-                @packet.facility = 0
-            elsif record['systemd']['u']['SYSLOG_FACILITY'].eql? 'kern'
-                @packet.facility = 'kern'
+              @packet.facility = fval
             else
+              if record['systemd']['u']['SYSLOG_FACILITY'].eql? '0'
+                @packet.facility = 0
+              else
                 @packet.facility = record['systemd']['u']['SYSLOG_FACILITY'] || @facility
+              end
             end
           elsif record.key?('_KERNEL_DEVICE')
             @packet.facility = 'kern'
@@ -91,36 +92,48 @@ module Fluent
           @packet.facility = @facilty
           @packet.severity = @severity
         end
-        if record['time']
-          time = Time.parse(record['time'])
+        time = if record['time']
+          Time.parse(record['time'])
         else
-          time = Time.now
+          Time.now
         end
         @packet.time = time
-        if @tag_key.any?
+        @packet.tag = @random_string
+        if @tag_key.any? && record.any?
+          # tag_key is an array type
+          # E.g., tag_key ident,systemd.u.SYSLOG_IDENTIFIER,ident
+          #       tkey = ident
+          #       tkey = systemd.u.SYSLOG_IDENTIFIER
           @tag_key.each { |tkey|
+            # ident => record[ident]
+            # systemd.u.SYSLOG_IDENTIFIER => record[systemd][u][SYSLOG_IDENTIFIER]
             mytag = record
+            # check if tkey is '.' separated.
             tkey.split('.').each { |p|
-              break if ! mytag.key?(p)
+              if ! mytag.key?(p)
+                if ! p.eql? tkey
+                  log.debug "out:syslog: #{p} from #{tkey} in tag_key #{@tag_key} is not a key of record."
+                end
+                break
+              end
               mytag = mytag[p]
             }
             next if ! mytag.is_a? String
-            next if mytag.empty?
             @packet.tag = mytag[0..31].gsub(/[\[\]\s]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
             break
           }
         end
-        if @packet.tag.nil? || @packet.tag.empty?
+        if @packet.tag.eql? random_string
           @packet.tag = tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
         end
         packet = @packet.dup
-        if @use_record && (record.key?('kubernetes')) && @record[@payload_key]
-            packet.content = (((record['kubernetes']).key?('namespace_name')) ? 'namespace_name=' + record['kubernetes']['namespace_name'] + ', ' : '' ) + \
-                             (((record['kubernetes']).key?('container_name')) ? 'container_name=' + record['kubernetes']['container_name'] + ', ' : '' ) + \
-                             (((record['kubernetes']).key?('pod_name')) ? 'pod_name=' + record['kubernetes']['pod_name'] + ', ' : '' ) + \
-                             @payload_key + '=' + record[@payload_key]
+        packet.content = if @use_record && (record.key?('kubernetes')) && record[@payload_key]
+          (((record['kubernetes']).key?('namespace_name')) ? 'namespace_name=' + record['kubernetes']['namespace_name'] + ', ' : '' ) + \
+          (((record['kubernetes']).key?('container_name')) ? 'container_name=' + record['kubernetes']['container_name'] + ', ' : '' ) + \
+          (((record['kubernetes']).key?('pod_name')) ? 'pod_name=' + record['kubernetes']['pod_name'] + ', ' : '' ) + \
+          @payload_key + '=' + record[@payload_key]
         else
-            packet.content = record[@payload_key]
+          record[@payload_key]
         end
         @socket.send(packet.assemble, 0, @remote_syslog, @port)
     }

--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -15,7 +15,7 @@ module Fluent
     config_param :port, :integer, :default => 25
     config_param :hostname, :string, :default => ""
     config_param :remove_tag_prefix, :string, :default => nil
-    config_param :tag_key, :string, :default => nil
+    config_param :tag_key, :array, default: nil
     config_param :facility, :string, :default => 'user'
     config_param :severity, :string, :default => 'debug'
     config_param :use_record, :string, :default => nil
@@ -67,11 +67,27 @@ module Fluent
       tag = tag.sub(@remove_tag_prefix, '') if @remove_tag_prefix
       chain.next
       es.each {|time,record|
-        @packet.hostname = hostname
         if @use_record
-          @packet.facility = record['facility'] || @facilty
-          @packet.severity = record['severity'] || @severity
+          @packet.hostname = record['hostname'] || hostname
+          @packet.severity = (record['level'].eql? 'warning')? 'warn' : record['level'] || @severity
+          if @use_record && record.key?('systemd') && (record['systemd']).key?('u') && (record['systemd']['u']).key?('SYSLOG_FACILITY')
+            fval = record['systemd']['u']['SYSLOG_FACILITY'].to_i
+            if (1..23).include?(fval)
+                @packet.facility = fval
+            elsif record['systemd']['u']['SYSLOG_FACILITY'].eql? '0'
+                @packet.facility = 0
+            elsif record['systemd']['u']['SYSLOG_FACILITY'].eql? 'kern'
+                @packet.facility = 'kern'
+            else
+                @packet.facility = record['systemd']['u']['SYSLOG_FACILITY'] || @facility
+            end
+          elsif record.key?('_KERNEL_DEVICE')
+            @packet.facility = 'kern'
+          else
+            @packet.facility = record['facility'] || @facility
+          end
         else
+          @packet.hostname = hostname
           @packet.facility = @facilty
           @packet.severity = @severity
         end
@@ -81,17 +97,31 @@ module Fluent
           time = Time.now
         end
         @packet.time = time
-        @packet.tag = if @tag_key
-                        begin
-                          record[@tag_key][0..31].gsub(/[\[\]\s]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
-                        rescue
-                          tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
-                        end
-                      else
-                          tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
-                      end
+        if @tag_key.any?
+          @tag_key.each { |tkey|
+            mytag = record
+            tkey.split('.').each { |p|
+              break if ! mytag.key?(p)
+              mytag = mytag[p]
+            }
+            next if ! mytag.is_a? String
+            next if mytag.empty?
+            @packet.tag = mytag[0..31].gsub(/[\[\]\s]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
+            break
+          }
+        end
+        if @packet.tag.nil? || @packet.tag.empty?
+          @packet.tag = tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
+        end
         packet = @packet.dup
-        packet.content = record[@payload_key]
+        if @use_record && (record.key?('kubernetes')) && @record[@payload_key]
+            packet.content = (((record['kubernetes']).key?('namespace_name')) ? 'namespace_name=' + record['kubernetes']['namespace_name'] + ', ' : '' ) + \
+                             (((record['kubernetes']).key?('container_name')) ? 'container_name=' + record['kubernetes']['container_name'] + ', ' : '' ) + \
+                             (((record['kubernetes']).key?('pod_name')) ? 'pod_name=' + record['kubernetes']['pod_name'] + ', ' : '' ) + \
+                             @payload_key + '=' + record[@payload_key]
+        else
+            packet.content = record[@payload_key]
+        end
         @socket.send(packet.assemble, 0, @remote_syslog, @port)
     }
     end

--- a/fluentd/out_syslog_buffered.rb
+++ b/fluentd/out_syslog_buffered.rb
@@ -26,6 +26,7 @@ module Fluent
       require 'socket'
       require 'syslog_protocol'
       require 'timeout'
+      require 'securerandom'
     end
 
     def configure(conf)
@@ -33,7 +34,7 @@ module Fluent
       if not conf['remote_syslog']
         raise Fluent::ConfigError.new("remote syslog required")
       end
-        @socket = create_tcp_socket(conf['remote_syslog'], conf['port'])
+      @socket = create_tcp_socket(conf['remote_syslog'], conf['port'])
       @packet = SyslogProtocol::Packet.new
       if remove_tag_prefix = conf['remove_tag_prefix']
         @remove_tag_prefix = Regexp.new('^' + Regexp.escape(remove_tag_prefix))
@@ -45,6 +46,7 @@ module Fluent
       if not @payload_key
         @payload_key = "message"
       end
+      @random_string = SecureRandom.hex
     end
 
     def format(tag, time, record)
@@ -85,8 +87,8 @@ module Fluent
 
     def write(chunk)
       chunk.msgpack_each {|(tag,time,record)|
-            send_to_syslog(tag, time, record)
-          }
+        send_to_syslog(tag, time, record)
+      }
     end
 
     def send_to_syslog(tag, time, record)
@@ -97,13 +99,13 @@ module Fluent
         if @use_record && record.key?('systemd') && (record['systemd']).key?('u') && (record['systemd']['u']).key?('SYSLOG_FACILITY')
           fval = record['systemd']['u']['SYSLOG_FACILITY'].to_i
           if (1..23).include?(fval)
-              @packet.facility = fval
-          elsif record['systemd']['u']['SYSLOG_FACILITY'].eql? '0'
-              @packet.facility = 0
-          elsif record['systemd']['u']['SYSLOG_FACILITY'].eql? 'kern'
-              @packet.facility = 'kern'
+            @packet.facility = fval
           else
+            if record['systemd']['u']['SYSLOG_FACILITY'].eql? '0'
+              @packet.facility = 0
+            else
               @packet.facility = record['systemd']['u']['SYSLOG_FACILITY'] || @facility
+            end
           end
         elsif record.key?('_KERNEL_DEVICE')
           @packet.facility = 'kern'
@@ -115,36 +117,48 @@ module Fluent
         @packet.facility = @facilty
         @packet.severity = @severity
       end
-      if record['time']
-        time = Time.parse(record['time'])
+      time = if record['time']
+        Time.parse(record['time'])
       else
-        time = Time.now
+        Time.now
       end
       @packet.time = time
-      if @tag_key.any?
+      @packet.tag = @random_string
+      if @tag_key.any? && record.any?
+        # tag_key is an array type
+        # E.g., tag_key ident,systemd.u.SYSLOG_IDENTIFIER,ident
+        #       tkey = ident
+        #       tkey = systemd.u.SYSLOG_IDENTIFIER
         @tag_key.each { |tkey|
+          # ident => record[ident]
+          # systemd.u.SYSLOG_IDENTIFIER => record[systemd][u][SYSLOG_IDENTIFIER]
           mytag = record
+          # check if tkey is '.' separated.
           tkey.split('.').each { |p|
-            break if ! mytag.key?(p)
+            if ! mytag.key?(p)
+              if ! p.eql? tkey
+                log.debug "out:syslog_buffered: #{p} from #{tkey} in tag_key #{@tag_key} is not a key of record."
+              end
+              break
+            end
             mytag = mytag[p]
           }
           next if ! mytag.is_a? String
-          next if mytag.empty?
           @packet.tag = mytag[0..31].gsub(/[\[\]\s]/,'') # tag is trimmed to 32 chars for syslog_protocol gem compatibility
           break
         }
       end
-      if @packet.tag.nil? || @packet.tag.empty?
+      if @packet.tag.eql? @random_string
         @packet.tag = tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
       end
       packet = @packet.dup
-      if @use_record && record.key?('kubernetes') && record[@payload_key]
-          packet.content = (((record['kubernetes']).key?('namespace_name')) ? 'namespace_name=' + record['kubernetes']['namespace_name'] + ', ' : '' ) + \
-                           (((record['kubernetes']).key?('container_name')) ? 'container_name=' + record['kubernetes']['container_name'] + ', ' : '' ) + \
-                           (((record['kubernetes']).key?('pod_name')) ? 'pod_name=' + record['kubernetes']['pod_name'] + ', ' : '' ) + \
-                           @payload_key + '=' + record[@payload_key]
+      packet.content = if @use_record && (record.key?('kubernetes')) && record[@payload_key]
+        (((record['kubernetes']).key?('namespace_name')) ? 'namespace_name=' + record['kubernetes']['namespace_name'] + ', ' : '' ) + \
+        (((record['kubernetes']).key?('container_name')) ? 'container_name=' + record['kubernetes']['container_name'] + ', ' : '' ) + \
+        (((record['kubernetes']).key?('pod_name')) ? 'pod_name=' + record['kubernetes']['pod_name'] + ', ' : '' ) + \
+        @payload_key + '=' + record[@payload_key]
       else
-          packet.content = record[@payload_key]
+        record[@payload_key]
       end
       begin
         if not @socket

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -236,8 +236,8 @@ cleanup() {
   if [ $cnt -gt 1 ]; then
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
-    exit $return_code
   fi
+  exit $return_code
 }
 trap "cleanup" EXIT
 

--- a/test/remote-syslog.sh
+++ b/test/remote-syslog.sh
@@ -9,6 +9,8 @@ source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::util::environment::use_sudo
 
 FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
+MUX_WAIT_TIME=$(( 10 * minute ))
+ALTPORT=601
 
 os::test::junit::declare_suite_start "Remote Syslog Configuration Tests"
 
@@ -16,182 +18,384 @@ os::test::junit::declare_suite_start "Remote Syslog Configuration Tests"
 saveds=$( mktemp )
 oc export ds/logging-fluentd -o yaml > $saveds
 
+# switch pods type depending on the mux configuration
+fluentdtype="fluentd"
+mpod=$( get_running_pod mux )
+if [ -n "${mpod:-}" ]; then
+    # mux is configured; make sure mux client fluentd runs as maximal mode.
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+    os::log::debug "$( oc set env ds/logging-fluentd MUX_CLIENT_MODE=maximal )"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+    fluentdtype="mux"
+fi
+
 # restore configs back to how it was before we ran our tests
 function reset_fluentd_daemonset() {
-  os::log::info Restoring original fluentd daemonset environment variable
+  os::log::info Restoring original fluentd daemonset / mux deploymentconfig environment variable
   os::log::debug "$( oc replace -f $saveds )"
 }
 
-# bz1515715 -- check if mux is enabled.
-savemuxdc=""
-if oc get dc/logging-mux > /dev/null 2>&1 ; then
-  savemuxdc=$( mktemp )
-  oc export dc/logging-mux -o yaml > $savemuxdc
-fi
+artifact_log Starting fluentd-plugin-remote-syslog tests on $fluentdtype at "$( date )"
 
-function reset_mux_deployconfig() {
-  if [ "$savemuxdc" != "" ]; then
-    os::log::info Restoring original mux deployconfig environment variable
-    os::log::debug "$( oc replace -f $savemuxdc )"
-  fi
-}
+os::log::info Starting fluentd-plugin-remote-syslog tests on $fluentdtype at $( date )
 
-os::log::info Starting fluentd-plugin-remote-syslog tests at $( date )
+cleanup() {
+    local return_code="$?"
+    set +e
 
-my_remote_syslog_host=$( oc set env ds/logging-fluentd --list | grep REMOTE_SYSLOG_HOST | awk -F'=' '{print $2}' || : )
-if [ -n "${my_remote_syslog_host:-}" ] ; then
-  os::log::info Test 0, checking user configured REMOTE_SYSLOG_HOST is respected.
-  os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-  os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-  os::log::debug "$( oc set env ds/logging-fluentd USE_REMOTE_SYSLOG=true )"
-  os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-  os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-  fpod=$( get_running_pod fluentd )
-  os::cmd::try_until_success "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-  os::cmd::expect_success_and_text "oc exec $fpod grep 'remote_syslog' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" "remote_syslog ${my_remote_syslog_host}"
-fi
-
-os::log::info Test 1, expecting generate_syslog_config.rb to have created configuration file
-
-# make sure fluentd is running after previous test
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-fpod=$( get_running_pod fluentd )
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-
-os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 )"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
-fpod=$( get_running_pod fluentd )
-os::cmd::try_until_success "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-
-
-os::log::info Test 2, expecting generate_syslog_config.rb to not create a configuration file
-
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-
-os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST- )"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
-fpod=$( get_running_pod fluentd )
-os::cmd::try_until_failure "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-
-
-os::log::info Test 3, expecting generate_syslog_config.rb to generate multiple stores
-
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-
-os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_HOST2=127.0.0.1 )"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
-fpod=$( get_running_pod fluentd )
-os::cmd::try_until_text "oc exec $fpod grep '<store>' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf | wc -l" '^2$'
-
-
-os::log::info Test 4, making sure tag_key=message does not cause remote-syslog plugin crash
-
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-
-os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=message)"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
-fpod=$( get_running_pod fluentd )
-os::cmd::try_until_success "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success "oc exec $fpod grep 'tag_key message' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success_and_not_text "oc logs $fpod" "nil:NilClass"
-
-extra_rsyslog_artifacts=$ARTIFACT_DIR/rsyslog-artifacts.txt
-if [ -n "${DEBUG:-}" ] ; then
-  echo Test 4, making sure tag_key=message does not cause remote-syslog plugin crash > $extra_rsyslog_artifacts
-  echo "$( date --rfc-3339=ns )" "Enabled REMOTE_SYSLOG: USE_REMOTE_SYSLOG=true, REMOTE_SYSLOG_HOST=127.0.0.1, REMOTE_SYSLOG_HOST2=127.0.0.1, REMOTE_SYSLOG_TAG_KEY=message" >> $extra_rsyslog_artifacts
-
-  oc logs $fpod >> $extra_rsyslog_artifacts 2>&1
-
-  echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
-
-  oc exec $fpod -- cat /etc/fluent/configs.d/dynamic/output-remote-syslog.conf >> $extra_rsyslog_artifacts
-fi
-
-os::log::info Test 5, making sure tag_key=bogus does not cause remote-syslog plugin crash
-
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
-os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-
-os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=bogus)"
-os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
-os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
-fpod=$( get_running_pod fluentd )
-os::cmd::try_until_success "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success "oc exec $fpod grep 'tag_key bogus' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success_and_not_text "oc logs $fpod" "nil:NilClass"
-
-if [ -n "${DEBUG:-}" ] ; then
-  echo Test Test 5, making sure tag_key=bogus does not cause remote-syslog plugin crash >> $extra_rsyslog_artifacts
-  echo "$( date --rfc-3339=ns )" "Enabled REMOTE_SYSLOG: USE_REMOTE_SYSLOG=true, REMOTE_SYSLOG_HOST=127.0.0.1, REMOTE_SYSLOG_HOST2=127.0.0.1, REMOTE_SYSLOG_TAG_KEY=bogus" >> $extra_rsyslog_artifacts
-
-  oc logs $fpod >> $extra_rsyslog_artifacts 2>&1
-
-  echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
-
-  oc exec $fpod -- cat /etc/fluent/configs.d/dynamic/output-remote-syslog.conf >> $extra_rsyslog_artifacts
-fi
-
-reset_fluentd_daemonset
-
-if [ "$savemuxdc" != "" ]; then
-
-  os::log::info Test 6, verify openshift_logging_mux_remote_syslog_host is respected in the mux pod
-
-  if [ -n "${DEBUG:-}" ] ; then
-    echo Test 6, verify openshift_logging_mux_remote_syslog_host is respected in the mux pod >> $extra_rsyslog_artifacts
-  fi
-
-  # make sure mux is running.
-  os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
-
-  os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
-  os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $FLUENTD_WAIT_TIME
-
-  # bz1515715 -- is openshift_logging_mux_remote_syslog_host set?
-  my_remote_syslog_host=$( oc set env dc/logging-mux --list | grep REMOTE_SYSLOG_HOST | awk -F'=' '{print $2}' || : )
-  if [ -n "${my_remote_syslog_host:-}" ] ; then
-    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true )"
-    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
-    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
-    mpod=$( get_running_pod mux )
-    if [ -n "${DEBUG:-}" ] ; then
-      oc logs $mpod >> $extra_rsyslog_artifacts 2>&1
-      echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
-      oc exec $mpod -- cat /etc/fluent/configs.d/dynamic/output-remote-syslog.conf >> $extra_rsyslog_artifacts
+    if [ $return_code -ne 0 ]; then
+       artifact_log "oc get pods"
+       oc get pods 2>&1 | artifact_out || :
+       artifact_log "/var/log/messages files"
+       sudo ls -ltZ /var/log/messages* 2>&1 | artifact_out || :
+       artifact_log "Sample of /var/log/messages"
+       sudo tail -n 30 /var/log/messages 2>&1 | artifact_out || :
+       artifact_log "Sample of /var/log/messages DONE"
+       if [ "$fluentdtype" = "fluentd" ] ; then
+           mypod=$( get_running_pod fluentd )
+       else
+           mypod=$( get_running_pod fluentd )
+           artifact_log log from $mypod
+           oc logs $mypod 2>&1 | artifact_out || :
+           mypod=$( get_running_pod mux )
+       fi
+       artifact_log log from $mypod
+       oc logs $mypod 2>&1 | artifact_out || :
+       artifact_log get events
+       oc get events 2>&1 | artifact_out || :
+       artifact_log fluentd logs in journalctl output
+       sudo journalctl | grep fluentd | tail -n 30 2>&1 | artifact_out || :
+       artifact_log rsyslog logs in journalctl output
+       sudo journalctl | grep rsyslogd | tail -n 30 2>&1 | artifact_out || :
+       artifact_log something in audit.log
+       sudo grep rsyslog /var/log/audit/audit.log 2>&1 | artifact_out || :
     fi
-    os::cmd::try_until_success "oc exec $mpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-    os::cmd::expect_success_and_text "oc exec $mpod grep 'remote_syslog' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" "remote_syslog ${my_remote_syslog_host}"
-    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
-    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $FLUENTD_WAIT_TIME
-  fi
 
-  os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 )"
-  os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
-  os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
+    if [ "$fluentdtype" = "fluentd" ] ; then
+        reset_fluentd_daemonset
+    else
+        os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+        os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+        os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=false REMOTE_SYSLOG_HOST- REMOTE_SYSLOG_USE_RECORD- REMOTE_SYSLOG_PORT=514 )"
+        os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+        os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
 
-  mpod=$( get_running_pod mux )
-  os::cmd::try_until_success "oc exec $mpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-  os::cmd::expect_success_and_text "oc exec $mpod grep 'remote_syslog' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" "remote_syslog 127.0.0.1"
-  if [ -n "${DEBUG:-}" ] ; then
-    oc logs $mpod >> $extra_rsyslog_artifacts 2>&1
-    echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
-    oc exec $mpod -- cat /etc/fluent/configs.d/dynamic/output-remote-syslog.conf >> $extra_rsyslog_artifacts
-  fi
+        os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+        os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+        os::log::debug "$( oc set env ds/logging-fluentd MUX_CLIENT_MODE- )"
+        os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+    fi
 
-  reset_mux_deployconfig
+    # Resetting rsyslogd
+    #   Provides TCP syslog reception
+    #   $ModLoad imtcp
+    #   $InputTCPServerRun 514
+    if [ -f ${rsyslogconfbakup:-""} ]; then
+        sudo cp $rsyslogconfbakup /etc/rsyslog.conf
+    fi
+    if [ -f ${rsyslogconfbakup2:-""} ]; then
+        sudo mv $rsyslogconfbakup2 /etc/rsyslog.d
+    fi
+    os::cmd::expect_success "sudo service rsyslog restart"
+
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    my_remote_syslog_host=$( oc set env ds/logging-fluentd --list | grep REMOTE_SYSLOG_HOST | awk -F'=' '{print $2}' || : )
+else
+    my_remote_syslog_host=$( oc set env dc/logging-mux --list | grep REMOTE_SYSLOG_HOST | awk -F'=' '{print $2}' || : )
 fi
 
-os::test::junit::reconcile_output
+if [ -n "$my_remote_syslog_host" ]; then
+    title="Test 0, checking user configured REMOTE_SYSLOG_HOST is respected"
+    os::log::info $title
+
+    if [ "$fluentdtype" = "fluentd" ] ; then
+        os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+        os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+        os::log::debug "$( oc set env ds/logging-fluentd USE_REMOTE_SYSLOG=true )"
+        os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+        mypod=$( get_running_pod fluentd )
+    else
+        # make sure mux is running after previous test
+        os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+        os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+        os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+        os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true )"
+        os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+        os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+        mypod=$( get_running_pod mux )
+    fi
+    os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
+    os::cmd::expect_success_and_text "oc exec $mypod grep 'remote_syslog' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" "remote_syslog ${my_remote_syslog_host}"
+    artifact_log $title $mypod
+fi
+
+
+title="Test 1, expecting generate_syslog_config.rb to have created configuration file"
+os::log::info $title
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    # make sure fluentd is running after previous test
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    # choosing an unrealistic REMOTE_SYSLOG_HOST
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=111.222.111.222 )"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    # make sure mux is running after previous test
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    # choosing an unrealistic REMOTE_SYSLOG_HOST
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=111.222.111.222 )"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
+artifact_log $title $mypod
+
+
+title="Test 2, expecting generate_syslog_config.rb to not create a configuration file"
+os::log::info $title
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST- )"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST- )"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_failure "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
+artifact_log $title $mypod
+
+
+title="Test 3, expecting generate_syslog_config.rb to generate multiple stores"
+os::log::info $title
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_HOST2=127.0.0.1 )"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_HOST2=127.0.0.1 )"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_text "oc exec $mypod grep '<store>' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf | wc -l" '^2$' $MUX_WAIT_TIME
+artifact_log $title $mypod
+
+
+title="Test 4, making sure tag_key=message does not cause remote-syslog plugin crash"
+os::log::info $title
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=message REMOTE_SYSLOG_HOST2-)"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=message REMOTE_SYSLOG_HOST2-)"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
+os::cmd::expect_success "oc exec $mypod grep 'tag_key message' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
+os::cmd::expect_success_and_not_text "oc logs $mypod" "nil:NilClass"
+
+artifact_log $title $mypod
+
+
+title="Test 5, making sure tag_key=bogus does not cause remote-syslog plugin crash"
+os::log::info $title
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=bogus)"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=bogus)"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
+os::cmd::expect_success "oc exec $mypod grep 'tag_key bogus' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
+os::cmd::expect_success_and_not_text "oc logs $mypod" "nil:NilClass"
+artifact_log $title $mypod
+
+
+title="Test 6, use rsyslogd on the node"
+os::log::info $title
+
+artifact_log iptables ACCEPT ${ALTPORT}
+sudo iptables -A INPUT -m tcp -p tcp --dport ${ALTPORT} -j ACCEPT 2>&1 | artifact_out || :
+sudo iptables -L 2>&1 | artifact_out || :
+
+# Make sure rsyslogd is listening on port 514 up and running
+#   Provides TCP syslog reception
+#   $ModLoad imtcp
+#   $InputTCPServerRun 514 -> 601
+rsyslogconfbakup=$( mktemp )
+artifact_log ORIGINAL /etc/rsyslog.conf
+cat /etc/rsyslog.conf 2>&1 | artifact_out
+artifact_log ORIGINAL /etc/rsyslog.conf END
+cp /etc/rsyslog.conf $rsyslogconfbakup
+sudo sed -i -e 's/^#*\(\$ModLoad imtcp\)/\1/' -e "s/^#*\(\$InputTCPServerRun\) 514/\1 ${ALTPORT}/" \
+         -e 's/\(\$ModLoad imuxsock\)/#\1/' -e 's/\(\$ModLoad imjournal\)/#\1/' -e 's/\(\$OmitLocalLogging\)/#\1/' \
+         -e 's/\(\$IMJournalStateFile imjournal.state\)/#\1/' -e 's/\(\$ActionFileEnableSync\)/#\1/' \
+         -e 's/\(#### RULES .*\)/\1\n\$template precise,"%syslogpriority%,%syslogfacility%,%timegenerated%,%HOSTNAME%,%syslogtag%,%msg%\\n"/' \
+         -e 's/^*.info;mail.none;authpriv.none;cron.none *\(\/var\/log\/messages\)/*.* \1;precise/' \
+         /etc/rsyslog.conf
+sudo ls -l /etc/rsyslog.d | artifact_out || :
+rsyslogconfbakup2=/tmp/listen.conf
+if [ -f /etc/rsyslog.d/listen.conf ]; then
+    sudo mv /etc/rsyslog.d/listen.conf $rsyslogconfbakup2
+fi
+artifact_log MODIFIED /etc/rsyslog.conf
+cat /etc/rsyslog.conf 2>&1 | artifact_out
+artifact_log MODIFIED /etc/rsyslog.conf END
+
+artifact_log Before restarting rsyslog
+sudo service rsyslog status 2>&1 | artifact_out || :
+os::cmd::expect_success "sudo service rsyslog stop"
+sudo mv /var/log/messages /var/log/messages."$( date +%Y%m%d-%H%M%S )" || :
+sudo touch /var/log/messages || :
+sudo chmod 600 /var/log/messages || :
+sudo semanage fcontext -a -t var_log_t -s system_u /var/log/messages || :
+sudo restorecon -vF /var/log/messages || :
+os::cmd::expect_success "sudo service rsyslog start"
+artifact_log After restarted rsyslog
+sudo service rsyslog status 2>&1 | artifact_out || :
+artifact_log journald.conf
+sudo cat /etc/systemd/journald.conf 2>&1 | artifact_out || :
+
+myhost=$( hostname )
+
+if [ "$fluentdtype" = "fluentd" ] ; then
+    # make sure fluentd is running after previous test
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset/logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=$myhost REMOTE_SYSLOG_PORT=${ALTPORT} REMOTE_SYSLOG_USE_RECORD=true REMOTE_SYSLOG_SEVERITY=info REMOTE_SYSLOG_TAG_KEY='ident,systemd.u.SYSLOG_IDENTIFIER' )"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    mypod=$( get_running_pod fluentd )
+else
+    # make sure fluentd is running after previous test
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset/logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    os::log::debug "$( oc set env daemonset/logging-fluentd FORWARD_INPUT_LOG_LEVEL=info )"
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true --overwrite=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    # make sure mux is running after previous test
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
+    os::log::debug "$( oc scale --replicas=0 dc logging-mux )"
+    os::cmd::try_until_text "oc get dc logging-mux -o jsonpath='{ .status.replicas }'" "0" $MUX_WAIT_TIME
+    os::log::debug "$( oc set env dc/logging-mux FORWARD_INPUT_LOG_LEVEL=info USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=$myhost REMOTE_SYSLOG_PORT=${ALTPORT} REMOTE_SYSLOG_USE_RECORD=true REMOTE_SYSLOG_SEVERITY=info REMOTE_SYSLOG_TAG_KEY='ident,systemd.u.SYSLOG_IDENTIFIER' )"
+    os::log::debug "$( oc scale --replicas=1 dc logging-mux )"
+    os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
+
+    mypod=$( get_running_pod mux )
+fi
+os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
+artifact_log $title $mypod
+oc logs $mypod 2>&1 | artifact_out || :
+oc exec $mypod -- head -n 60 /etc/fluent/fluent.conf /etc/fluent/configs.d/openshift/output-operations.conf /etc/fluent/configs.d/openshift/output-applications.conf /etc/fluent/configs.d/dynamic/output-remote-syslog.conf | artifact_out || :
+artifact_log ping $myhost from $mypod
+oc exec $mypod -- ping $myhost -c 3 | artifact_out || :
+
+# wait for the precise formatted logs are found in /var/log/messages
+# os::cmd::try_until_text "sudo egrep \"^[0-6],[0-9]*,\" /var/log/messages" "[0-6],[0-9]*,.*" $MUX_WAIT_TIME
+# sudo egrep \"^[0-6],[0-9]*,\" /var/log/messages | tail -n 5 | artifact_out || :
+
+artifact_log docker info
+docker info | artifact_out || :
+
+mymessage="rsyslogTestMessage-"$( date +%Y%m%d-%H%M%S )
+logger -i -p local1.err -t rsyslogTestTag $mymessage
+es_pod=$( get_es_pod es )
+es_ops_pod=$( get_es_pod es-ops )
+es_ops_pod=${es_ops_pod:-$es_pod}
+qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"rsyslogTestTag"}}}'
+if os::cmd::try_until_text "curl_es ${es_ops_pod} /.operations.*/_count -X POST -d '$qs' | get_count_from_json" 1 $MUX_WAIT_TIME; then
+    artifact_log good - found $mymessage
+else
+    artifact_log failed - not found $mymessage
+fi
+os::cmd::try_until_text "sudo egrep \"${mymessage}$\" /var/log/messages" ".*${mymessage}.*" $MUX_WAIT_TIME
+artifact_log Log test message by logger: $mymessage
+sudo egrep "${mymessage}$" /var/log/messages 2>&1 | artifact_out || :
+
+mymessage="testKibanaMessage-"$( date +%Y%m%d-%H%M%S )
+add_test_message $mymessage
+es_pod=$( get_es_pod es )
+qs='{"query":{"match_phrase":{"message":"'"${mymessage}"'"}}}'
+if os::cmd::try_until_text "curl_es ${es_pod} /project.logging.*/_count -X POST -d '$qs' | get_count_from_json" 1 $MUX_WAIT_TIME; then
+    artifact_log good - found $mymessage
+else
+    artifact_log failed - not found $mymessage
+fi
+os::cmd::try_until_text "sudo egrep \"/${mymessage}\" /var/log/messages" ".*${mymessage}.*" $MUX_WAIT_TIME
+artifact_log Log test message by kibana: $mymessage
+sudo egrep "/${mymessage}" /var/log/messages 2>&1 | artifact_out || :
+


### PR DESCRIPTION
Changes in the CI test scrip remote-syslog.sh
-  use artifact_log, artifact_out and add_test_message.
- testing fluentd -> mux -> rsyslogd, as well.
- added cleanup function
- use_record for hostname, too.
  use_record true, by default.
  Including "container_name", "namespace_name", and "pod_name" in the
  output content, when use_record is true.
- adding test case to cover use_record (Test 6)
  use rsyslogd on the node
  modified /etc/rsyslog.conf so that rsyslogd only takes the input
  from fluentd remote-syslog plugin and outputs more log fields such
  as priority, facility, tag, etc. in the Test 6.

Migrated from https://github.com/openshift/origin-aggregated-logging/pull/909