### PR TITLE
Bug 1536651 - logging-mux not working in 3.7.z when logging installed…

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -63,8 +63,12 @@ else
     export USE_JOURNAL=true
 fi
 
-if [ ! -d /etc/fluent/muxkeys ]; then
+if [ ! -d /etc/fluent/muxkeys -o "${USE_MUX:-}" = "true" ] ; then
+    # mux is not configured or starting fluentd as mux
     unset MUX_CLIENT_MODE
+else
+    # set MUX_CLIENT_MODE to maximal by default for the mux client
+    MUX_CLIENT_MODE=${MUX_CLIENT_MODE:-maximal}
 fi
 
 IPADDR4=`/usr/sbin/ip -4 addr show dev eth0 | grep inet | sed -e "s/[ \t]*inet \([0-9.]*\).*/\1/"`


### PR DESCRIPTION
… with openshift_logging_use_mux=true

set MUX_CLIENT_MODE to maximal by default for the mux client.
I.e., if /etc/fluent/muxkeys dir exists (configuring mux system) and
      USE_MUX is not set or false (it is not a mux fluentd) and
      MUX_CLIENT_MODE is null/empty, maximal is set to MUX_CLIENT_MODE.

This pr requires https://github.com/openshift/openshift-ansible/pull/7192.