### PR TITLE
rsyslog testing - test k8s, es tls, viaq formatting

### DIFF
--- a/hack/testing/rsyslog/elasticsearch.conf.j2
+++ b/hack/testing/rsyslog/elasticsearch.conf.j2
@@ -1,0 +1,48 @@
+template(name="viaq_template" type="list") {
+    property(name="$!all-json-plain")
+}
+
+template(name="index_pattern" type="list") {
+    property(name="$.viaq_index_prefix")
+    property(name="$!@timestamp" dateFormat="rfc3339" position.from="1" position.to="4")
+    constant(value=".")
+    property(name="$!@timestamp" dateFormat="rfc3339" position.from="6" position.to="7")
+    constant(value=".")
+    property(name="$!@timestamp" dateFormat="rfc3339" position.from="9" position.to="10")
+}
+
+{%if openshift_logging_use_ops | default(False) %}
+if $.viaq_index_prefix startswith "project." then {
+{% endif %}
+action(
+    type="omelasticsearch"
+    server="{{ elasticsearch_server_host | default('logging-es') }}"
+    serverport="{{ elasticsearch_server_port | default(9200) }}"
+    template="viaq_template"
+    searchIndex="index_pattern"
+    dynSearchIndex="on"
+    searchType="com.redhat.viaq.common"
+    bulkmode="on"
+    usehttps="on"
+    tls.cacert="/etc/rsyslog.d/viaq/es-ca.crt"
+    tls.mycert="/etc/rsyslog.d/viaq/es-cert.pem"
+    tls.myprivkey="/etc/rsyslog.d/viaq/es-key.pem"
+)
+{%if openshift_logging_use_ops | default(False) %}
+} else {
+action(
+    type="omelasticsearch"
+    server="{{ elasticsearch_ops_server_host | default('logging-es-ops') }}"
+    serverport="{{ elasticsearch_ops_server_port | default(9200) }}"
+    template="viaq_template"
+    searchIndex="index_pattern"
+    dynSearchIndex="on"
+    searchType="com.redhat.viaq.common"
+    bulkmode="on"
+    usehttps="on"
+    tls.cacert="/etc/rsyslog.d/viaq/es-ca.crt"
+    tls.mycert="/etc/rsyslog.d/viaq/es-cert.pem"
+    tls.myprivkey="/etc/rsyslog.d/viaq/es-key.pem"
+)
+}
+{% endif %}

--- a/hack/testing/rsyslog/k8s_container_name.rulebase
+++ b/hack/testing/rsyslog/k8s_container_name.rulebase
@@ -1,0 +1,2 @@
+rule=:%k8s_prefix:char-to:_%_%container_name:char-to:.%.%container_hash:char-to:_%_%pod_name:char-to:_%_%namespace_name:char-to:_%_%not_used_1:char-to:_%_%not_used_2:rest%
+rule=:%k8s_prefix:char-to:_%_%container_name:char-to:_%_%pod_name:char-to:_%_%namespace_name:char-to:_%_%not_used_1:char-to:_%_%not_used_2:rest%

--- a/hack/testing/rsyslog/k8s_filename.rulebase
+++ b/hack/testing/rsyslog/k8s_filename.rulebase
@@ -1,0 +1,2 @@
+rule=:/var/log/containers/%pod_name:char-to:.%.%container_hash:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log
+rule=:/var/log/containers/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log

--- a/hack/testing/rsyslog/mmk8s.conf.j2
+++ b/hack/testing/rsyslog/mmk8s.conf.j2
@@ -1,0 +1,26 @@
+module(load="mmkubernetes" kubernetesurl="{{ openshift_master_api_url | default('https://localhost:8443') }}"
+       filenamerulebase="/etc/rsyslog.d/viaq/k8s_filename.rulebase"
+       containerrulebase="/etc/rsyslog.d/viaq/k8s_container_name.rulebase"
+       tls.cacert="/etc/rsyslog.d/viaq/mmk8s.ca.crt"
+       tokenfile="/etc/rsyslog.d/viaq/mmk8s.token" annotation_match=["."])
+
+input(type="imfile" file="/var/log/containers/*.log" tag="kubernetes" addmetadata="on")
+
+if ((strlen($!CONTAINER_NAME) > 0) and (strlen($!CONTAINER_ID_FULL) > 0)) or
+    ($!metadata!filename startswith "/var/log/containers/") then {
+    if $!metadata!filename startswith "/var/log/containers/" then {
+        action(type="mmjsonparse" cookie="") # parse entire message as json
+    }
+    action(type="mmkubernetes")
+    if strlen($!MESSAGE) > 0 then {
+        action(type="mmnormalize" ruleBase="/etc/rsyslog.d/viaq/parse_json.rulebase" variable="$!MESSAGE")
+    } else {
+        action(type="mmnormalize" ruleBase="/etc/rsyslog.d/viaq/parse_json.rulebase" variable="$!log")
+    }
+    # there is no way to move these fields to be top level fields in rscript in 8.24
+    # do it in mmk8s for now - revisit when upgrade to 8.33
+#    foreach ($.ii in $!payload) do {
+#        set $! = $.ii;
+#    }
+#    unset $!payload;
+}

