### PR TITLE
remove CONTAINER_TAG field

### DIFF
--- a/test/viaq-data-model.sh
+++ b/test/viaq-data-model.sh
@@ -97,6 +97,7 @@ cat > $cfg <<EOF
     undefined4 undefined4
     undefined5 undefined5
   </record>
+  remove_keys CONTAINER_TAG
 </filter>
 EOF
 


### PR DESCRIPTION
tell the viaq test to ignore the CONTAINER_TAG field