### PR TITLE
ES5 disallows empty field names

### DIFF
--- a/hack/testing/test-viaq-data-model.py
+++ b/hack/testing/test-viaq-data-model.py
@@ -95,7 +95,7 @@ test2match = {
               "undefined4": "undefined4",
               "undefined5": "undefined5",
               "empty1": "",
-              "undefined3": {"": ""}
+              "undefined3": {"emptyvalue": ""}
     }
 }
 

--- a/test/viaq-data-model.sh
+++ b/test/viaq-data-model.sh
@@ -97,7 +97,7 @@ cat > $cfg <<EOF
     undefined12 \${true}
     empty1 ""
     undefined2 {"undefined2":"undefined2","":"","undefined22":2222,"undefined23":false}
-    undefined3 {"":""}
+    undefined3 {"emptyvalue":""}
     undefined4 undefined4
     undefined5 undefined5
   </record>


### PR DESCRIPTION
If you attempt to submit an doc with an empty field name, you'll get
an error like this:
```
Object field starting or ending with a [.] makes object resolution ambiguous: []
```
which is very unhelpful.
See https://discuss.elastic.co/t/object-field-starting-or-ending-with-a-makes-object-resolution-ambiguous/123351