### PR TITLE
Add rawtcp plugin to fluentd

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -58,7 +58,7 @@ RUN yum-config-manager --enable rhel-7-server-ose-3.9-rpms && \
 
 ADD configs.d/ /etc/fluent/configs.d/
 ADD filter_k8s_meta_for_mux_client.rb /etc/fluent/plugin/
-ADD out_syslog_buffered.rb out_syslog.rb /etc/fluent/plugin/
+ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb /etc/fluent/plugin/
 ADD parser_viaq_docker_audit.rb viaq_docker_audit.rb /etc/fluent/plugin/
 ADD run.sh generate_throttle_configs.rb generate_syslog_config.rb ${HOME}/
 

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -50,7 +50,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
 
 ADD configs.d/ /etc/fluent/configs.d/
 ADD filter_k8s_meta_for_mux_client.rb /etc/fluent/plugin/
-ADD out_syslog_buffered.rb out_syslog.rb /etc/fluent/plugin/
+ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb /etc/fluent/plugin/
 ADD parser_viaq_docker_audit.rb viaq_docker_audit.rb /etc/fluent/plugin/
 ADD run.sh generate_throttle_configs.rb generate_syslog_config.rb ${HOME}/
 

--- a/fluentd/out_rawtcp.rb
+++ b/fluentd/out_rawtcp.rb
@@ -1,0 +1,129 @@
+# coding: utf-8
+# 
+# License: Apache2
+# https://github.com/uken/fluent-plugin-out_rawtcp
+
+module Fluent
+  class RawTcpOutput < BufferedOutput
+    Plugin.register_output('rawtcp', self)
+
+    def initialize
+      super
+      require 'socket'
+      require 'timeout'
+      require 'fileutils'
+      @nodes = []  #=> [Node]
+    end
+
+    config_param :send_timeout, :time, :default => 60
+    config_param :connect_timeout, :time, :default => 5
+    config_param :output_type, :string, :default => "msgpack"
+    config_param :output_append_newline, :bool, :default => false
+    attr_reader :nodes
+
+    def configure(conf)
+      super
+
+      conf.elements.each do |e|
+        next if e.name != "server"
+
+        host = e['host']
+        port = e['port']
+        port = port ? port.to_i : DEFAULT_LISTEN_PORT
+
+        name = e['name']
+        unless name
+          name = "#{host}:#{port}"
+        end
+
+        @nodes << RawNode.new(name, host, port)
+        log.info "adding forwarding server '#{name}'", :host=>host, :port=>port
+      end
+    end
+
+    def start
+      super
+    end
+
+    def shutdown
+      super
+    end
+
+    def format(tag, time, record)
+      [tag, time, record].to_msgpack
+    end
+
+    def write(chunk)
+      return if chunk.empty?
+
+      error = nil
+
+      @nodes.each do |node|
+        begin
+          send_data(node, chunk)
+          return
+        rescue
+          error = $!
+        end
+      end
+
+      raise error if error
+      raise "No nodes available"
+    end
+
+    private
+    def send_data(node, chunk)
+      sock = connect(node)
+      begin
+        opt = [1, @send_timeout.to_i].pack('I!I!')  # { int l_onoff; int l_linger; }
+        sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, opt)
+
+        opt = [@send_timeout.to_i, 0].pack('L!L!')  # struct timeval
+        sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDTIMEO, opt)
+
+        chunk.msgpack_each do |tag, time, record|
+          next unless record.is_a? Hash
+          sock.write(prepare_data_to_send(tag, time, record))
+        end
+      ensure
+        sock.close
+      end
+    end
+
+    def prepare_data_to_send(tag, time, record)
+      if @output_type == "json"
+        new_line_suf = ""
+        if @output_append_newline
+          new_line_suf = "\n"
+        end
+        return "#{record.to_json}#{new_line_suf}"
+      else
+        return [tag, time, record].to_msgpack
+      end
+    end
+
+    def connect(node)
+      Timeout.timeout(@connect_timeout) do
+        return TCPSocket.new(node.resolved_host, node.port)
+      end
+    end
+
+    class RawNode
+      attr_reader :name, :host, :port
+
+      def initialize(name, host, port)
+        @name = name
+        @host = host
+        @port = port
+        resolved_host
+      end
+
+      def resolved_host
+        @sockaddr = Socket.pack_sockaddr_in(@port, @host)
+        _, rhost = Socket.unpack_sockaddr_in(@sockaddr)
+        rhost
+      end
+    end
+  end
+end
+

--- a/hack/templates/logstash.yml
+++ b/hack/templates/logstash.yml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: logstash
+  namespace: openshift-logging
+  labels:
+    component: logstash
+spec:
+  replicas: 1
+  template:
+      metadata:
+        labels:
+          component: logstash
+      spec:
+        containers:
+        - name: fluentd-logstash
+          image: docker.io/logstash:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 9400
+          command:
+          - "/usr/share/logstash/bin/logstash"
+          - "-e"
+          - "input { tcp { port => 9400 codec => fluent } } output { stdout { codec => rubydebug } }"
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          volumeMounts:
+          - mountPath: /usr/share/logstash/data
+            name: data
+          - mountPath: /var/lib/logstash
+            name: lib
+        nodeSelector:
+          logging-infra-fluentd: "true"
+        restartPolicy: Always
+        volumes:
+        - name: data
+          emptyDir: {}
+        - name: lib
+          emptyDir: {}
+--- 
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    logging-infra: support
+  name: logstash
+  namespace: openshift-logging
+spec:
+  ports:
+    - name: logstash-forward
+      port: 9400
+      protocol: TCP
+      targetPort: 9400
+  selector:
+    component: logstash
+

