### PR TITLE
Bug 1548720 - fluent-plugin-secure-forward couldn't read the Environment ${HOSTNAME}

### DIFF
--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -1,7 +1,7 @@
 <match **>
   @type secure_forward
   log_level "#{ENV['FORWARD_INPUT_LOG_LEVEL'] || ENV['LOG_LEVEL'] || 'warn'}"
-  self_hostname ${HOSTNAME}
+  self_hostname ${hostname}
   shared_key "#{File.open('/etc/fluent/muxkeys/shared_key') do |f| f.readline end.rstrip}"
   secure yes
   ca_cert_path /etc/fluent/muxkeys/ca

--- a/fluentd/configs.d/user/secure-forward.conf
+++ b/fluentd/configs.d/user/secure-forward.conf
@@ -1,8 +1,8 @@
 # <store>
 #   @type secure_forward
 
-#   self_hostname ${HOSTNAME}
-#   shared_key ${SECRET_STRING}
+#   self_hostname ${hostname} # ${hostname} is a placeholder.
+#   shared_key <shared_key_between_forwarder_and_forwardee>
 
 #   secure yes
 #   enable_strict_verification yes


### PR DESCRIPTION
Replacing the self_hostname value ${HOSTNAME} with the placeholder ${hostname}.