### PR TITLE
Fix `.kibana` regex

### DIFF
--- a/curator/src/curator_cmd.py
+++ b/curator/src/curator_cmd.py
@@ -95,7 +95,7 @@ class CuratorCmd():
                     + ' --older-than ' + str(count) \
                     + ' --time-unit ' + unit \
                     + ' --exclude ' + shellquote('^' + re.escape('.searchguard.') + '.*$') \
-                    + ' --exclude ' + shellquote('^' + re.escape('.kibana.') + '.*$')
+                    + ' --exclude ' + shellquote('^' + re.escape('.kibana') + '.*$')
         return default_command
 
     def connection_info(self):


### PR DESCRIPTION
I was trying to fix `' --exclude .searchguard* --exclude .kibana*'` and did not realize that the kibana index is named just `.kibana` and the regex `.kibana*` worked only by accident. 