--- a/hack/testing/test-out_rawtcp.sh
+++ b/hack/testing/test-out_rawtcp.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/out_rawtcp.sh

--- a/test/out_rawtcp.sh
+++ b/test/out_rawtcp.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# This is a test suite for the fluentd raw_tcp feature
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+os::util::environment::use_sudo
+
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
+
+os::test::junit::declare_suite_start "test/raw-tcp"
+
+update_current_fluentd() {
+    # undeploy fluentd
+    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+
+    # update configmap logging-fluentd
+    # edit so we don't send to ES
+    oc get configmap/logging-fluentd -o yaml | sed '/## matches/ a\
+    <match **>\
+      @type copy\
+      @include configs.d/user/raw-tcp.conf\
+    </match>' | oc replace -f -
+      oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "add", "path": "/data/raw-tcp.conf", "#": "generated config file raw-tcp.conf" }]' 2>&1
+      oc patch configmap/logging-fluentd --type=json --patch '[{ "op": "replace", "path": "/data/raw-tcp.conf", "value": "\
+  <store>\n\
+   @type rawtcp\n\
+   flush_interval 1\n\
+    <server>\n\
+      name logstash\n\
+      host logstash.openshift-logging.svc.cluster.local\n\
+      port 9400\n\
+    </server>\n\
+  </store>\n"}]'
+
+    # redeploy fluentd
+    os::cmd::expect_success flush_fluentd_pos_files
+    os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+    fpod=$( get_running_pod logstash )
+    if [ -n "${fpod:-}" ] ; then
+      os::cmd::try_until_text "oc logs $fpod 2>&1" ".*kubernetes.*" $FLUENTD_WAIT_TIME
+    fi
+    fpod=$( get_running_pod fluentd ) || :
+    artifact_log update_current_fluentd "(oc logs $fpod)"
+}
+
+create_forwarding_logstash() {
+  oc apply -f $OS_O_A_L_DIR/hack/templates/logstash.yml
+  # wait for logstash to start
+  os::cmd::try_until_text "oc get pods -l component=logstash" "^logstash-.* Running " 360000
+  POD=$( oc get pods -l component=logstash -o name )
+  artifact_log create_forwarding_logstash "(oc logs $POD)"
+  oc logs $POD 2>&1 | artifact_out || :
+}
+
+# save current fluentd daemonset
+saveds=$( mktemp )
+oc get daemonset logging-fluentd -o yaml > $saveds
+
+# save current fluentd configmap
+savecm=$( mktemp )
+oc get configmap logging-fluentd -o yaml > $savecm
+
+cleanup() {
+  local return_code="$?"
+  set +e
+  if [ $return_code = 0 ] ; then
+    mycmd=os::log::info
+  else
+    mycmd=os::log::error
+  fi
+
+  # dump the pod before we restart it
+  if [ -n "${fpod:-}" ] ; then
+    artifact_log cleanup "(oc logs $fpod)"
+    oc logs $fpod 2>&1 | artifact_out || :
+  fi
+  oc get pods 2>&1 | artifact_out
+ 
+  POD=$( oc get pods -l component=fluentd -o name ) || :
+  artifact_log cleanup "(oc logs $POD)"
+  oc logs $POD 2>&1 | artifact_out || :
+
+  os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+  os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+  if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
+    os::log::debug "$( oc replace --force -f $savecm )"
+  fi
+  if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
+    os::log::debug "$( oc replace --force -f $saveds )"
+  fi
+
+  $mycmd raw-tcp test finished at $( date )
+
+  # Clean up only if it's still around
+  os::log::debug "$( oc delete service/logstash 2>&1 || : )"
+  os::log::debug "$( oc delete deploymentconfig/logstash 2>&1 || : )"
+
+  os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+  os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+  fpod=$( get_running_pod fluentd )
+  os::cmd::expect_success wait_for_fluentd_to_catch_up
+  os::cmd::expect_success flush_fluentd_pos_files
+}
+trap "cleanup" EXIT
+
+os::log::info Starting raw-tcp test at $( date )
+
+# make sure fluentd is working normally
+os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+fpod=$( get_running_pod fluentd )
+os::cmd::expect_success wait_for_fluentd_to_catch_up
+
+create_forwarding_logstash
+update_current_fluentd


### PR DESCRIPTION
Hello, 

In order to send logs to external logstash service from ```user/output-extra-*.conf```, I added https://github.com/uken/fluent-plugin-out_rawtcp fluentd plugin. 
This plugin implements a simple TCP forward, without heartbeats or any other out-of-band checks. 

Regards,