### PR TITLE
Bug 1550842 - Embed json logs when using cri-o

### DIFF
--- a/fluentd/generate_throttle_configs.rb
+++ b/fluentd/generate_throttle_configs.rb
@@ -163,7 +163,7 @@ def create_default_docker(excluded)
   pos_file "#{ENV[POS_FILE] || '/var/log/es-containers.log.pos'}"
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
-  format #{ENV['USE_CRIO'] == 'true' ? '/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<message>.*)$/' : 'json'}
+  format #{ENV['USE_CRIO'] == 'true' ? '/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/' : 'json'}
   keep_time_key true
   read_from_head "#{ENV[READ_FROM_HEAD] || 'true'}"
   exclude_path #{excluded}


### PR DESCRIPTION
The `kubernetes_metadata_filter` plugin expects `log` as a key for logs obtained via `in_tail` plugin from `/var/log/containers` and `MESSAGE` for journal logs.
https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/blob/master/lib/fluent/plugin/filter_kubernetes_metadata.rb#L240-L243

The ViaQ plugin then appears to move the `log` field into `message` for the `in_tail` logs
https://github.com/ViaQ/fluent-plugin-viaq_data_model/blob/9693cb0dfede21fa5ebec187988112de2c57c65a/lib/fluent/plugin/filter_viaq_data_model.rb#L310

However, the observed behaviour is following:

**1. When the app logs `message`**
```
$ oc logs --namespace=test6 test
{"message":1,"level":"debug","test":"works_well"}

$ cat /var/log/containers/test_test6_test-9f030e17ffa740ad814dd88ef9c2f46b25490b90a21c008cc1ac4851c754daed.log 
2018-03-06T03:41:07.983782713-05:00 stdout F {"message":1,"level":"debug","test":"works_well"}

$ curl https://$ES:9200/project.test8.bf6dbfa5-211b-11e8-b857-5254001ecf30.2018.03.06/_search?pretty
...
"hits" : [ {
  "_index" : "project.test6.686c1ecc-2118-11e8-b857-5254001ecf30.2018.03.06",
  "_type" : "com.redhat.viaq.common",
  "_id" : "AWH6eN1_S_iXdzxYRsq4",
  "_score" : 1.0,
  "_source" : {
    "message" : 1,
    "level" : "debug",
    "test" : "works_well",
    "logtag" : "F",
...
    "@timestamp" : "2018-03-06T08:41:07.983783+00:00"
  }
} ]
```

**2. When the app logs `log`**
```
$ oc logs --namespace=test7 test
{"log":1,"level":"debug","test":"works_wrong"}

$  cat /var/log/containers/test_test7_test-4b361938535d7efbb53fde44aea4501b6a3443dc8bb5e42c7e9dac5545f0a069.log 
2018-03-06T04:43:11.380936826-05:00 stdout F {"log":1,"level":"debug","test":"works_wrong"}

$ curl https://$ES:9200/project.test7.b1e8775b-2122-11e8-b857-5254001ecf30.2018.03.06/_search?pretty
...
"hits" : [ {
  "_index" : "project.test7.b1e8775b-2122-11e8-b857-5254001ecf30.2018.03.06",
  "_type" : "com.redhat.viaq.common",
  "_id" : "N2JhYmQ0YzItODhmZi00MzYzLWJlN2MtMTZiMWY2NzMyNzQ0",
  "_score" : 1.0,
  "_source" : { 
    "level" : "debug",
    "test" : "works_wrong",
    "logtag" : "F",
...
    "message" : "{\"log\":1,\"level\":\"debug\",\"test\":\"works_wrong\"}",
...
  }
} ]
```

**fluentd config**
```
$ oc exec --namespace=logging -ti logging-fluentd-9kdsh cat /etc/fluent/configs.d/dynamic/input-docker-default-docker.conf

<source>
  @type tail
  @label @INGRESS
  path "/var/log/containers/*.log"
  pos_file "/var/log/es-containers.log.pos"
  time_format %Y-%m-%dT%H:%M:%S.%N%Z
  tag kubernetes.*
  format /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
  keep_time_key true
  read_from_head "true"
  exclude_path []
</source>
```
So changing the regexp parsing cri-o formatted logs to output the message field from `message` to `log` works, but it seems rather counterintuitive that it will work only if the application formats the log message with `message` field. I will inspect ViaQ and kubernetes-metadata filter plugins to see if it is possible to fix easily