### PR TITLE
check logging namespace for actual resources

### DIFF
--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -26,7 +26,7 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 
 LOGGING_NS=openshift-logging
-if oc get project logging -o name > /dev/null ; then
+if oc get project logging -o name > /dev/null && [ $(oc get dc -n logging -o name | wc -l) -gt 0 ]  ; then
     LOGGING_NS=logging
 fi
 export LOGGING_NS


### PR DESCRIPTION
Check for the logging namespace with resources in case there is just an empty namespace