### PR TITLE
Modify the check for logging namespace

### DIFF
--- a/hack/logging-dump.sh
+++ b/hack/logging-dump.sh
@@ -46,11 +46,11 @@ then
     components=( "kibana" "fluentd" "curator" "elasticsearch" "project_info" )
 fi
 
-if [ -z "${NAMESPACE:-''}" ] && oc get project logging > /dev/null ; then
+if [ -z "${NAMESPACE:-}" ] && oc get project logging > /dev/null ; then
   NAMESPACE=logging
 fi
 
-NAMESPACE=${NAMESPACE:-logging}
+NAMESPACE=${NAMESPACE:-openshift-logging}
 
 DATE=`date +%Y%m%d_%H%M%S`
 target=${target:-"logging-$DATE"}

--- a/hack/logging-dump.sh
+++ b/hack/logging-dump.sh
@@ -50,7 +50,7 @@ if [ -z "${NAMESPACE:-''}" ] && oc get project logging > /dev/null ; then
   NAMESPACE=logging
 fi
 
-NAMESPACE=${NAMESPACE:-openshift-logging}
+NAMESPACE=${NAMESPACE:-logging}
 
 DATE=`date +%Y%m%d_%H%M%S`
 target=${target:-"logging-$DATE"}


### PR DESCRIPTION
Signed-off-by: root <root@sgaikwad.pnq.csb>
The script fails to capture the logging data if the namespace openshift-logging does not exist or if the user is not a member of this project.
[root@master ~]# ./logging-dump.sh
error: You are not a member of project "openshift-logging".

[root@master ~]# ./logging-dump.sh
error: A project named "openshift-logging" does not exist on "https://master.example.com:443"

Changed the code to use logging namespace as a default namespace to capture the information.
