### PR TITLE
[release-3.7] reduce test flakes with false hits for ops projects

### DIFF
--- a/hack/testing/templates/test-template.yaml
+++ b/hack/testing/templates/test-template.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: test-template
+  annotations:
+    description: "For creating test pods"
+objects:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: ${TEST_POD_NAME}
+    namespace: ${TEST_NAMESPACE_NAME}
+  spec:
+    terminationGracePeriodSeconds: 0
+    containers:
+    - name: test
+      image: centos:7
+      command:
+      - bash
+      - -c
+      - |-
+        loops=0
+        while true; do
+          loops=$( expr $loops + 1 )
+          for ii in $( seq 1 ${TEST_ITERATIONS} ) ; do
+            echo "${TEST_POD_MESSAGE} $loops $ii"
+          done
+          sleep ${TEST_POD_SLEEP_TIME}
+        done
+parameters:
+- description: Namespace name to create pod in
+  value: logging
+  name: TEST_NAMESPACE_NAME
+- description: name of test pod to create
+  value: test
+  name: TEST_POD_NAME
+- description: message to print
+  value: "I am a test pod"
+  name: TEST_POD_MESSAGE
+- description: time to sleep between each message in seconds
+  value: "1"
+  name: TEST_POD_SLEEP_TIME
+- description: number of times to print message before sleeping
+  value: "1"
+  name: TEST_ITERATIONS
+labels:
+  test: "true"

--- a/test/zzz-correct-index-names.sh
+++ b/test/zzz-correct-index-names.sh
@@ -24,19 +24,59 @@ es_pod=$( get_es_pod es )
 es_ops_pod=$( get_es_pod es-ops )
 es_ops_pod=${es_ops_pod:-$es_pod}
 
-for project in default openshift openshift-infra ; do
+OPS_NAMESPACES="default openshift openshift-infra"
+
+# write some logs from namespace openshift and openshift-infra
+test_template=$OS_O_A_L_DIR/hack/testing/templates/test-template.yaml
+
+for project in $OPS_NAMESPACES ; do
+    delete_project=""
+    if oc get project $project 2>&1 | artifact_out ; then
+        os::log::debug "use existing project $project"
+    else
+        os::log::info Creating project $project
+        oc adm new-project $project --node-selector='' 2>&1 | artifact_out
+        os::cmd::try_until_success "oc get project $project" 2>&1 | artifact_out
+        delete_project="$project"
+    fi
+    message_uuid=$( uuidgen | sed 's/[-]//g' )
+    oc process -f $test_template \
+        -p TEST_POD_NAME=test-pod \
+        -p TEST_POD_MESSAGE="$message_uuid" \
+        -p TEST_POD_SLEEP_TIME=1 \
+        -p TEST_NAMESPACE_NAME=${project} \
+        -p TEST_ITERATIONS=1 | oc create -f - 2>&1 | artifact_out
+    os::cmd::try_until_text "oc get -n ${project} pods test-pod" "^test-pod.* Running "
+    # The query part will return more than one if successful - due to the fuzzy matching,
+    # it may return results from more than one namespace - the jq select will ensure that
+    # the namespace name matches exactly
+    os::cmd::try_until_text "curl_es $es_ops_pod /.operations.*/_search?q=message:$message_uuid | \
+        jq '.hits.hits | map(select(._source.kubernetes.namespace_name == \"${project}\")) | length | . > 0'" "^true\$"
+    oc delete -n ${project} --force pod test-pod 2>&1 | artifact_out
+    os::cmd::try_until_failure "oc get -n ${project} pod test-pod"
+    if [ -n "$delete_project" ] ; then
+        oc delete project $delete_project 2>&1 | artifact_out
+        os::cmd::try_until_failure "oc get project $delete_project" 2>&1 | artifact_out
+    fi
+done
+
+for project in $OPS_NAMESPACES ; do
     qs='{"query":{"term":{"kubernetes.namespace_name":"'"${project}"'"}}}'
     os::cmd::expect_success_and_not_text "curl_es $es_pod /_cat/indices" "project\.${project}\."
     os::cmd::expect_success_and_text "curl_es $es_pod /project.${project}.*/_count | get_count_from_json" "^0\$"
-    os::cmd::expect_success_and_text "curl_es $es_pod /project.*/_count -X POST -d '$qs' | get_count_from_json" "^0\$"
+    # since we can't rely on query term to give us an exact match, do that part in jq
+    #os::cmd::expect_success_and_text "curl_es $es_pod /project.*/_count -X POST -d '$qs' | get_count_from_json" "^0\$"
+    # use large size e.g. a fuzzy search for q=kubernetes.namespace_name:openshift-infra could return 9998
+    # hits for kubernetes.namespace_name=openshift and one for openshift-infra
+    os::cmd::expect_success_and_text "curl_es $es_pod /project.*/_search?q=kubernetes.namespace_name:${project}\&size=9999 | \
+        jq '.hits.hits | map(select(._source.kubernetes.namespace_name == \"${project}\")) | length | . > 0'" "^false\$"
     if [ "$es_pod" != "$es_ops_pod" ] ; then
         os::cmd::expect_success_and_not_text "curl_es $es_ops_pod /_cat/indices" "project\.${project}\."
         os::cmd::expect_success_and_text "curl_es $es_ops_pod /project.${project}.*/_count | get_count_from_json" "^0\$"
-        os::cmd::expect_success_and_text "curl_es $es_ops_pod /project.*/_count -X POST -d '$qs' | get_count_from_json" "^0\$"
+        #os::cmd::expect_success_and_text "curl_es $es_ops_pod /project.*/_count -X POST -d '$qs' | get_count_from_json" "^0\$"
+        os::cmd::expect_success_and_text "curl_es $es_ops_pod /project.*/_search?q=kubernetes.namespace_name:${project}\&size=9999 | \
+            jq '.hits.hits | map(select(._source.kubernetes.namespace_name == \"${project}\")) | length | . > 0'" "^false\$"
     fi
-    # there will almost always be logs from the default namespace from router and registry
-    # there will almost never be logs from openshift and openshift-infra
-    if [ "$project" = "default" ] ; then
-        os::cmd::expect_success_and_not_text "curl_es $es_ops_pod /.operations.*/_count -X POST -d '$qs' | get_count_from_json" "^0\$"
-    fi
+    os::cmd::expect_success_and_text "curl_es $es_ops_pod /.operations.*/_search?q=kubernetes.namespace_name:${project}\&size=9999 | \
+        jq '.hits.hits | map(select(._source.kubernetes.namespace_name == \"${project}\")) | length | . > 0'" "^true\$"
 done


### PR DESCRIPTION
Because of the problem where index templates can be loaded after the
data, we cannot rely on exact match searches (query term).  Instead,
do a possibly "fuzzy" search for namespace_name, then use jq to further
parse and query the output.
In order to make sure the code which processes operational and
"openshift-*" projects is working, create log messages for those
projects.

(cherry picked from commit c4c0be0565c6e5566c265b688e865bd2f3136b92)