--- a/hack/testing/rsyslog/normalize_level.json
+++ b/hack/testing/rsyslog/normalize_level.json
@@ -1,0 +1,20 @@
+{ "version" : 1,
+  "nomatch" : "UNKNOWN",
+  "type" : "string",
+  "table" : [
+    {"index": "emerg", "value": "emerg"},
+    {"index": "panic", "value": "emerg"},
+    {"index": "alert", "value": "alert"},
+    {"index": "crit", "value": "crit"},
+    {"index": "critical", "value": "crit"},
+    {"index": "err", "value": "err"},
+    {"index": "error", "value": "err"},
+    {"index": "warning", "value": "warning"},
+    {"index": "warn", "value": "warning"},
+    {"index": "notice", "value": "notice"},
+    {"index": "info", "value": "info"},
+    {"index": "debug", "value": "debug"},
+    {"index": "trace", "value": "trace"},
+    {"index": "unknown", "value": "unknown"}
+  ]
+}

--- a/hack/testing/rsyslog/parse_json.rulebase
+++ b/hack/testing/rsyslog/parse_json.rulebase
@@ -1,0 +1,1 @@
+rule=:%payload:json%

--- a/hack/testing/rsyslog/playbook.yaml
+++ b/hack/testing/rsyslog/playbook.yaml
@@ -1,0 +1,219 @@
+---
+- name: install/configure prerequisites
+  hosts: all
+  gather_facts: true
+  tasks:
+  - name: get patched rsyslog repo
+    get_url:
+      url: https://copr.fedorainfracloud.org/coprs/rmeggins/rsyslog/repo/epel-7/rmeggins-rsyslog-epel-7.repo
+      dest: /etc/yum.repos.d/rmeggins-rsyslog-epel-7.repo
+      mode: 0444
+    when: use_mmk8s | default(True)
+
+  - name: install prereqs
+    yum: state=latest name={{ item }}
+    with_items:
+    - rsyslog
+    - rsyslog-mmnormalize
+    - rsyslog-mmjsonparse
+    - nmap-ncat
+    - systemd-python
+    - rsyslog-elasticsearch
+    - policycoreutils
+    - checkpolicy
+    - policycoreutils-python
+
+  - name: pkgs
+    yum: state=latest name={{ item }}
+    with_items:
+    - rsyslog-mmkubernetes
+    when: use_mmk8s | default(True)
+
+  - name: create rsyslog viaq subdir
+    file: path=/etc/rsyslog.d/viaq state=directory mode=0700
+
+  - name: get fluentd secret for token and k8s CA
+    shell: |
+      for name in $( oc get -n {{ openshift_logging_namespace }} sa aggregated-logging-fluentd -o jsonpath='{.secrets[*].name}' ) ; do
+        case $name in
+        *-fluentd-token-*) echo $name ; break ;;
+        esac
+      done
+    register: fluentdsecret
+    when: use_mmk8s | default(True)
+
+  - name: get fluentd token
+    command: >
+      oc extract -n {{ openshift_logging_namespace }} secret/{{ fluentdsecret.stdout }} --keys=token --to=-
+    register: fluentdtoken
+    when: use_mmk8s | default(True)
+
+  - name: get fluentd CA cert for k8s
+    command: >
+      oc extract -n {{ openshift_logging_namespace }} secret/{{ fluentdsecret.stdout }} --keys=ca.crt --to=-
+    register: fluentdcak8s
+    when: use_mmk8s | default(True)
+
+  - name: install token file
+    copy: content={{ fluentdtoken.stdout }} dest=/etc/rsyslog.d/viaq/mmk8s.token mode=0400
+    when: use_mmk8s | default(True)
+
+  - name: install CA cert file
+    copy: content={{ fluentdcak8s.stdout }} dest=/etc/rsyslog.d/viaq/mmk8s.ca.crt mode=0400
+    when: use_mmk8s | default(True)
+
+  - name: get k8s api url from node kubeconfig
+    shell: |
+      found=0
+      for file in /etc/origin/node/system\:node\:*.kubeconfig ; do
+        if [ -f "$file" ] ; then
+          oc --config="$file" config view -o jsonpath='{.clusters[0].cluster.server}'
+          found=1
+          break
+        fi
+      done
+      if [ $found -eq 0 -a -d /var/lib/origin/openshift.local.config ] ; then
+        for file in /var/lib/origin/openshift.local.config/node*/*.kubeconfig ; do
+          if [ -f "$file" ] ; then
+            oc --config="$file" config view -o jsonpath='{.clusters[0].cluster.server}'
+            break
+          fi
+        done
+      fi
+    register: k8s_api_url
+    when:
+    - openshift_master_api_url is not defined
+    - use_mmk8s | default(True)
+
+  - name: set k8s api url
+    set_fact:
+      openshift_master_api_url: "{{ k8s_api_url.stdout }}"
+    when:
+    - openshift_master_api_url is not defined
+    - use_mmk8s | default(True)
+
+  - name: install template config files
+    template: src={{ item }}.j2 dest=/etc/rsyslog.d/viaq/{{ item }} mode=0400
+    with_items:
+    - mmk8s.conf
+    when: use_mmk8s | default(True)
+
+  - name: get fluentd CA cert for ES
+    command: >
+      oc extract -n {{ openshift_logging_namespace }} secret/logging-fluentd --keys=ca --to=-
+    register: fluentdcaes
+
+  - name: get fluentd client cert for ES
+    command: >
+      oc extract -n {{ openshift_logging_namespace }} secret/logging-fluentd --keys=cert --to=-
+    register: fluentdcert
+
+  - name: get fluentd client key for ES
+    command: >
+      oc extract -n {{ openshift_logging_namespace }} secret/logging-fluentd --keys=key --to=-
+    register: fluentdkey
+
+  - name: get es ip addr
+    command: >
+      oc get -n {{ openshift_logging_namespace }} endpoints logging-es -o jsonpath='{.subsets[0].addresses[0].ip}'
+    register: esip
+    when: elasticsearch_server_host is not defined
+
+  - name: setup host alias for es ip
+    shell: |
+      if grep -q '^{{ esip.stdout }} .* logging-es$' ; then
+        echo already have alias logging-es for {{ esip.stdout }}
+      else
+        sudo sed -i '/^{{ esip.stdout }}/d' /etc/hosts
+        sudo sed -i '/ logging-es$/d' /etc/hosts
+        echo {{ esip.stdout }} logging-es | sudo tee -a /etc/hosts
+      fi
+    when: elasticsearch_server_host is not defined
+
+  - name: install ES CA cert file
+    copy: content={{ fluentdcaes.stdout }} dest=/etc/rsyslog.d/viaq/es-ca.crt mode=0400
+
+  - name: install ES client cert file
+    copy: content={{ fluentdcert.stdout }} dest=/etc/rsyslog.d/viaq/es-cert.pem mode=0400
+
+  - name: install ES client key file
+    copy: content={{ fluentdkey.stdout }} dest=/etc/rsyslog.d/viaq/es-key.pem mode=0400
+
+  - name: handle es-ops
+    when: openshift_logging_use_ops
+    block:
+    - name: get es-ops ip addr
+      command: >
+        oc get -n {{ openshift_logging_namespace }} endpoints logging-es-ops -o jsonpath='{.subsets[0].addresses[0].ip}'
+      register: esopsip
+      when: elasticsearch_ops_server_host is not defined
+
+    - name: setup host alias for es-ops ip
+      shell: |
+        if grep -q '^{{ esopsip.stdout }} .* logging-es-ops$' ; then
+          echo already have alias logging-es-ops for {{ esopsip.stdout }}
+        else
+          sudo sed -i '/^{{ esopsip.stdout }}/d' /etc/hosts
+          sudo sed -i '/ logging-es-ops$/d' /etc/hosts
+          echo {{ esopsip.stdout }} logging-es-ops | sudo tee -a /etc/hosts
+        fi
+      when: elasticsearch_server_host is not defined
+
+  - name: install template config files
+    template: src={{ item }}.j2 dest=/etc/rsyslog.d/viaq/{{ item }} mode=0400
+    with_items:
+    - elasticsearch.conf
+
+  - name: install config files
+    copy: src={{ item }} dest=/etc/rsyslog.d/viaq/{{ item }} mode=0400
+    with_items:
+    - normalize_level.json
+    - prio_to_level.json
+    - viaq_formatting.conf
+    - k8s_filename.rulebase
+    - k8s_container_name.rulebase
+    - parse_json.rulebase
+
+  - name: install main viaq config file
+    copy: src={{ item }} dest=/etc/rsyslog.d/{{ item }} mode=0400
+    with_items:
+    - viaq_main.conf
+
+  - name: copy selinux policy files
+    copy: src={{ item }} dest=/root/ mode=0400
+    with_items:
+    - rsyslog2k8s.te
+    - rsyslog2es.te
+    - varlibdockercont.te
+    - rsyslogaccessnssdb.te
+
+  - name: build policy
+    shell: |
+      cd /root
+      sysmods=$( semodule -l | awk '{print $1}' )
+      for mod in varlibdockercont rsyslog2k8s rsyslogaccessnssdb rsyslog2es ; do
+        if echo "$sysmods" | grep -q $mod ; then
+          echo using existing selinux module $mod
+        elif [ -f ${mod}.te ] ; then
+          checkmodule -M -m -o ${mod}.mod ${mod}.te
+          semodule_package -o ${mod}.pp -m ${mod}.mod
+          semodule -i ${mod}.pp
+        fi
+      done
+
+  # openshift devenv is very noisy - need to increase rsyslog limits for imjournal
+  - name: Update rsyslog.conf imjournal
+    lineinfile:
+      dest: /etc/rsyslog.conf
+      regexp: '^(\$ModLoad imjournal|module\(load="imjournal")'
+      line: 'module(load="imjournal" StateFile="imjournal.state" UsePidFromSystem="on" RateLimit.Burst="{{ imjournal_ratelimit_burst|default(1000000) }}" RateLimit.Interval="{{ imjournal_ratelimit_interval|default(10) }}" PersistStateInterval="1000")'
+      backup: yes
+
+  - name: Comment out rsyslog.conf IMJournalStateFile
+    lineinfile:
+      dest: /etc/rsyslog.conf
+      regexp: '^\$IMJournalStateFile|^#\$IMJournalStateFile'
+      line: '#$IMJournalStateFile imjournal.state'
+
+  - name: restart rsyslog
+    systemd: name=rsyslog state=restarted

--- a/hack/testing/rsyslog/prio_to_level.json
+++ b/hack/testing/rsyslog/prio_to_level.json
@@ -1,0 +1,16 @@
+{ "version" : 1,
+  "nomatch" : "UNKNOWN",
+  "type" : "array",
+  "table" : [
+    {"index": 0, "value": "emerg"},
+    {"index": 1, "value": "alert"},
+    {"index": 2, "value": "crit"},
+    {"index": 3, "value": "err"},
+    {"index": 4, "value": "warning"},
+    {"index": 5, "value": "notice"},
+    {"index": 6, "value": "info"},
+    {"index": 7, "value": "debug"},
+    {"index": 8, "value": "trace"},
+    {"index": 9, "value": "unknown"}
+  ]
+}

--- a/hack/testing/rsyslog/rsyslog2es.te
+++ b/hack/testing/rsyslog/rsyslog2es.te
@@ -1,0 +1,13 @@
+
+module rsyslog2es 1.0;
+
+require {
+	type syslogd_t;
+	type unreserved_port_t;
+	class tcp_socket name_connect;
+}
+
+#============= syslogd_t ==============
+
+#!!!! This avc can be allowed using the boolean 'nis_enabled'
+allow syslogd_t unreserved_port_t:tcp_socket name_connect;

--- a/hack/testing/rsyslog/rsyslog2k8s.te
+++ b/hack/testing/rsyslog/rsyslog2k8s.te
@@ -1,0 +1,13 @@
+
+module rsyslog2k8s 1.0;
+
+require {
+	type syslogd_t;
+	type http_port_t;
+	class tcp_socket name_connect;
+}
+
+#============= syslogd_t ==============
+
+#!!!! This avc can be allowed using the boolean 'nis_enabled'
+allow syslogd_t http_port_t:tcp_socket name_connect;

--- a/hack/testing/rsyslog/rsyslogaccessnssdb.te
+++ b/hack/testing/rsyslog/rsyslogaccessnssdb.te
@@ -1,0 +1,13 @@
+
+module rsyslogaccessnssdb 1.0;
+
+require {
+	type syslogd_t;
+	type cert_t;
+	class dir write;
+	class file write;
+}
+
+#============= syslogd_t ==============
+allow syslogd_t cert_t:dir write;
+allow syslogd_t cert_t:file write;

--- a/hack/testing/rsyslog/valgrind-rsyslogd
+++ b/hack/testing/rsyslog/valgrind-rsyslogd
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+QUIETMODE="-q"
+outputfile=/var/log/rsyslogd.$$.vg
+
+valgrind $QUIETMODE --trace-children=yes --tool=memcheck --track-origins=yes \
+  --read-var-info=yes --leak-check=yes --leak-resolution=high \
+  --num-callers=50 --log-file=$outputfile rsyslogd "$@"

--- a/hack/testing/rsyslog/varlibdockercont.te
+++ b/hack/testing/rsyslog/varlibdockercont.te
@@ -1,0 +1,13 @@
+
+module varlibdockercont 1.0;
+
+require {
+    type syslogd_t;
+    type container_var_lib_t;
+    class dir { search getattr };
+    class file { getattr ioctl open read };
+}
+
+#============= syslogd_t ==============
+allow syslogd_t container_var_lib_t:dir { search getattr };
+allow syslogd_t container_var_lib_t:file { getattr ioctl open read };

--- a/hack/testing/rsyslog/viaq_formatting.conf
+++ b/hack/testing/rsyslog/viaq_formatting.conf
@@ -1,0 +1,253 @@
+lookup_table(name="prio_to_level" file="/etc/rsyslog.d/viaq/prio_to_level.json")
+lookup_table(name="normalize_level" file="/etc/rsyslog.d/viaq/normalize_level.json")
+
+template(name="cnvt_to_viaq_timestamp" type="list") {
+    property(name="TIMESTAMP" dateFormat="rfc3339")
+}
+
+if strlen($!_MACHINE_ID) > 0 then {
+    # convert from imjournal to viaq systemd format
+    # https://github.com/ViaQ/elasticsearch-templates/blob/master/namespaces/systemd.yml
+
+    set $!systemd!t!MACHINE_ID = $!_MACHINE_ID;
+    unset $!_MACHINE_ID;
+    if strlen($!CODE_FILE) > 0 then {
+        set $!systemd!u!CODE_FILE = $!CODE_FILE;
+    }
+    unset $!CODE_FILE;
+    if strlen($!CODE_FUNCTION) > 0 then {
+        set $!systemd!u!CODE_FUNCTION = $!CODE_FUNCTION;
+    }
+    unset $!CODE_FUNCTION;
+    if strlen($!CODE_LINE) > 0 then {
+        set $!systemd!u!CODE_LINE = $!CODE_LINE;
+    }
+    unset $!CODE_LINE;
+    if strlen($!ERRNO) > 0 then {
+        set $!systemd!u!ERRNO = $!ERRNO;
+    }
+    unset $!ERRNO;
+    if strlen($!MESSAGE_ID) > 0 then {
+        set $!systemd!u!MESSAGE_ID = $!MESSAGE_ID;
+    }
+    unset $!MESSAGE_ID;
+    if strlen($!RESULT) > 0 then {
+        set $!systemd!u!RESULT = $!RESULT;
+    }
+    unset $!RESULT;
+    if strlen($!UNIT) > 0 then {
+        set $!systemd!u!UNIT = $!UNIT;
+    }
+    unset $!UNIT;
+    if strlen($!SYSLOG_FACILITY) > 0 then {
+        set $!systemd!u!SYSLOG_FACILITY = $!SYSLOG_FACILITY;
+    }
+    unset $!SYSLOG_FACILITY;
+    if strlen($!SYSLOG_IDENTIFIER) > 0 then {
+        set $!systemd!u!SYSLOG_IDENTIFIER = $!SYSLOG_IDENTIFIER;
+    }
+    unset $!SYSLOG_IDENTIFIER;
+    if strlen($!SYSLOG_PID) > 0 then {
+        set $!systemd!u!SYSLOG_PID = $!SYSLOG_PID;
+    }
+    unset $!SYSLOG_PID;
+    if strlen($!_AUDIT_LOGINUID) > 0 then {
+        set $!systemd!t!AUDIT_LOGINUID = $!_AUDIT_LOGINUID;
+    }
+    unset $!_AUDIT_LOGINUID;
+    if strlen($!_AUDIT_SESSION) > 0 then {
+        set $!systemd!t!AUDIT_SESSION = $!_AUDIT_SESSION;
+    }
+    unset $!_AUDIT_SESSION;
+    if strlen($!_BOOT_ID) > 0 then {
+        set $!systemd!t!BOOT_ID = $!_BOOT_ID;
+    }
+    unset $!_BOOT_ID;
+    if strlen($!_CAP_EFFECTIVE) > 0 then {
+        set $!systemd!t!CAP_EFFECTIVE = $!_CAP_EFFECTIVE;
+    }
+    unset $!_CAP_EFFECTIVE;
+    if strlen($!_CMDLINE) > 0 then {
+        set $!systemd!t!CMDLINE = $!_CMDLINE;
+    }
+    unset $!_CMDLINE;
+    if strlen($!_COMM) > 0 then {
+        set $!systemd!t!COMM = $!_COMM;
+    }
+    unset $!_COMM;
+    if strlen($!_EXE) > 0 then {
+        set $!systemd!t!EXE = $!_EXE;
+    }
+    unset $!_EXE;
+    if strlen($!_GID) > 0 then {
+        set $!systemd!t!GID = $!_GID;
+    }
+    unset $!_GID;
+    if strlen($!_HOSTNAME) > 0 then {
+        set $!systemd!t!HOSTNAME = $!_HOSTNAME;
+    }
+    unset $!_HOSTNAME;
+    if strlen($!_PID) > 0 then {
+        set $!systemd!t!PID = $!_PID;
+    }
+    unset $!_PID;
+    if strlen($!_SELINUX_CONTEXT) > 0 then {
+        set $!systemd!t!SELINUX_CONTEXT = $!_SELINUX_CONTEXT;
+    }
+    unset $!_SELINUX_CONTEXT;
+    if strlen($!_SOURCE_REALTIME_TIMESTAMP) > 0 then {
+        set $!systemd!t!SOURCE_REALTIME_TIMESTAMP = $!_SOURCE_REALTIME_TIMESTAMP;
+    }
+    unset $!_SOURCE_REALTIME_TIMESTAMP;
+    if strlen($!_SYSTEMD_CGROUP) > 0 then {
+        set $!systemd!t!SYSTEMD_CGROUP = $!_SYSTEMD_CGROUP;
+    }
+    unset $!_SYSTEMD_CGROUP;
+    if strlen($!_SYSTEMD_OWNER_UID) > 0 then {
+        set $!systemd!t!SYSTEMD_OWNER_UID = $!_SYSTEMD_OWNER_UID;
+    }
+    unset $!_SYSTEMD_OWNER_UID;
+    if strlen($!_SYSTEMD_SESSION) > 0 then {
+        set $!systemd!t!SYSTEMD_SESSION = $!_SYSTEMD_SESSION;
+    }
+    unset $!_SYSTEMD_SESSION;
+    if strlen($!_SYSTEMD_SLICE) > 0 then {
+        set $!systemd!t!SYSTEMD_SLICE = $!_SYSTEMD_SLICE;
+    }
+    unset $!_SYSTEMD_SLICE;
+    if strlen($!_SYSTEMD_UNIT) > 0 then {
+        set $!systemd!t!SYSTEMD_UNIT = $!_SYSTEMD_UNIT;
+    }
+    unset $!_SYSTEMD_UNIT;
+    if strlen($!_SYSTEMD_USER_UNIT) > 0 then {
+        set $!systemd!t!SYSTEMD_USER_UNIT = $!_SYSTEMD_USER_UNIT;
+    }
+    unset $!_SYSTEMD_USER_UNIT;
+    if strlen($!_TRANSPORT) > 0 then {
+        set $!systemd!t!TRANSPORT = $!_TRANSPORT;
+    }
+    unset $!_TRANSPORT;
+    if strlen($!_UID) > 0 then {
+        set $!systemd!t!UID = $!_UID;
+    }
+    unset $!_UID;
+    if strlen($!_KERNEL_DEVICE) > 0 then {
+        set $!systemd!k!KERNEL_DEVICE = $!_KERNEL_DEVICE;
+    }
+    unset $!_KERNEL_DEVICE;
+    if strlen($!_KERNEL_SUBSYSTEM) > 0 then {
+        set $!systemd!k!KERNEL_SUBSYSTEM = $!_KERNEL_SUBSYSTEM;
+    }
+    unset $!_KERNEL_SUBSYSTEM;
+    if strlen($!_UDEV_SYSNAME) > 0 then {
+        set $!systemd!k!UDEV_SYSNAME = $!_UDEV_SYSNAME;
+    }
+    unset $!_UDEV_SYSNAME;
+    if strlen($!_UDEV_DEVNODE) > 0 then {
+        set $!systemd!k!UDEV_DEVNODE = $!_UDEV_DEVNODE;
+    }
+    unset $!_UDEV_DEVNODE;
+    if strlen($!_UDEV_DEVLINK) > 0 then {
+        set $!systemd!k!UDEV_DEVLINK = $!_UDEV_DEVLINK;
+    }
+    unset $!_UDEV_DEVLINK;
+
+    # these fields require special handling
+    if strlen($!level) == 0 then {
+        if strlen($!PRIORITY) > 0 then {
+            set $!level = lookup("prio_to_level", $!PRIORITY);
+        }
+    }
+    unset $!PRIORITY;
+    if strlen($!message) == 0 then {
+        if strlen($!MESSAGE) > 0 then {
+            set $!message = $!MESSAGE;
+        } else {
+            if strlen($!log) > 0 then {
+                set $!message = $!log;
+            }
+        }
+    }
+    unset $!MESSAGE;
+    if strlen($!hostname) == 0 then {
+        if strlen($!kubernetes!host) > 0 then {
+            set $!hostname = $!kubernetes!host;
+        } else {
+            if strlen($!_HOSTNAME) > 0 then {
+                set $!hostname = $!_HOSTNAME;
+            } else {
+                set $!hostname = $hostname;
+            }
+        }
+    }
+    unset $!_HOSTNAME;
+    if strlen($!@timestamp) == 0 then {
+        # need to figure out how to convert _SOURCE_REALTIME_TIMESTAMP
+        # in the meantime . . .
+        set $!@timestamp = exec_template('cnvt_to_viaq_timestamp');
+    }
+    unset $!_SOURCE_REALTIME_TIMESTAMP;
+    unset $!__REALTIME_TIMESTAMP;
+    # end of block that converts imjournal to viaq format
+} else if strlen($!kubernetes!namespace_name) > 0 then {
+    # clean up container log formatting
+    if (strlen($!message) == 0) and (strlen($!log) > 0) then {
+        set $!message = $!log;
+    }
+    if strlen($!hostname) == 0 then {
+        if strlen($!kubernetes!host) > 0 then {
+            set $!hostname = $!kubernetes!host;
+        } else {
+            set $!hostname = $hostname;
+        }
+    }
+    if strlen($!@timestamp) == 0 then {
+        if strlen($!time) > 0 then {
+            set $!@timestamp = $!time;
+        } else {
+            set $!@timestamp = $TIMESTAMP;
+        }
+    }
+}
+
+# normalize level
+if strlen($!level) > 0 then {
+    set $.lclevel = tolower($!level);
+    set $.normlevel = lookup("normalize_level", $.lclevel);
+    if $.normlevel == "unknown" then {
+        continue # do nothing - preserve original value
+    } else {
+        set $!level = $.normlevel;
+    }
+    unset $.lclevel;
+    unset $.normlevel;
+} else {
+    if $!stream == "stdout" then {
+        set $!level = "info";
+    } else {
+        if $!stream == "stderr" then {
+            set $!level = "err";
+        } else {
+            set $!level = "unknown";
+        }
+    }
+}
+
+# add eventrouter
+# add pipeline_metadata
+
+if strlen($!kubernetes!namespace_name) > 0 then {
+    # see if this is an operations namespace
+    if ($!kubernetes!namespace_name == "default") or ($!kubernetes!namespace_name == "openshift") or
+        ($!kubernetes!namespace_name startswith "openshift-") then {
+            set $.viaq_index_prefix = ".operations.";
+    } else {
+        if strlen($!kubernetes!namespace_id) > 0 then {
+            set $.viaq_index_prefix = "project." & $!kubernetes!namespace_name & "." & $!kubernetes!namespace_id & ".";
+        } else {
+            set $.viaq_index_prefix = ".orphaned.";
+        }
+    } 
+} else {
+    set $.viaq_index_prefix = ".operations.";
+}

--- a/hack/testing/rsyslog/viaq_main.conf
+++ b/hack/testing/rsyslog/viaq_main.conf
@@ -1,0 +1,10 @@
+module(load="mmjsonparse")
+module(load="mmnormalize")
+module(load="omelasticsearch")
+module(load="imfile" mode="inotify")
+
+$IncludeConfig /etc/rsyslog.d/viaq/mmk8s.conf
+
+$IncludeConfig /etc/rsyslog.d/viaq/viaq_formatting.conf
+
+$IncludeConfig /etc/rsyslog.d/viaq/elasticsearch.conf

--- a/hack/testing/test-zzz-rsyslog.sh
+++ b/hack/testing/test-zzz-rsyslog.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/zzz-rsyslog.sh

--- a/test/zzz-rsyslog.sh
+++ b/test/zzz-rsyslog.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# This is a test suite for testing basic log processing
+# functionality and Kubernetes processing for rsyslog
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+os::util::environment::use_sudo
+
+os::test::junit::declare_suite_start "test/zzz-rsyslog"
+
+es_pod=$( get_es_pod es )
+es_ops_pod=$( get_es_pod es-ops )
+es_ops_pod=${es_ops_pod:-$es_pod}
+
+cleanup() {
+    local return_code="$?"
+    set +e
+    if [ -n "${tmpinv}" -a -f "${tmpinv}" ] ; then
+        rm -f $tmpinv
+    fi
+    if [ -n "${rsyslog_save}" -a -d "${rsyslog_save}" ] ; then
+        sudo rm -rf /etc/rsyslog.d/*
+        sudo cp -p ${rsyslog_save}/* /etc/rsyslog.d
+        rm -rf ${rsyslog_save}
+        sudo systemctl restart rsyslog
+    fi
+    # cleanup fluentd pos file and restart
+    flush_fluentd_pos_files
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
+
+# turn off fluentd
+oc label node --all logging-infra-fluentd- 2>&1 | artifact_out || :
+os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $((second * 120))
+
+if [ $es_pod = $es_ops_pod ] ; then
+    use_es_ops=False
+else
+    use_es_ops=True
+fi
+rsyslog_save=$( mktemp -d )
+sudo cp -p /etc/rsyslog.d/* $rsyslog_save
+pushd $OS_O_A_L_DIR/hack/testing/rsyslog > /dev/null
+tmpinv=$( mktemp )
+cat > $tmpinv <<EOF
+localhost ansible_ssh_user=${RSYSLOG_ANSIBLE_SSH_USER:-ec2-user} openshift_logging_use_ops=$use_es_ops openshift_logging_namespace=${LOGGING_NS:-logging}
+EOF
+os::cmd::expect_success "ansible-playbook -vvv --become --become-user root --connection local \
+    -e use_mmk8s=True -i $tmpinv playbook.yaml > $ARTIFACT_DIR/zzz-rsyslog-ansible.log 2>&1"
+rm -f $tmpinv
+popd > /dev/null
+
+get_logmessage() {
+    logmessage="$1"
+}
+get_logmessage2() {
+    logmessage2="$1"
+}
+sudo systemctl stop rsyslog
+# make test run faster by resetting journal cursor to "now"
+sudo journalctl -n 1 --show-cursor | awk '/^-- cursor/ {printf("%s",$3)}' | sudo tee /var/lib/rsyslog/imjournal.state > /dev/null
+sudo systemctl start rsyslog
+sleep 10
+# we're actually waiting for rsyslog instead . . .
+wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
+fullmsg="GET /${logmessage} 404 "
+qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
+proj=$ARTIFACT_DIR/rsyslog-proj.json
+curl_es $es_pod /project.logging.*/_search -X POST -d "$qs" | jq .hits.hits[0] > $proj 2>&1
+qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
+ops=$ARTIFACT_DIR/rsyslog-ops.json
+curl_es $es_ops_pod /.operations.*/_search -X POST -d "$qs" | jq .hits.hits[0] > $ops 2>&1
+
+# see if the kubernetes metadata matches
+actual_pod_name=$( cat $proj | jq -r ._source.kubernetes.pod_name )
+actual_ns_name=$( cat $proj | jq -r ._source.kubernetes.namespace_name )
+actual_pod_id=$( cat $proj | jq -r ._source.kubernetes.pod_id )
+actual_ns_id=$( cat $proj | jq -r ._source.kubernetes.namespace_id )
+actual_pod_host=$( cat $proj | jq -r ._source.kubernetes.host )
+os::cmd::expect_success "test $actual_pod_id = $( oc get pod $actual_pod_name -o jsonpath='{.metadata.uid}' )"
+os::cmd::expect_success "test $actual_pod_host = $( oc get pod $actual_pod_name -o jsonpath='{.spec.nodeName}' )"
+os::cmd::expect_success "test $actual_ns_id = $( oc get project $actual_ns_name -o jsonpath='{.metadata.uid}' )"
+oc get pod $actual_pod_name -o json | jq -S .metadata.labels | \
+    jq 'with_entries(.key |= gsub("[.]";"_"))' > $ARTIFACT_DIR/zzz-rsyslog-expected-labels.json
+cat $proj | jq -S ._source.kubernetes.labels > $ARTIFACT_DIR/zzz-rsyslog-actual-labels.json
+os::cmd::expect_success "diff $ARTIFACT_DIR/zzz-rsyslog-expected-labels.json $ARTIFACT_DIR/zzz-rsyslog-actual-labels.json"
+
+oc get pod $actual_pod_name -o json | jq -S .metadata.annotations | \
+    jq 'with_entries(.key |= gsub("[.]";"_"))' > $ARTIFACT_DIR/zzz-rsyslog-expected-annotations.json
+cat $proj | jq -S ._source.kubernetes.annotations > $ARTIFACT_DIR/zzz-rsyslog-actual-annotations.json
+os::cmd::expect_success "diff $ARTIFACT_DIR/zzz-rsyslog-expected-annotations.json $ARTIFACT_DIR/zzz-rsyslog-actual-annotations.json"
+
+if [ -n "$( oc get project $actual_ns_name -o jsonpath='{.metadata.labels}')" ] ; then
+    oc get project $actual_ns_name -o json | jq -S .metadata.labels | \
+        jq 'with_entries(.key |= gsub("[.]";"_"))' > $ARTIFACT_DIR/zzz-rsyslog-expected-nslabels.json
+    cat $proj | jq -S ._source.kubernetes.namespace_labels > $ARTIFACT_DIR/zzz-rsyslog-actual-nslabels.json
+    os::cmd::expect_success "diff $ARTIFACT_DIR/zzz-rsyslog-expected-nslabels.json $ARTIFACT_DIR/zzz-rsyslog-actual-nslabels.json"
+else
+    os::cmd::expect_success_and_text "cat $proj | jq ._source.metadata.namespace_labels" "^null\$"
+fi
+
+if [ -n "$( oc get project $actual_ns_name -o jsonpath='{.metadata.annotations}')" ] ; then
+    oc get project $actual_ns_name -o json | jq -S .metadata.annotations | \
+        jq 'with_entries(.key |= gsub("[.]";"_"))' > $ARTIFACT_DIR/zzz-rsyslog-expected-nsannotations.json
+    cat $proj | jq -S ._source.kubernetes.namespace_annotations > $ARTIFACT_DIR/zzz-rsyslog-actual-nsannotations.json
+    os::cmd::expect_success "diff $ARTIFACT_DIR/zzz-rsyslog-expected-nsannotations.json $ARTIFACT_DIR/zzz-rsyslog-actual-nsannotations.json"
+else
+    os::cmd::expect_success_and_text "cat $proj | jq ._source.metadata.namespace_annotations" "^null\$"
+fi
+
+# see if ops fields are present
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.systemd.t.TRANSPORT" "^null$"
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.systemd.t.SELINUX_CONTEXT" "^null$"
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.systemd.u.SYSLOG_FACILITY" "^null$"
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.systemd.u.SYSLOG_PID" "^null$"
+os::cmd::expect_success_and_text "cat $ops | jq -r ._source.message" "^${logmessage2}\$"
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.level" "^null$"
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.hostname" "^null$"
+ts=$( cat $ops | jq -r '._source."@timestamp"' )
+os::cmd::expect_success "test ${ts} != null"


### PR DESCRIPTION
This tests the ability of rsyslog to do kubernetes metadata
annotation, elasticsearch with client cert auth, and some basic
viaq data model formatting

This currently uses pre-release rsyslog built in fedora copr, but
that should move into more official repos soon.