### PR TITLE
[release-3.9] Fix access-control, mux-client-mode, docker hostmount, other issues

### DIFF
--- a/docs/mux-logging-service.md
+++ b/docs/mux-logging-service.md
@@ -112,7 +112,7 @@ You will need the mux CA cert and shared_key.  You can obtain them from the
 logging cluster like this:
 
     # oc login --username=system:admin
-    # oc project logging
+    # oc project openshift-logging # if that project doesn't exist, use logging
     # oc get secret logging-mux --template='{{index .data "ca"}}' | base64 -d > mux-ca.crt
     # oc get secret logging-mux --template='{{index .data "shared_key"}}' | \
       base64 -d > mux-shared-key

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -66,7 +66,7 @@ Could not find the requested service "'origin-master'":
 This message may be ignored.  You may now log in and confirm your deployment:
 
 ```
-$ oc project logging
+$ oc project openshift-logging # if that project doesn't exist, use logging
 $ oc get pods
 NAME                          READY     STATUS    RESTARTS   AGE
 logging-curator-13-kbdj0      1/1       Running   1          1d

--- a/fluentd/configs.d/filter-pre-mux-client-retag-raw.conf
+++ b/fluentd/configs.d/filter-pre-mux-client-retag-raw.conf
@@ -6,3 +6,8 @@
   rewriterule1 message .+ ${tag}.raw
   rewriterule2 message !.+ ${tag}.raw
 </match>
+
+<match **>
+  @type relabel
+  @label @OUTPUT
+</match>

--- a/fluentd/configs.d/filter-pre-mux-client-retag-raw.conf
+++ b/fluentd/configs.d/filter-pre-mux-client-retag-raw.conf
@@ -1,0 +1,8 @@
+# used only for MUX_CLIENT_MODE=minimal for json-file logs
+# tag messages as raw (i.e. unprocessed) and send to @OUTPUT label
+<match kubernetes.**>
+  @type rewrite_tag_filter
+  @label @OUTPUT
+  rewriterule1 message .+ ${tag}.raw
+  rewriterule2 message !.+ ${tag}.raw
+</match>

--- a/fluentd/configs.d/input-post-forward-mux.conf
+++ b/fluentd/configs.d/input-post-forward-mux.conf
@@ -33,12 +33,18 @@
     @type record_transformer
     enable_ruby
     <record>
-      CONTAINER_NAME ${record['CONTAINER_NAME'] || (md = /var\.log\.containers\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]+)\.log$/.match(tag); "k8s_" + md["container_name"] + ".0_" + md["pod_name"] + "_" + md["namespace"] + "_0_01234567")}
-      CONTAINER_ID_FULL ${record['CONTAINER_ID_FULL'] || (md = /var\.log\.containers\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]+)\.log$/.match(tag); md["docker_id"])}
+      CONTAINER_NAME ${record['CONTAINER_NAME'] || (md = /var\.log\.containers\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]+)\.log(?:\.raw)?$/.match(tag); "k8s_" + md["container_name"] + ".0_" + md["pod_name"] + "_" + md["namespace"] + "_0_01234567")}
+      CONTAINER_ID_FULL ${record['CONTAINER_ID_FULL'] || (md = /var\.log\.containers\.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]+)\.log(?:\.raw)?$/.match(tag); md["docker_id"])}
     </record>
   </filter>
 
-  # If this record has already been processed by fluentd e.g. in MUX_CLIENT_MODE=maximal
+  # raw record from fluentd MUX_CLIENT_MODE=minimal - redirect to normal processing
+  <match **.raw>
+    @type relabel
+    @label @INGRESS
+  </match>
+
+# If this record has already been processed by fluentd e.g. in MUX_CLIENT_MODE=maximal
   # then tag it so that it will be processed by the k8s plugin (if kubernetes.**)
   # and have an index name created for it, but it will not be processed in any other way.
   # Assume that if the record has the @timestamp field then it has already been

--- a/fluentd/configs.d/input-post-forward-mux.conf
+++ b/fluentd/configs.d/input-post-forward-mux.conf
@@ -44,7 +44,7 @@
     @label @INGRESS
   </match>
 
-# If this record has already been processed by fluentd e.g. in MUX_CLIENT_MODE=maximal
+  # If this record has already been processed by fluentd e.g. in MUX_CLIENT_MODE=maximal
   # then tag it so that it will be processed by the k8s plugin (if kubernetes.**)
   # and have an index name created for it, but it will not be processed in any other way.
   # Assume that if the record has the @timestamp field then it has already been

--- a/fluentd/configs.d/input-post-output.conf
+++ b/fluentd/configs.d/input-post-output.conf
@@ -1,0 +1,10 @@
+# note - only used for MUX_CLIENT_MODE=minimal in cases where the fluent.conf is
+# older and has no @OUTPUT label
+<label @OUTPUT>
+## matches
+  @include configs.d/openshift/output-pre-*.conf
+  @include configs.d/openshift/output-operations.conf
+  @include configs.d/openshift/output-applications.conf
+  # no post - applications.conf matches everything left
+##
+</label>

--- a/hack/README-dump.md
+++ b/hack/README-dump.md
@@ -117,7 +117,7 @@ Examples:
 
 ### Common
 * Nodes description `oc describe nodes`
-* Project `oc get project logging -o yaml`
+* Project `oc get project openshift-logging -o yaml`
 * Pod Logs compressed. Use `find . -name "*.xz" | while read filename; do xz -d $filename; done`
 * Docker image version `/root/buildinfo/Dockerfile-openshift3*`
 * Environment variables

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -147,7 +147,7 @@ function run_suite() {
 	suite_name="$( basename "${test}" '.sh' )"
 	os::test::junit::declare_suite_start "test/setup/${suite_name}"
 	os::cmd::expect_success "oc login -u system:admin"
-	os::cmd::expect_success "oc project logging"
+	os::cmd::expect_success "oc project $LOGGING_NS"
 	os::test::junit::declare_suite_end
 
 	os::log::info "Logging test suite ${suite_name} started at $( date )"

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -101,11 +101,11 @@ monitor_es_bulk_stats() {
         esopspod=${esopspod:-$espod}
         if [ -n "${espod}" ] ; then
             date -Ins >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1
-            curl_es $espod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs,bqs >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1
+            curl_es $espod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs,bqs >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1 || :
         fi
         if [ -n "${esopspod}" -a "${espod}" != "${esopspod}" ] ; then
             date -Ins >> $ARTIFACT_DIR/monitor_es_bulk_stats-es-ops.log 2>&1
-            curl_es $esopspod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs,bqs >> $ARTIFACT_DIR/monitor_es_bulk_stats-es-ops.log 2>&1
+            curl_es $esopspod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs,bqs >> $ARTIFACT_DIR/monitor_es_bulk_stats-es-ops.log 2>&1 || :
         fi
         sleep $interval
     done

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -26,7 +26,7 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 
 LOGGING_NS=openshift-logging
-if oc get project logging -o name > /dev/null ; then
+if oc get project logging -o name > /dev/null && [ $(oc get dc -n logging -o name | wc -l) -gt 0 ]  ; then
     LOGGING_NS=logging
 fi
 export LOGGING_NS

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -57,7 +57,7 @@ monitor_fluentd_top() {
     # assumes running in a subshell
     cp $KUBECONFIG $ARTIFACT_DIR/monitor_fluentd_top.kubeconfig
     export KUBECONFIG=$ARTIFACT_DIR/monitor_fluentd_top.kubeconfig
-    oc project logging > /dev/null
+    oc project ${LOGGING_NS} > /dev/null
     while true ; do
         fpod=$( get_running_pod fluentd )
         if [ -n "$fpod" ] ; then
@@ -95,6 +95,9 @@ monitor_journal_lograte() {
 
 monitor_es_bulk_stats() {
     local interval=5
+    cp $KUBECONFIG $ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
+    export KUBECONFIG=$ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
+    oc project ${LOGGING_NS} > /dev/null
     while true ; do
         local espod=$( get_es_pod es ) || :
         local esopspod=$( get_es_pod es-ops ) || :

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -59,7 +59,7 @@ monitor_fluentd_top() {
     export KUBECONFIG=$ARTIFACT_DIR/monitor_fluentd_top.kubeconfig
     oc project ${LOGGING_NS} > /dev/null
     while true ; do
-        fpod=$( get_running_pod fluentd )
+        fpod=$( get_running_pod fluentd 2> /dev/null ) || :
         if [ -n "$fpod" ] ; then
             oc exec $fpod -- top -b -d 1 || :
         else
@@ -99,8 +99,8 @@ monitor_es_bulk_stats() {
     export KUBECONFIG=$ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
     oc project ${LOGGING_NS} > /dev/null
     while true ; do
-        local espod=$( get_es_pod es ) || :
-        local esopspod=$( get_es_pod es-ops ) || :
+        local espod=$( get_es_pod es 2> /dev/null ) || :
+        local esopspod=$( get_es_pod es-ops 2> /dev/null ) || :
         esopspod=${esopspod:-$espod}
         if [ -n "${espod}" ] ; then
             date -Ins >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1

--- a/hack/testing/rsyslog/elasticsearch.conf.j2
+++ b/hack/testing/rsyslog/elasticsearch.conf.j2
@@ -11,7 +11,7 @@ template(name="index_pattern" type="list") {
     property(name="$!@timestamp" dateFormat="rfc3339" position.from="9" position.to="10")
 }
 
-{%if openshift_logging_use_ops | default(False) %}
+{% if openshift_logging_use_ops | default(False) %}
 if $.viaq_index_prefix startswith "project." then {
 {% endif %}
 action(
@@ -27,8 +27,9 @@ action(
     tls.cacert="/etc/rsyslog.d/viaq/es-ca.crt"
     tls.mycert="/etc/rsyslog.d/viaq/es-cert.pem"
     tls.myprivkey="/etc/rsyslog.d/viaq/es-key.pem"
+    errorfile="/var/lib/rsyslog/es-errors.log"
 )
-{%if openshift_logging_use_ops | default(False) %}
+{% if openshift_logging_use_ops | default(False) %}
 } else {
 action(
     type="omelasticsearch"
@@ -43,6 +44,7 @@ action(
     tls.cacert="/etc/rsyslog.d/viaq/es-ca.crt"
     tls.mycert="/etc/rsyslog.d/viaq/es-cert.pem"
     tls.myprivkey="/etc/rsyslog.d/viaq/es-key.pem"
+    errorfile="/var/lib/rsyslog/es-errors.log"
 )
 }
 {% endif %}

--- a/hack/testing/templates/test-template.yaml
+++ b/hack/testing/templates/test-template.yaml
@@ -29,7 +29,7 @@ objects:
         done
 parameters:
 - description: Namespace name to create pod in
-  value: logging
+  value: openshift-logging
   name: TEST_NAMESPACE_NAME
 - description: name of test pod to create
   value: test

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -199,31 +199,55 @@ function wait_for_fluentd_to_catch_up() {
     local priority=${TEST_REC_PRIORITY:-info}
 
     wait_for_fluentd_ready
+
+    # look for the messages in the source
+    local fullmsg="GET /${uuid_es} 404 "
+    local using_journal=0
+    local checkpids
+    if docker_uses_journal ; then
+        using_journal=1
+        sudo journalctl -f -o export | \
+            awk -v es=$uuid_es -v es_ops=$uuid_es_ops \
+            -v es_out=$ARTIFACT_DIR/es_out.txt -v es_ops_out=$ARTIFACT_DIR/es_ops_out.txt '
+                BEGIN{RS="";FS="\n"};
+                $0 ~ es {print > es_out; found += 1};
+                $0 ~ es_ops {print > es_ops_out; found += 1};
+                {if (found == 2) {exit 0}}' & checkpids=$!
+    else
+        sudo journalctl -f -o export | \
+            awk -v es_ops=$uuid_es_ops -v es_ops_out=$ARTIFACT_DIR/es_ops_out.txt '
+                BEGIN{RS="";FS="\n"};
+                $0 ~ es_ops {print > es_ops_out; exit 0}' & checkpids=$!
+        while ! sudo grep -b -n "$fullmsg" /var/log/containers/*.log > $ARTIFACT_DIR/es_out.txt ; do
+            sleep 1
+        done & checkpids="$checkpids $!"
+    fi
+
     add_test_message $uuid_es
-    os::log::debug added es message $uuid_es
+    artifact_log added es message $uuid_es
     logger -i -p local6.${priority} -t $uuid_es_ops $uuid_es_ops
-    os::log::debug added es-ops message $uuid_es_ops
+    artifact_log added es-ops message $uuid_es_ops
 
     local rc=0
 
     # poll for logs to show up
-    local fullmsg="GET /${uuid_es} 404 "
     local qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
     if os::cmd::try_until_text "curl_es ${es_pod} /project.logging.*/_count -X POST -d '$qs' | get_count_from_json" $expected $(( timeout * second )); then
         os::log::debug good - $FUNCNAME: found $expected record project logging for \'$fullmsg\'
     else
         os::log::error $FUNCNAME: not found $expected record project logging for \'$fullmsg\' after $timeout seconds
         os::log::debug "$( curl_es ${es_pod} /project.logging.*/_search -X POST -d "$qs" )"
-        os::log::error "Checking journal for '$fullmsg' ..."
-        if sudo journalctl | grep -q "$fullmsg" ; then
-            os::log::error "Found '$fullmsg' in journal"
-            os::log::debug "$( sudo journalctl | grep "$fullmsg" )"
-        elif sudo grep -q "$fullmsg" /var/log/containers/* ; then
-            os::log::error "Found '$fullmsg' in /var/log/containers/*"
-            os::log::debug "$( sudo grep -q "$fullmsg" /var/log/containers/* )"
+        if [ -s $ARTIFACT_DIR/es_out.txt ] ; then
+            os::log::error "$( cat $ARTIFACT_DIR/es_out.txt )"
         else
-            os::log::error "Unable to find '$fullmsg' in journal or /var/log/containers/*"
+            os::log::error apps record for "$fullmsg" not found in source
         fi
+        if sudo test -f /var/log/es-containers.log.pos ; then
+            os::log::error here are the current container log positions
+            sudo cat /var/log/es-containers.log.pos
+        fi
+        os::log::error here is the current fluentd journal cursor
+        sudo cat /var/log/journal.pos
 
         rc=1
     fi
@@ -235,14 +259,18 @@ function wait_for_fluentd_to_catch_up() {
         os::log::error $FUNCNAME: not found $expected record project .operations for $uuid_es_ops after $timeout seconds
         os::log::debug "$( curl_es ${es_ops_pod} /.operations.*/_search -X POST -d "$qs" )"
         os::log::error "Checking journal for $uuid_es_ops..."
-        if sudo journalctl | grep -q $uuid_es_ops ; then
-            os::log::error "Found $uuid_es_ops in journal"
-            os::log::debug "$( sudo journalctl | grep $uuid_es_ops )"
+        if [ -s $ARTIFACT_DIR/es_ops_out.txt ] ; then
+            os::log::error "$( cat $ARTIFACT_DIR/es_ops_out.txt )"
         else
-            os::log::error "Unable to find $uuid_es_ops in journal"
+            os::log::error ops record for "$uuid_es_ops" not found in journal
         fi
+        os::log::error here is the current fluentd journal cursor
+        sudo cat /var/log/journal.pos
         rc=1
     fi
+
+    kill $checkpids > /dev/null 2>&1 || :
+    kill -9 $checkpids > /dev/null 2>&1 || :
 
     if [ -n "${1:-}" ] ; then
         $1 $uuid_es

--- a/test/access_control.sh
+++ b/test/access_control.sh
@@ -268,9 +268,11 @@ fi
 
 os::log::info now auth using admin + token
 get_test_user_token $LOG_ADMIN_USER $LOG_ADMIN_PW
-nrecs=$( curl_es_with_token $espod "/${logging_index}/_count" $test_name $test_token | \
-         get_count_from_json )
-os::cmd::expect_success "test $nrecs -gt 1"
+if [ ${LOGGING_NS} = "logging" ] && [ $espod != $esopspod] ; then
+  nrecs=$( curl_es_with_token $espod "/${logging_index}/_count" $test_name $test_token | \
+           get_count_from_json )
+  os::cmd::expect_success "test $nrecs -gt 1"
+fi
 nrecs=$( curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | \
          get_count_from_json )
 os::cmd::expect_success "test $nrecs -gt 1"

--- a/test/access_control.sh
+++ b/test/access_control.sh
@@ -65,7 +65,8 @@ function add_message_to_index() {
     # espod is $3
     local project_uuid=$( oc get project $1 -o jsonpath='{ .metadata.uid }' )
     local index="project.$1.$project_uuid.$(date -u +'%Y.%m.%d')"
-    curl_es "$3" "/$index/access-control-test/" -XPOST -d '{"message":"'${2:-"access-control message"}'"}' | python -mjson.tool 2>&1 | artifact_out
+    local espod=$3
+    curl_es "$espod" "/$index/access-control-test/" -XPOST -d '{"message":"'${2:-"access-control message"}'"}' | python -mjson.tool 2>&1 | artifact_out
 }
 
 # test the following
@@ -245,11 +246,11 @@ oc get users 2>&1 | artifact_out
 # # oc login --username=loguser --password=loguser
 # error: The server was unable to respond - verify you have provided the correct host and port and that the server is currently running.
 # or - set REUSE=true
-LOG_NORMAL_USER=${LOG_NORMAL_USER:-loguserac}
-LOG_NORMAL_PW=${LOG_NORMAL_PW:-loguserac}
+LOG_NORMAL_USER=${LOG_NORMAL_USER:-loguserac-$RANDOM}
+LOG_NORMAL_PW=${LOG_NORMAL_PW:-loguserac-$RANDOM}
 
-LOG_USER2=${LOG_USER2:-loguser2ac}
-LOG_PW2=${LOG_PW2:-loguser2ac}
+LOG_USER2=${LOG_USER2:-loguser2ac-$RANDOM}
+LOG_PW2=${LOG_PW2:-loguser2ac-$RANDOM}
 
 create_user_and_assign_to_projects $LOG_NORMAL_USER $LOG_NORMAL_PW access-control-1 access-control-2
 create_user_and_assign_to_projects $LOG_USER2 $LOG_PW2 access-control-2 access-control-3
@@ -260,9 +261,14 @@ oc project ${LOGGING_NS} > /dev/null
 test_user_has_proper_access $LOG_NORMAL_USER $LOG_NORMAL_PW access-control-1 access-control-2 -- access-control-3
 test_user_has_proper_access $LOG_USER2 $LOG_PW2 access-control-2 access-control-3 -- access-control-1
 
+logging_index=".operations.*"
+if [ ${LOGGING_NS} = "logging" ] ; then
+  logging_index="project.logging.*"
+fi
+
 os::log::info now auth using admin + token
 get_test_user_token $LOG_ADMIN_USER $LOG_ADMIN_PW
-nrecs=$( curl_es_with_token $espod "/project.${LOGGING_NS}.*/_count" $test_name $test_token | \
+nrecs=$( curl_es_with_token $espod "/${logging_index}/_count" $test_name $test_token | \
          get_count_from_json )
 os::cmd::expect_success "test $nrecs -gt 1"
 nrecs=$( curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | \

--- a/test/access_control.sh
+++ b/test/access_control.sh
@@ -226,7 +226,7 @@ LOG_ADMIN_USER=${LOG_ADMIN_USER:-admin}
 LOG_ADMIN_PW=${LOG_ADMIN_PW:-admin}
 
 if oc get users "$LOG_ADMIN_USER" > /dev/null 2>&1 ; then
-    Using existing admin user $LOG_ADMIN_USER 2>&1 | artifact_out
+    echo Using existing admin user $LOG_ADMIN_USER 2>&1 | artifact_out
 else
     os::log::info Creating cluster-admin user $LOG_ADMIN_USER
     current_project="$( oc project -q )"
@@ -236,6 +236,7 @@ else
 fi
 oc adm policy add-cluster-role-to-user cluster-admin $LOG_ADMIN_USER 2>&1 | artifact_out
 os::log::info workaround access_control admin failures - sleep 60 seconds to allow system to process cluster role setting
+sleep 60
 oc policy can-i '*' '*' --user=$LOG_ADMIN_USER 2>&1 | artifact_out
 oc get users 2>&1 | artifact_out
 

--- a/test/cluster/rollout.sh
+++ b/test/cluster/rollout.sh
@@ -16,11 +16,12 @@
 source "$(dirname "${BASH_SOURCE[0]}" )/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
+LOGGING_NS=${LOGGING_NS:-openshift-logging}
 FLUENTD_WAIT_TIME=$(( 2 * minute ))
 
 os::test::junit::declare_suite_start "test/cluster/rollout"
 
-os::cmd::expect_success "oc project logging"
+os::cmd::expect_success "oc project ${LOGGING_NS}"
 
 os::log::info "Checking for DeploymentConfigurations..."
 for deploymentconfig in ${OAL_EXPECTED_DEPLOYMENTCONFIGS}; do

--- a/test/debug_level_logs.sh
+++ b/test/debug_level_logs.sh
@@ -6,17 +6,10 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::test::junit::declare_suite_start "test/debug_level_logs"
 
-get_logmessage() {
-    logmessage="$1"
-}
 get_logmessage2() {
     logmessage2="$1"
+    cat > $ARTIFACT_DIR/debug_level_logs-ops.json
 }
 
-es_pod=$( get_es_pod es )
-es_ops_pod=$( get_es_pod es-ops )
-es_ops_pod=${es_ops_pod:-$es_pod}
-
-TEST_REC_PRIORITY=debug wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es ${es_ops_pod} /.operations.*/_count -X POST -d '$qs' | jq '.count > 0'"
+TEST_REC_PRIORITY=debug wait_for_fluentd_to_catch_up '' get_logmessage2
+os::cmd::expect_success "cat $ARTIFACT_DIR/debug_level_logs-ops.json | jq '.hits.hits[0]._source.level == \"debug\"'"

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -247,16 +247,16 @@ os::log::info Starting fluentd-forward test at $( date )
 # make sure fluentd is working normally
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
-os::cmd::expect_success wait_for_fluentd_to_catch_up
+wait_for_fluentd_to_catch_up
 
 # FORWARDCNT must be 1 or 2
 FORWARDCNT=1
 create_forwarding_fluentd
 update_current_fluentd
-os::cmd::expect_success wait_for_fluentd_to_catch_up
+wait_for_fluentd_to_catch_up
 cleanup
 
 FORWARDCNT=2
 create_forwarding_fluentd
 update_current_fluentd
-os::cmd::expect_success "wait_for_fluentd_to_catch_up '' '' 2"
+wait_for_fluentd_to_catch_up '' '' 2

--- a/test/json-parsing.sh
+++ b/test/json-parsing.sh
@@ -36,13 +36,12 @@ os::log::info Starting json-parsing test at $( date )
 # logging should parse this and make "type", "tags", "statusCode", etc. as top level fields
 # the "message" field should contain only the embedded message and not the entire JSON blob
 
-get_uuid_es() {
+get_record() {
     json_test_uuid=$1
+    cp $2 $ARTIFACT_DIR/json-parsing-output.json
 }
-wait_for_fluentd_to_catch_up get_uuid_es
-
-es_pod=$( get_es_pod es )
+wait_for_fluentd_to_catch_up get_record
 
 os::log::info Testing if record is in correct format . . .
-os::cmd::expect_success "curl_es $es_pod /project.logging.*/_search?q=message:$json_test_uuid | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/json-parsing-output.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-json-parsing.py $json_test_uuid"

--- a/test/mux-client-mode.sh
+++ b/test/mux-client-mode.sh
@@ -8,9 +8,9 @@ os::util::environment::use_sudo
 
 # only works if there is a mux dc
 if oc get dc/logging-mux > /dev/null 2>&1 ; then
-    os::log::debug "$( oc get dc/logging-mux )"
+    oc get dc/logging-mux 2>&1 | artifact_out
 else
-    os::log::debug "$( oc get dc/logging-mux )"
+    oc get dc/logging-mux 2>&1 | artifact_out
     os::log::info dc/logging-mux is not present - skipping test
     exit 0
 fi
@@ -28,19 +28,19 @@ cleanup() {
     set +e
     # dump the pods before we restart them
     if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod > $ARTIFACT_DIR/$fpod.log 2>&1
+        oc logs $fpod > $ARTIFACT_DIR/mux-client-mode-fluentd-pod.log 2>&1
     fi
     if [ -n "${muxpod:-}" ] ; then
-        oc logs $muxpod > $ARTIFACT_DIR/$muxpod.log 2>&1
+        oc logs $muxpod > $ARTIFACT_DIR/mux-client-mode-mux-pod.log 2>&1
     fi
     if [ -n "${saveds:-}" ] ; then
         if [ -f "${saveds:-}" ]; then
-            os::log::debug "$( oc replace --force -f $saveds )"
+            oc replace --force -f $saveds 2>&1 | artifact_out
             rm -f $saveds
         fi
     fi
     os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true || : )"
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
@@ -52,8 +52,8 @@ reset_fluentd_daemonset() {
   muxcerts=$( oc get daemonset logging-fluentd -o yaml | egrep muxcerts ) || :
 
   if [ "$muxcerts" = "" ]; then
-      os::log::debug "$( oc set volumes daemonset/logging-fluentd --add --overwrite \
-               --name=muxcerts --default-mode=0400 -t secret -m /etc/fluent/muxkeys --secret-name logging-mux 2>&1 )"
+      oc set volumes daemonset/logging-fluentd --add --overwrite \
+               --name=muxcerts --default-mode=0400 -t secret -m /etc/fluent/muxkeys --secret-name logging-mux 2>&1 | artifact_out
   fi
 }
 
@@ -61,24 +61,24 @@ fpod=$( get_running_pod fluentd )
 muxpod=$( get_running_pod mux )
 
 os::log::info configure fluentd to use MUX_CLIENT_MODE=minimal - verify logs get through
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
 os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-os::log::debug "$( oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=minimal )"
+oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=minimal 2>&1 | artifact_out
 reset_fluentd_daemonset
 os::cmd::expect_success flush_fluentd_pos_files
-os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up
 
 # configure fluentd to use MUX_CLIENT_MODE=maximal - verify logs get through
 os::log::info configure fluentd to use MUX_CLIENT_MODE=maximal - verify logs get through
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
 os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-os::log::debug "$( oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=maximal )"
+oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=maximal 2>&1 | artifact_out
 reset_fluentd_daemonset
 os::cmd::expect_success flush_fluentd_pos_files
-os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up

--- a/test/pre-upgrade.sh
+++ b/test/pre-upgrade.sh
@@ -6,16 +6,14 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::test::junit::declare_suite_start "test/pre-upgrade"
 
-LOGGING_NS=:${LOGGING_NS:-openshift-logging}
-
 #store log messages to file so post-upgrade can validate their existence
 store_upgrade_test_uuid() {
+    cp $2 $ARTIFACT_DIR/pre-upgrade-record.json
     upgrade_test_uuid="$1"
     echo "$1" > /tmp/upgrade_test_uuid
 }
 
 wait_for_fluentd_to_catch_up store_upgrade_test_uuid
-es_pod=$( get_es_pod es )
 
-os::cmd::expect_success "curl_es $es_pod /project.logging.*/_search?q=message:$upgrade_test_uuid | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/pre-upgrade-record.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-json-parsing.py $upgrade_test_uuid"

--- a/test/remote-syslog.sh
+++ b/test/remote-syslog.sh
@@ -401,9 +401,13 @@ sudo egrep "${mymessage}$" /var/log/messages 2>&1 | artifact_out || :
 
 mymessage="testKibanaMessage-"$( date +%Y%m%d-%H%M%S )
 add_test_message $mymessage
-es_pod=$( get_es_pod es )
-qs='{"query":{"match_phrase":{"message":"'"${mymessage}"'"}}}'
-if os::cmd::try_until_text "curl_es ${es_pod} /project.logging.*/_count -X POST -d '$qs' | get_count_from_json" 1 $MUX_WAIT_TIME; then
+fullmsg="GET /${mymessage} 404 "
+qs='{"query":{"bool":{"filter":{"match_phrase":{"message":"'"${fullmsg}"'"}},"must":{"term":{"kubernetes.container_name":"kibana"}}}}}'
+case "${LOGGING_NS}" in
+default|openshift|openshift-*) logging_index=".operations.*" ; es_pod=$es_ops_pod ;;
+*) logging_index="project.${LOGGING_NS}.*" ;;
+esac
+if os::cmd::try_until_text "curl_es ${es_pod} /${logging_index}/_count -X POST -d '$qs' | get_count_from_json" 1 $MUX_WAIT_TIME; then
     artifact_log good - found $mymessage
 else
     artifact_log failed - not found $mymessage
@@ -411,4 +415,3 @@ fi
 os::cmd::try_until_text "sudo egrep \"/${mymessage}\" /var/log/messages" ".*${mymessage}.*" $MUX_WAIT_TIME
 artifact_log Log test message by kibana: $mymessage
 sudo egrep "/${mymessage}" /var/log/messages 2>&1 | artifact_out || :
-

--- a/test/upgrade.sh
+++ b/test/upgrade.sh
@@ -10,12 +10,13 @@ LOGGING_NS=${LOGGING_NS:-openshift-logging}
 
 get_upgrade_test_uuid() {
     upgrade_test_uuid="$1"
+    cp $2 $ARTIFACT_DIR/upgrade-record.json
 }
 
 wait_for_fluentd_to_catch_up get_upgrade_test_uuid
 es_pod=$( get_es_pod es )
 
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search?q=message:$upgrade_test_uuid | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/upgrade-record.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-json-parsing.py $upgrade_test_uuid"
 
 old_upgrade_test_uuid=$(cat /tmp/upgrade_test_uuid)

--- a/test/viaq-data-model.sh
+++ b/test/viaq-data-model.sh
@@ -114,20 +114,19 @@ fpod=$( get_running_pod fluentd )
 
 get_logmessage() {
     logmessage="$1"
+    cp $2 $ARTIFACT_DIR/viaq-data-model-test.json
 }
 get_logmessage2() {
     logmessage2="$1"
+    cp $2 $ARTIFACT_DIR/viaq-data-model-test-ops.json
 }
 
 # TEST 1
 # default - undefined fields are passed through untouched
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-fullmsg="GET /${logmessage} 404 "
-qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test1"
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test-ops.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test1"
 
 # these fields are present because it is a kibana log message - we
@@ -143,12 +142,9 @@ os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-fullmsg="GET /${logmessage} 404 "
-qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test2"
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test-ops.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test2"
 
 # TEST 3
@@ -158,13 +154,9 @@ os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-fullmsg="GET /${logmessage} 404 "
-qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test3"
-
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test-ops.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test3"
 
 # TEST 4
@@ -174,13 +166,9 @@ os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-fullmsg="GET /${logmessage} 404 "
-qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test4"
-
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test-ops.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test4"
 
 # TEST 5
@@ -198,13 +186,9 @@ if [ -n "$is_maximal" ] ; then
 fi
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-fullmsg="GET /${logmessage} 404 "
-qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test5 allow_empty"
-
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test-ops.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test5 allow_empty"
 
 if [ -n "$is_maximal" ] ; then


### PR DESCRIPTION
hack for docker hostmount problem
    better way to save and restore bulk config

    fix mux-client-mode by tagging raw messages with .raw suffix
    The code relies on the presence of the @timestamp field to indicate that
    the record has already been processed into the common data model. However,
    some applications actually use the @timestamp field, so we need some other
    way to denote to mux that the message is a raw message. Change fluentd
    running in MUX_CLIENT_MODE=minimal to add a `.raw` tag suffix to
    unprocessed log records before sending to mux so that mux will know the
    record is not processed.

    ignore errors for bulk index monitor
    improve mux-client-mode debugging
    efficiently look for source record to report missing records
    add errorfile to rsyslog test to capture elasticsearch errors
    add bulk indexing stats monitor to CI
    fix bugs
    sleep to allow cluster admin user to be processed; more debugging