### PR TITLE
Bug 1544815 - logging-fluentd SEGV_ACCERR crash on init when libjemalloc is used in scalability CI lab cluster

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -323,6 +323,7 @@ fi
 
 if type -p jemalloc-config > /dev/null 2>&1 && [ "${USE_JEMALLOC:-true}" = true ] ; then
     export LD_PRELOAD=$( jemalloc-config --libdir )/libjemalloc.so.$( jemalloc-config --revision )
+    export LD_BIND_NOW=1 # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1544815
 fi
 
 # Include DEBUG log level messages when collecting from journald


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1544815
Use

    export LD_BIND_NOW=1

to workaround the problem when using jemalloc.