### PR TITLE
Generate uuid on ingestion to reduce duplicates

### DIFF
--- a/fluentd/configs.d/openshift/filter-post-genid.conf
+++ b/fluentd/configs.d/openshift/filter-post-genid.conf
@@ -1,0 +1,6 @@
+# generate ids at source mitigate creating duplicate records
+# requires fluent-plugin-elasticsearch
+<filter **>
+  @type elasticsearch_genid
+  hash_id_key viaq_msg_id
+</filter>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -4,6 +4,7 @@
       port "#{ENV['ES_PORT']}"
       scheme https
       target_index_key viaq_index_name
+      id_key viaq_msg_id
       remove_keys viaq_index_name
       user fluentd
       password changeme

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -4,6 +4,7 @@
       port "#{ENV['OPS_PORT']}"
       scheme https
       target_index_key viaq_index_name
+      id_key viaq_msg_id
       remove_keys viaq_index_name
       user fluentd
       password changeme

--- a/fluentd/configs.d/user/fluent.conf
+++ b/fluentd/configs.d/user/fluent.conf
@@ -33,4 +33,3 @@
   # no post - applications.conf matches everything left
 ##
 </label>
-

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -55,6 +55,10 @@ update_current_fluentd() {
       else
     # edit so we don't send to ES
     oc get configmap/logging-fluentd -o yaml | sed '/## matches/ a\
+      <filter **>\
+        @type record_transformer\
+        remove_keys _id, viaq_msg_id\
+      </filter>\
       <match **>\
         @type copy\
         @include configs.d/user/secure-forward1.conf\


### PR DESCRIPTION
This PR generates record uuids at the source to resolve:

https://bugzilla.redhat.com/show_bug.cgi?id=1548104

where when ES is underload, it fails bulk indexing and retries can produce duplicate entries