### PR TITLE
[es5.x] fix several CI issues; merge with latest master; bulk reject test fixes

### DIFF
--- a/docs/log-drivers-and-throttling.md
+++ b/docs/log-drivers-and-throttling.md
@@ -3,15 +3,19 @@ Introduction
 
 When Fluentd is collecting node logs, the main sources are the system logs from
 the journal, and container logs, the source of which depends on the `docker
---log-driver` configuration:
+--log-driver` configuration and container runtime selection configured in
+`/etc/origin/node/node-config.yaml` mounted to fluentd container from host:
 
 * `journald` - container logs are written to the journal and denoted with the
   `CONTAINER_NAME` field
 * `json-file` - container logs are made available in `/var/log/containers`
   (through a long a complicated process of several layers of symlinks).
+* `cri-o` - container logs are made available in `/var/log/containers` similarly
+  to the `json-file` log driver but with cri-o format
 
 Fluentd will always read system logs from the journal, and will always read
-container logs from both `journald` and `json-file`.
+container logs from `journald` or `/var/log/containers`, latter formatted either
+as `json` or `cri-o`.
 
 ### JSON file container log parameters ###
 
@@ -27,6 +31,21 @@ reading from where it left off if the Fluentd pod is restarted.
 * `JSON_FILE_READ_FROM_HEAD` - default `true` - if `false`, start reading from
 the tail/end of the file.  If the `JSON_FILE_POS_FILE` exists and has an
 entry for this file, the `JSON_FILE_READ_FROM_HEAD` setting is ignored.
+
+### cri-o container log parameters ###
+
+Just like the json-file, these are provided for documentation purposes only.
+Do not set these unless you know what you are doing.
+
+* `CRIO_FILE_PATH` - default `/var/log/containers/*.log` - full path and filename
+match pattern for docker json-file log driver logs
+* `CRIO_FILE_POS_FILE` - default `/var/log/es-containers.log.pos` - full path
+and filename for the Fluentd `in_tail` position file.  This file should be on a
+persistent volume (e.g. bind mounted from the host) so that Fluentd can resume
+reading from where it left off if the Fluentd pod is restarted.
+* `CRIO_FILE_READ_FROM_HEAD` - default `true` - if `false`, start reading from
+the tail/end of the file.  If the `CRIO_FILE_POS_FILE` exists and has an
+entry for this file, the `CRIO_FILE_READ_FROM_HEAD` setting is ignored.
 
 ### journal parameters ###
 

--- a/docs/mux-logging-service.md
+++ b/docs/mux-logging-service.md
@@ -112,7 +112,7 @@ You will need the mux CA cert and shared_key.  You can obtain them from the
 logging cluster like this:
 
     # oc login --username=system:admin
-    # oc project logging
+    # oc project openshift-logging # if that project doesn't exist, use logging
     # oc get secret logging-mux --template='{{index .data "ca"}}' | base64 -d > mux-ca.crt
     # oc get secret logging-mux --template='{{index .data "shared_key"}}' | \
       base64 -d > mux-shared-key

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -66,7 +66,7 @@ Could not find the requested service "'origin-master'":
 This message may be ignored.  You may now log in and confirm your deployment:
 
 ```
-$ oc project logging
+$ oc project openshift-logging # if that project doesn't exist, use logging
 $ oc get pods
 NAME                          READY     STATUS    RESTARTS   AGE
 logging-curator-13-kbdj0      1/1       Running   1          1d

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -7,3 +7,16 @@ Following are the environment variables that can be modified to adjust the confi
 | Environment Variable | Description |Example|
 |----------------------|-------------|---|
 | `OCP_OPERATIONS_PROJECTS`| The list of project or patterns for which messages will be sent to the operations indices|`OCP_OPERATIONS_PROJECTS="default openshift openshift-"`
+
+## Cri-o Formatted Container Logs
+In order to enable cri-o logs parsing, it is necessary to mount 
+`node-config.yaml` from the host inside the fluentd container to this path:
+```
+/etc/origin/node/node-config.yaml
+```
+If EFK stack is deployed using openshift-ansible 3.9 or later, the mount point
+is already created by ansible installer.
+
+Fluentd pod on startup automatically determines from the `node-config.yaml`
+whether to setup `in_tail` plugin to parse cri-o formatted logs in
+`/var/log/containers/*` or whether to read logs from docker driver.

--- a/fluentd/configs.d/filter-pre-mux-client-retag-raw.conf
+++ b/fluentd/configs.d/filter-pre-mux-client-retag-raw.conf
@@ -1,0 +1,13 @@
+# used only for MUX_CLIENT_MODE=minimal for json-file logs
+# tag messages as raw (i.e. unprocessed) and send to @OUTPUT label
+<match kubernetes.**>
+  @type rewrite_tag_filter
+  @label @OUTPUT
+  rewriterule1 message .+ ${tag}.raw
+  rewriterule2 message !.+ ${tag}.raw
+</match>
+
+<match **>
+  @type relabel
+  @label @OUTPUT
+</match>

--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -1,7 +1,7 @@
 <match **>
   @type secure_forward
   log_level "#{ENV['FORWARD_INPUT_LOG_LEVEL'] || ENV['LOG_LEVEL'] || 'warn'}"
-  self_hostname ${HOSTNAME}
+  self_hostname ${hostname}
   shared_key "#{File.open('/etc/fluent/muxkeys/shared_key') do |f| f.readline end.rstrip}"
   secure yes
   ca_cert_path /etc/fluent/muxkeys/ca

--- a/fluentd/configs.d/input-post-forward-mux.conf
+++ b/fluentd/configs.d/input-post-forward-mux.conf
@@ -38,6 +38,12 @@
     </record>
   </filter>
 
+  # raw record from fluentd MUX_CLIENT_MODE=minimal - redirect to normal processing
+  <match **.raw>
+    @type relabel
+    @label @INGRESS
+  </match>
+
   # If this record has already been processed by fluentd e.g. in MUX_CLIENT_MODE=maximal
   # then tag it so that it will be processed by the k8s plugin (if kubernetes.**)
   # and have an index name created for it, but it will not be processed in any other way.

--- a/fluentd/configs.d/openshift/filter-post-genid.conf
+++ b/fluentd/configs.d/openshift/filter-post-genid.conf
@@ -1,0 +1,6 @@
+# generate ids at source mitigate creating duplicate records
+# requires fluent-plugin-elasticsearch
+<filter **>
+  @type elasticsearch_genid
+  hash_id_key viaq_msg_id
+</filter>

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -4,6 +4,7 @@
       port "#{ENV['ES_PORT']}"
       scheme https
       target_index_key viaq_index_name
+      id_key viaq_msg_id
       remove_keys viaq_index_name
       user fluentd
       password changeme

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -4,6 +4,7 @@
       port "#{ENV['OPS_PORT']}"
       scheme https
       target_index_key viaq_index_name
+      id_key viaq_msg_id
       remove_keys viaq_index_name
       user fluentd
       password changeme

--- a/fluentd/configs.d/user/fluent.conf
+++ b/fluentd/configs.d/user/fluent.conf
@@ -33,4 +33,3 @@
   # no post - applications.conf matches everything left
 ##
 </label>
-

--- a/fluentd/configs.d/user/secure-forward.conf
+++ b/fluentd/configs.d/user/secure-forward.conf
@@ -1,8 +1,8 @@
 # <store>
 #   @type secure_forward
 
-#   self_hostname ${HOSTNAME}
-#   shared_key ${SECRET_STRING}
+#   self_hostname ${hostname} # ${hostname} is a placeholder.
+#   shared_key <shared_key_between_forwarder_and_forwardee>
 
 #   secure yes
 #   enable_strict_verification yes

--- a/fluentd/generate_throttle_configs.rb
+++ b/fluentd/generate_throttle_configs.rb
@@ -163,7 +163,7 @@ def create_default_docker(excluded)
   pos_file "#{ENV[POS_FILE] || '/var/log/es-containers.log.pos'}"
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
-  format json
+  format #{ENV['USE_CRIO'] == 'true' ? '/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/' : 'json'}
   keep_time_key true
   read_from_head "#{ENV[READ_FROM_HEAD] || 'true'}"
   exclude_path #{excluded}

--- a/fluentd/generate_throttle_configs.rb
+++ b/fluentd/generate_throttle_configs.rb
@@ -21,12 +21,16 @@ DEFAULT_OPS_PROJECTS = !ENV['OCP_OPERATIONS_PROJECTS'].nil? ? ENV['OCP_OPERATION
 DEFAULT_FILENAME = "/etc/fluent/configs.d/user/throttle-config.yaml"
 
 VALID_SETTINGS = {"read_lines_limit" => "number"}
+CONTAINER_LOG_DRIVER = ENV['USE_CRIO'] == 'true' ? "CRIO" : "JSON_FILE"
+POS_FILE = CONTAINER_LOG_DRIVER + "_POS_FILE"
+READ_FROM_HEAD = CONTAINER_LOG_DRIVER + "_READ_FROM_HEAD"
+CONT_LOGS_PATH = CONTAINER_LOG_DRIVER + "_PATH"
 
-def json_pos_file
-  ENV['JSON_FILE_POS_FILE'] || '/var/log/es-containers.log.pos'
+def cont_pos_file
+  ENV[POS_FILE] || '/var/log/es-containers.log.pos'
 end
 
-def get_json_pos_file_name(name)
+def get_cont_pos_file_name(name)
   return "/var/log/es-container-#{name}.log.pos"
 end
 
@@ -80,7 +84,7 @@ end
 
 ## This will copy the pos entries from the throttle configs back to the default pos file
 def revert_throttle()
-  get_all_throttle_files.each { |file_name| move_pos_file_project_entry(file_name, json_pos_file, '.*') }
+  get_all_throttle_files.each { |file_name| move_pos_file_project_entry(file_name, cont_pos_file, '.*') }
 end
 
 def seed_file(file_name, project)
@@ -91,10 +95,10 @@ def seed_file(file_name, project)
     ## openshift-* is a protected project prefix -- so users would not be able to create
     ## a project that starts with this. Guard taken to prevent possible collision with a
     ## user created project 'operations'
-    pos_file = get_json_pos_file_name('openshift-operations')
+    pos_file = get_cont_pos_file_name('openshift-operations')
   else
     path = get_project_pattern(project)
-    pos_file = get_json_pos_file_name(project)
+    pos_file = get_cont_pos_file_name(project)
   end
 
   File.open(file_name, 'w') { |file|
@@ -109,8 +113,8 @@ def seed_file(file_name, project)
   }
 
   # Set up the initial pos file in case we had already read from container files
-  move_pos_file_project_entry(json_pos_file, pos_file, project) unless project.eql?('.operations')
-  DEFAULT_OPS_PROJECTS.each{ |ops_project| move_pos_file_project_entry(json_pos_file, pos_file, ops_project) } if project.eql?('.operations')
+  move_pos_file_project_entry(cont_pos_file, pos_file, project) unless project.eql?('.operations')
+  DEFAULT_OPS_PROJECTS.each{ |ops_project| move_pos_file_project_entry(cont_pos_file, pos_file, ops_project) } if project.eql?('.operations')
 end
 
 def write_to_file(project, key, value)
@@ -139,7 +143,7 @@ def close_file(project)
   tag kubernetes.*
   format json
   keep_time_key true
-  read_from_head "#{ENV['JSON_FILE_READ_FROM_HEAD'] || 'true'}"
+  read_from_head "#{ENV[READ_FROM_HEAD] || 'true'}"
 </source>
     CONF
   } if File.exist?(file_name)
@@ -155,13 +159,13 @@ def create_default_docker(excluded)
 <source>
   @type tail
   @label @INGRESS
-  path "#{ENV['JSON_FILE_PATH'] || '/var/log/containers/*.log'}"
-  pos_file "#{ENV['JSON_FILE_POS_FILE'] || '/var/log/es-containers.log.pos'}"
+  path "#{ENV[CONT_LOGS_PATH] || '/var/log/containers/*.log'}"
+  pos_file "#{ENV[POS_FILE] || '/var/log/es-containers.log.pos'}"
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
   format json
   keep_time_key true
-  read_from_head "#{ENV['JSON_FILE_READ_FROM_HEAD'] || 'true'}"
+  read_from_head "#{ENV[READ_FROM_HEAD] || 'true'}"
   exclude_path #{excluded}
 </source>
     CONF

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -214,12 +214,12 @@ if [ $TOTAL_LIMIT -le 0 ]; then
     exit 1
 fi
 
-# If secure-forward outputs are configured, add them to NUM_OUTPUTS.
-sec_forward_files=$( grep -l "@type *secure_forward" ${CFG_DIR}/*/* 2> /dev/null || : )
-for afile in ${sec_forward_files} ; do
+# If forward and secure-forward outputs are configured, add them to NUM_OUTPUTS.
+forward_files=$( grep -l "@type .*forward" ${CFG_DIR}/*/* 2> /dev/null || : )
+for afile in ${forward_files} ; do
     file=$( basename $afile )
     if [ "$file" != "${mux_client_filename:-}" ]; then
-        grep "@type *secure_forward" $afile | while read -r line; do
+        grep "@type .*forward" $afile | while read -r line; do
             if [ $( expr "$line" : "^ *#" ) -eq 0 ]; then
                 NUM_OUTPUTS=$( expr $NUM_OUTPUTS + 1 )
             fi

--- a/hack/README-dump.md
+++ b/hack/README-dump.md
@@ -117,7 +117,7 @@ Examples:
 
 ### Common
 * Nodes description `oc describe nodes`
-* Project `oc get project logging -o yaml`
+* Project `oc get project openshift-logging -o yaml`
 * Pod Logs compressed. Use `find . -name "*.xz" | while read filename; do xz -d $filename; done`
 * Docker image version `/root/buildinfo/Dockerfile-openshift3*`
 * Environment variables

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -9,16 +9,20 @@ function cleanup() {
 }
 trap "cleanup" EXIT
 
-tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
+tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin-"}"
 docker_suffix='.centos7'
 if [ "${RELEASE_STREAM:-}" = 'prod' ] ; then
   docker_suffix=''
 fi
 dockerfile="Dockerfile${docker_suffix}"
 
-OS_BUILD_IMAGE_ARGS="-f fluentd/${dockerfile}" os::build::image "${tag_prefix}-logging-fluentd"             fluentd
-OS_BUILD_IMAGE_ARGS="-f elasticsearch/${dockerfile}" os::build::image "${tag_prefix}-logging-elasticsearch" elasticsearch
-OS_BUILD_IMAGE_ARGS="-f kibana/${dockerfile}" os::build::image "${tag_prefix}-logging-kibana"               kibana
-OS_BUILD_IMAGE_ARGS="-f curator/${dockerfile}" os::build::image "${tag_prefix}-logging-curator"             curator
-OS_BUILD_IMAGE_ARGS="-f kibana-proxy/${dockerfile}" os::build::image "${tag_prefix}-logging-auth-proxy"     kibana-proxy
-OS_BUILD_IMAGE_ARGS="-f eventrouter/${dockerfile}" os::build::image "${tag_prefix}-logging-eventrouter"     eventrouter
+curbranch=$( git rev-parse --abbrev-ref HEAD )
+if [ "${curbranch:-master}" = es5.x ] ; then
+  name_suf="5"
+fi
+OS_BUILD_IMAGE_ARGS="-f fluentd/${dockerfile}" os::build::image "${tag_prefix}logging-fluentd"             fluentd
+OS_BUILD_IMAGE_ARGS="-f elasticsearch/${dockerfile}" os::build::image "${tag_prefix}logging-elasticsearch${name_suf:-}" elasticsearch
+OS_BUILD_IMAGE_ARGS="-f kibana/${dockerfile}" os::build::image "${tag_prefix}logging-kibana${name_suf:-}"               kibana
+OS_BUILD_IMAGE_ARGS="-f curator/${dockerfile}" os::build::image "${tag_prefix}logging-curator${name_suf:-}"             curator
+OS_BUILD_IMAGE_ARGS="-f kibana-proxy/${dockerfile}" os::build::image "${tag_prefix}logging-auth-proxy"     kibana-proxy
+OS_BUILD_IMAGE_ARGS="-f eventrouter/${dockerfile}" os::build::image "${tag_prefix}logging-eventrouter"     eventrouter

--- a/hack/logging-dump.sh
+++ b/hack/logging-dump.sh
@@ -99,7 +99,7 @@ check_project_info() {
   echo -- Project Description
   oc get namespace ${NAMESPACE} -o yaml > $project_folder/logging-project
   echo -- Events
-  oc get events > $project_folder/events
+  oc get events --sort-by='.lastTimestamp' > $project_folder/events
   # Don't get the secrets content for security reasons
   echo -- Secrets
   oc describe secrets > $project_folder/secrets

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -32,11 +32,16 @@ if [[ -z "${source_tag}" ]]; then
   source_tag="latest"
 fi
 
+curbranch=$( git rev-parse --abbrev-ref HEAD )
+if [[ "${curbranch:-master}" == es5.x ]] ; then
+  name_suffix="5"
+fi
+
 images=(
-  ${PREFIX}logging-curator
+  ${PREFIX}logging-curator${name_suffix:-}
   ${PREFIX}logging-fluentd
-  ${PREFIX}logging-elasticsearch
-  ${PREFIX}logging-kibana
+  ${PREFIX}logging-elasticsearch${name_suffix:-}
+  ${PREFIX}logging-kibana${name_suffix:-}
   ${PREFIX}logging-auth-proxy
   ${PREFIX}logging-eventrouter
 )

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -26,7 +26,7 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 
 LOGGING_NS=openshift-logging
-if oc get project logging -o name > /dev/null ; then
+if oc get project logging -o name > /dev/null && [ $(oc get dc -n logging -o name | wc -l) -gt 0 ] ; then
     LOGGING_NS=logging
 fi
 export LOGGING_NS

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -52,6 +52,10 @@ oc set -n ${LOGGING_NS} env ds/logging-fluentd COLLECT_JOURNAL_DEBUG_LOGS=true
 # MUX_CLIENT_MODE=maximal or minimal
 oc set -n ${LOGGING_NS} env ds/logging-fluentd MUX_CLIENT_MODE-
 
+# Starting in 3.10, we can no longer mount /var/lib/docker/containers
+oc volumes -n ${LOGGING_NS} ds/logging-fluentd --overwrite --add -t hostPath \
+    --name=varlibdockercontainers -m /var/lib/docker --path=/var/lib/docker || :
+
 # start a fluentd performance monitor
 monitor_fluentd_top() {
     # assumes running in a subshell

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -101,11 +101,11 @@ monitor_es_bulk_stats() {
         esopspod=${esopspod:-$espod}
         if [ -n "${espod}" ] ; then
             date -Ins >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1
-            curl_es $espod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs,bqs >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1
+            curl_es $espod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs,bqs >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1 || :
         fi
         if [ -n "${esopspod}" -a "${espod}" != "${esopspod}" ] ; then
             date -Ins >> $ARTIFACT_DIR/monitor_es_bulk_stats-es-ops.log 2>&1
-            curl_es $esopspod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs,bqs >> $ARTIFACT_DIR/monitor_es_bulk_stats-es-ops.log 2>&1
+            curl_es $esopspod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs,bqs >> $ARTIFACT_DIR/monitor_es_bulk_stats-es-ops.log 2>&1 || :
         fi
         sleep $interval
     done

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -63,7 +63,7 @@ monitor_fluentd_top() {
     export KUBECONFIG=$ARTIFACT_DIR/monitor_fluentd_top.kubeconfig
     oc project $LOGGING_NS > /dev/null
     while true ; do
-        fpod=$( get_running_pod fluentd )
+        fpod=$( get_running_pod fluentd 2> /dev/null ) || :
         if [ -n "$fpod" ] ; then
             oc exec $fpod -- top -b -d 1 || :
         else
@@ -101,10 +101,10 @@ monitor_es_bulk_stats() {
     local interval=5
     cp $KUBECONFIG $ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
     export KUBECONFIG=$ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
-    oc project $LOGGING_NS > /dev/null
+    oc project ${LOGGING_NS} > /dev/null
     while true ; do
-        local espod=$( get_es_pod es ) || :
-        local esopspod=$( get_es_pod es-ops ) || :
+        local espod=$( get_es_pod es 2> /dev/null ) || :
+        local esopspod=$( get_es_pod es-ops 2> /dev/null ) || :
         esopspod=${esopspod:-$espod}
         if [ -n "${espod}" ] ; then
             date -Ins >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -102,17 +102,19 @@ monitor_es_bulk_stats() {
     cp $KUBECONFIG $ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
     export KUBECONFIG=$ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
     oc project ${LOGGING_NS} > /dev/null
+    es_ver=$( get_es_major_ver )
+    bulk_url=$( get_bulk_thread_pool_url $es_ver "v" c r a q s qs )
     while true ; do
         local espod=$( get_es_pod es 2> /dev/null ) || :
         local esopspod=$( get_es_pod es-ops 2> /dev/null ) || :
         esopspod=${esopspod:-$espod}
         if [ -n "${espod}" ] ; then
             date -Ins >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1
-            curl_es $espod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs,bqs >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1 || :
+            curl_es $espod "${bulk_url}" >> $ARTIFACT_DIR/monitor_es_bulk_stats-es.log 2>&1 || :
         fi
         if [ -n "${esopspod}" -a "${espod}" != "${esopspod}" ] ; then
             date -Ins >> $ARTIFACT_DIR/monitor_es_bulk_stats-es-ops.log 2>&1
-            curl_es $esopspod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs,bqs >> $ARTIFACT_DIR/monitor_es_bulk_stats-es-ops.log 2>&1 || :
+            curl_es $esopspod "${bulk_url}" >> $ARTIFACT_DIR/monitor_es_bulk_stats-es-ops.log 2>&1 || :
         fi
         sleep $interval
     done

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -61,7 +61,7 @@ monitor_fluentd_top() {
     # assumes running in a subshell
     cp $KUBECONFIG $ARTIFACT_DIR/monitor_fluentd_top.kubeconfig
     export KUBECONFIG=$ARTIFACT_DIR/monitor_fluentd_top.kubeconfig
-    oc project logging > /dev/null
+    oc project $LOGGING_NS > /dev/null
     while true ; do
         fpod=$( get_running_pod fluentd )
         if [ -n "$fpod" ] ; then
@@ -99,6 +99,9 @@ monitor_journal_lograte() {
 
 monitor_es_bulk_stats() {
     local interval=5
+    cp $KUBECONFIG $ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
+    export KUBECONFIG=$ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
+    oc project $LOGGING_NS > /dev/null
     while true ; do
         local espod=$( get_es_pod es ) || :
         local esopspod=$( get_es_pod es-ops ) || :
@@ -148,7 +151,7 @@ function run_suite() {
 	suite_name="$( basename "${test}" '.sh' )"
 	os::test::junit::declare_suite_start "test/setup/${suite_name}"
 	os::cmd::expect_success "oc login -u system:admin"
-	os::cmd::expect_success "oc project logging"
+	os::cmd::expect_success "oc project $LOGGING_NS"
 	os::test::junit::declare_suite_end
 
 	os::log::info "Logging test suite ${suite_name} started at $( date )"

--- a/hack/testing/rsyslog/elasticsearch.conf.j2
+++ b/hack/testing/rsyslog/elasticsearch.conf.j2
@@ -1,0 +1,48 @@
+template(name="viaq_template" type="list") {
+    property(name="$!all-json-plain")
+}
+
+template(name="index_pattern" type="list") {
+    property(name="$.viaq_index_prefix")
+    property(name="$!@timestamp" dateFormat="rfc3339" position.from="1" position.to="4")
+    constant(value=".")
+    property(name="$!@timestamp" dateFormat="rfc3339" position.from="6" position.to="7")
+    constant(value=".")
+    property(name="$!@timestamp" dateFormat="rfc3339" position.from="9" position.to="10")
+}
+
+{%if openshift_logging_use_ops | default(False) %}
+if $.viaq_index_prefix startswith "project." then {
+{% endif %}
+action(
+    type="omelasticsearch"
+    server="{{ elasticsearch_server_host | default('logging-es') }}"
+    serverport="{{ elasticsearch_server_port | default(9200) }}"
+    template="viaq_template"
+    searchIndex="index_pattern"
+    dynSearchIndex="on"
+    searchType="com.redhat.viaq.common"
+    bulkmode="on"
+    usehttps="on"
+    tls.cacert="/etc/rsyslog.d/viaq/es-ca.crt"
+    tls.mycert="/etc/rsyslog.d/viaq/es-cert.pem"
+    tls.myprivkey="/etc/rsyslog.d/viaq/es-key.pem"
+)
+{%if openshift_logging_use_ops | default(False) %}
+} else {
+action(
+    type="omelasticsearch"
+    server="{{ elasticsearch_ops_server_host | default('logging-es-ops') }}"
+    serverport="{{ elasticsearch_ops_server_port | default(9200) }}"
+    template="viaq_template"
+    searchIndex="index_pattern"
+    dynSearchIndex="on"
+    searchType="com.redhat.viaq.common"
+    bulkmode="on"
+    usehttps="on"
+    tls.cacert="/etc/rsyslog.d/viaq/es-ca.crt"
+    tls.mycert="/etc/rsyslog.d/viaq/es-cert.pem"
+    tls.myprivkey="/etc/rsyslog.d/viaq/es-key.pem"
+)
+}
+{% endif %}

--- a/hack/testing/rsyslog/elasticsearch.conf.j2
+++ b/hack/testing/rsyslog/elasticsearch.conf.j2
@@ -11,7 +11,7 @@ template(name="index_pattern" type="list") {
     property(name="$!@timestamp" dateFormat="rfc3339" position.from="9" position.to="10")
 }
 
-{%if openshift_logging_use_ops | default(False) %}
+{% if openshift_logging_use_ops | default(False) %}
 if $.viaq_index_prefix startswith "project." then {
 {% endif %}
 action(
@@ -27,8 +27,9 @@ action(
     tls.cacert="/etc/rsyslog.d/viaq/es-ca.crt"
     tls.mycert="/etc/rsyslog.d/viaq/es-cert.pem"
     tls.myprivkey="/etc/rsyslog.d/viaq/es-key.pem"
+    errorfile="/var/lib/rsyslog/es-errors.log"
 )
-{%if openshift_logging_use_ops | default(False) %}
+{% if openshift_logging_use_ops | default(False) %}
 } else {
 action(
     type="omelasticsearch"
@@ -43,6 +44,7 @@ action(
     tls.cacert="/etc/rsyslog.d/viaq/es-ca.crt"
     tls.mycert="/etc/rsyslog.d/viaq/es-cert.pem"
     tls.myprivkey="/etc/rsyslog.d/viaq/es-key.pem"
+    errorfile="/var/lib/rsyslog/es-errors.log"
 )
 }
 {% endif %}

--- a/hack/testing/rsyslog/k8s_container_name.rulebase
+++ b/hack/testing/rsyslog/k8s_container_name.rulebase
@@ -1,0 +1,2 @@
+rule=:%k8s_prefix:char-to:_%_%container_name:char-to:.%.%container_hash:char-to:_%_%pod_name:char-to:_%_%namespace_name:char-to:_%_%not_used_1:char-to:_%_%not_used_2:rest%
+rule=:%k8s_prefix:char-to:_%_%container_name:char-to:_%_%pod_name:char-to:_%_%namespace_name:char-to:_%_%not_used_1:char-to:_%_%not_used_2:rest%

--- a/hack/testing/rsyslog/k8s_filename.rulebase
+++ b/hack/testing/rsyslog/k8s_filename.rulebase
@@ -1,0 +1,2 @@
+rule=:/var/log/containers/%pod_name:char-to:.%.%container_hash:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log
+rule=:/var/log/containers/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log

--- a/hack/testing/rsyslog/mmk8s.conf.j2
+++ b/hack/testing/rsyslog/mmk8s.conf.j2
@@ -1,0 +1,26 @@
+module(load="mmkubernetes" kubernetesurl="{{ openshift_master_api_url | default('https://localhost:8443') }}"
+       filenamerulebase="/etc/rsyslog.d/viaq/k8s_filename.rulebase"
+       containerrulebase="/etc/rsyslog.d/viaq/k8s_container_name.rulebase"
+       tls.cacert="/etc/rsyslog.d/viaq/mmk8s.ca.crt"
+       tokenfile="/etc/rsyslog.d/viaq/mmk8s.token" annotation_match=["."])
+
+input(type="imfile" file="/var/log/containers/*.log" tag="kubernetes" addmetadata="on")
+
+if ((strlen($!CONTAINER_NAME) > 0) and (strlen($!CONTAINER_ID_FULL) > 0)) or
+    ($!metadata!filename startswith "/var/log/containers/") then {
+    if $!metadata!filename startswith "/var/log/containers/" then {
+        action(type="mmjsonparse" cookie="") # parse entire message as json
+    }
+    action(type="mmkubernetes")
+    if strlen($!MESSAGE) > 0 then {
+        action(type="mmnormalize" ruleBase="/etc/rsyslog.d/viaq/parse_json.rulebase" variable="$!MESSAGE")
+    } else {
+        action(type="mmnormalize" ruleBase="/etc/rsyslog.d/viaq/parse_json.rulebase" variable="$!log")
+    }
+    # there is no way to move these fields to be top level fields in rscript in 8.24
+    # do it in mmk8s for now - revisit when upgrade to 8.33
+#    foreach ($.ii in $!payload) do {
+#        set $! = $.ii;
+#    }
+#    unset $!payload;
+}

--- a/hack/testing/rsyslog/normalize_level.json
+++ b/hack/testing/rsyslog/normalize_level.json
@@ -1,0 +1,20 @@
+{ "version" : 1,
+  "nomatch" : "UNKNOWN",
+  "type" : "string",
+  "table" : [
+    {"index": "emerg", "value": "emerg"},
+    {"index": "panic", "value": "emerg"},
+    {"index": "alert", "value": "alert"},
+    {"index": "crit", "value": "crit"},
+    {"index": "critical", "value": "crit"},
+    {"index": "err", "value": "err"},
+    {"index": "error", "value": "err"},
+    {"index": "warning", "value": "warning"},
+    {"index": "warn", "value": "warning"},
+    {"index": "notice", "value": "notice"},
+    {"index": "info", "value": "info"},
+    {"index": "debug", "value": "debug"},
+    {"index": "trace", "value": "trace"},
+    {"index": "unknown", "value": "unknown"}
+  ]
+}

--- a/hack/testing/rsyslog/parse_json.rulebase
+++ b/hack/testing/rsyslog/parse_json.rulebase
@@ -1,0 +1,1 @@
+rule=:%payload:json%

--- a/hack/testing/rsyslog/playbook.yaml
+++ b/hack/testing/rsyslog/playbook.yaml
@@ -1,0 +1,219 @@
+---
+- name: install/configure prerequisites
+  hosts: all
+  gather_facts: true
+  tasks:
+  - name: get patched rsyslog repo
+    get_url:
+      url: https://copr.fedorainfracloud.org/coprs/rmeggins/rsyslog/repo/epel-7/rmeggins-rsyslog-epel-7.repo
+      dest: /etc/yum.repos.d/rmeggins-rsyslog-epel-7.repo
+      mode: 0444
+    when: use_mmk8s | default(True)
+
+  - name: install prereqs
+    yum: state=latest name={{ item }}
+    with_items:
+    - rsyslog
+    - rsyslog-mmnormalize
+    - rsyslog-mmjsonparse
+    - nmap-ncat
+    - systemd-python
+    - rsyslog-elasticsearch
+    - policycoreutils
+    - checkpolicy
+    - policycoreutils-python
+
+  - name: pkgs
+    yum: state=latest name={{ item }}
+    with_items:
+    - rsyslog-mmkubernetes
+    when: use_mmk8s | default(True)
+
+  - name: create rsyslog viaq subdir
+    file: path=/etc/rsyslog.d/viaq state=directory mode=0700
+
+  - name: get fluentd secret for token and k8s CA
+    shell: |
+      for name in $( oc get -n {{ openshift_logging_namespace }} sa aggregated-logging-fluentd -o jsonpath='{.secrets[*].name}' ) ; do
+        case $name in
+        *-fluentd-token-*) echo $name ; break ;;
+        esac
+      done
+    register: fluentdsecret
+    when: use_mmk8s | default(True)
+
+  - name: get fluentd token
+    command: >
+      oc extract -n {{ openshift_logging_namespace }} secret/{{ fluentdsecret.stdout }} --keys=token --to=-
+    register: fluentdtoken
+    when: use_mmk8s | default(True)
+
+  - name: get fluentd CA cert for k8s
+    command: >
+      oc extract -n {{ openshift_logging_namespace }} secret/{{ fluentdsecret.stdout }} --keys=ca.crt --to=-
+    register: fluentdcak8s
+    when: use_mmk8s | default(True)
+
+  - name: install token file
+    copy: content={{ fluentdtoken.stdout }} dest=/etc/rsyslog.d/viaq/mmk8s.token mode=0400
+    when: use_mmk8s | default(True)
+
+  - name: install CA cert file
+    copy: content={{ fluentdcak8s.stdout }} dest=/etc/rsyslog.d/viaq/mmk8s.ca.crt mode=0400
+    when: use_mmk8s | default(True)
+
+  - name: get k8s api url from node kubeconfig
+    shell: |
+      found=0
+      for file in /etc/origin/node/system\:node\:*.kubeconfig ; do
+        if [ -f "$file" ] ; then
+          oc --config="$file" config view -o jsonpath='{.clusters[0].cluster.server}'
+          found=1
+          break
+        fi
+      done
+      if [ $found -eq 0 -a -d /var/lib/origin/openshift.local.config ] ; then
+        for file in /var/lib/origin/openshift.local.config/node*/*.kubeconfig ; do
+          if [ -f "$file" ] ; then
+            oc --config="$file" config view -o jsonpath='{.clusters[0].cluster.server}'
+            break
+          fi
+        done
+      fi
+    register: k8s_api_url
+    when:
+    - openshift_master_api_url is not defined
+    - use_mmk8s | default(True)
+
+  - name: set k8s api url
+    set_fact:
+      openshift_master_api_url: "{{ k8s_api_url.stdout }}"
+    when:
+    - openshift_master_api_url is not defined
+    - use_mmk8s | default(True)
+
+  - name: install template config files
+    template: src={{ item }}.j2 dest=/etc/rsyslog.d/viaq/{{ item }} mode=0400
+    with_items:
+    - mmk8s.conf
+    when: use_mmk8s | default(True)
+
+  - name: get fluentd CA cert for ES
+    command: >
+      oc extract -n {{ openshift_logging_namespace }} secret/logging-fluentd --keys=ca --to=-
+    register: fluentdcaes
+
+  - name: get fluentd client cert for ES
+    command: >
+      oc extract -n {{ openshift_logging_namespace }} secret/logging-fluentd --keys=cert --to=-
+    register: fluentdcert
+
+  - name: get fluentd client key for ES
+    command: >
+      oc extract -n {{ openshift_logging_namespace }} secret/logging-fluentd --keys=key --to=-
+    register: fluentdkey
+
+  - name: get es ip addr
+    command: >
+      oc get -n {{ openshift_logging_namespace }} endpoints logging-es -o jsonpath='{.subsets[0].addresses[0].ip}'
+    register: esip
+    when: elasticsearch_server_host is not defined
+
+  - name: setup host alias for es ip
+    shell: |
+      if grep -q '^{{ esip.stdout }} .* logging-es$' ; then
+        echo already have alias logging-es for {{ esip.stdout }}
+      else
+        sudo sed -i '/^{{ esip.stdout }}/d' /etc/hosts
+        sudo sed -i '/ logging-es$/d' /etc/hosts
+        echo {{ esip.stdout }} logging-es | sudo tee -a /etc/hosts
+      fi
+    when: elasticsearch_server_host is not defined
+
+  - name: install ES CA cert file
+    copy: content={{ fluentdcaes.stdout }} dest=/etc/rsyslog.d/viaq/es-ca.crt mode=0400
+
+  - name: install ES client cert file
+    copy: content={{ fluentdcert.stdout }} dest=/etc/rsyslog.d/viaq/es-cert.pem mode=0400
+
+  - name: install ES client key file
+    copy: content={{ fluentdkey.stdout }} dest=/etc/rsyslog.d/viaq/es-key.pem mode=0400
+
+  - name: handle es-ops
+    when: openshift_logging_use_ops
+    block:
+    - name: get es-ops ip addr
+      command: >
+        oc get -n {{ openshift_logging_namespace }} endpoints logging-es-ops -o jsonpath='{.subsets[0].addresses[0].ip}'
+      register: esopsip
+      when: elasticsearch_ops_server_host is not defined
+
+    - name: setup host alias for es-ops ip
+      shell: |
+        if grep -q '^{{ esopsip.stdout }} .* logging-es-ops$' ; then
+          echo already have alias logging-es-ops for {{ esopsip.stdout }}
+        else
+          sudo sed -i '/^{{ esopsip.stdout }}/d' /etc/hosts
+          sudo sed -i '/ logging-es-ops$/d' /etc/hosts
+          echo {{ esopsip.stdout }} logging-es-ops | sudo tee -a /etc/hosts
+        fi
+      when: elasticsearch_server_host is not defined
+
+  - name: install template config files
+    template: src={{ item }}.j2 dest=/etc/rsyslog.d/viaq/{{ item }} mode=0400
+    with_items:
+    - elasticsearch.conf
+
+  - name: install config files
+    copy: src={{ item }} dest=/etc/rsyslog.d/viaq/{{ item }} mode=0400
+    with_items:
+    - normalize_level.json
+    - prio_to_level.json
+    - viaq_formatting.conf
+    - k8s_filename.rulebase
+    - k8s_container_name.rulebase
+    - parse_json.rulebase
+
+  - name: install main viaq config file
+    copy: src={{ item }} dest=/etc/rsyslog.d/{{ item }} mode=0400
+    with_items:
+    - viaq_main.conf
+
+  - name: copy selinux policy files
+    copy: src={{ item }} dest=/root/ mode=0400
+    with_items:
+    - rsyslog2k8s.te
+    - rsyslog2es.te
+    - varlibdockercont.te
+    - rsyslogaccessnssdb.te
+
+  - name: build policy
+    shell: |
+      cd /root
+      sysmods=$( semodule -l | awk '{print $1}' )
+      for mod in varlibdockercont rsyslog2k8s rsyslogaccessnssdb rsyslog2es ; do
+        if echo "$sysmods" | grep -q $mod ; then
+          echo using existing selinux module $mod
+        elif [ -f ${mod}.te ] ; then
+          checkmodule -M -m -o ${mod}.mod ${mod}.te
+          semodule_package -o ${mod}.pp -m ${mod}.mod
+          semodule -i ${mod}.pp
+        fi
+      done
+
+  # openshift devenv is very noisy - need to increase rsyslog limits for imjournal
+  - name: Update rsyslog.conf imjournal
+    lineinfile:
+      dest: /etc/rsyslog.conf
+      regexp: '^(\$ModLoad imjournal|module\(load="imjournal")'
+      line: 'module(load="imjournal" StateFile="imjournal.state" UsePidFromSystem="on" RateLimit.Burst="{{ imjournal_ratelimit_burst|default(1000000) }}" RateLimit.Interval="{{ imjournal_ratelimit_interval|default(10) }}" PersistStateInterval="1000")'
+      backup: yes
+
+  - name: Comment out rsyslog.conf IMJournalStateFile
+    lineinfile:
+      dest: /etc/rsyslog.conf
+      regexp: '^\$IMJournalStateFile|^#\$IMJournalStateFile'
+      line: '#$IMJournalStateFile imjournal.state'
+
+  - name: restart rsyslog
+    systemd: name=rsyslog state=restarted

--- a/hack/testing/rsyslog/playbook.yaml
+++ b/hack/testing/rsyslog/playbook.yaml
@@ -65,20 +65,17 @@
   - name: get k8s api url from node kubeconfig
     shell: |
       found=0
-      for file in /etc/origin/node/system\:node\:*.kubeconfig ; do
+      for file in /etc/origin/node/node*.kubeconfig \
+        /etc/origin/node/system\:node\:*.kubeconfig \
+        /var/lib/origin/openshift.local.config/node*/*.kubeconfig ; do
         if [ -f "$file" ] ; then
           oc --config="$file" config view -o jsonpath='{.clusters[0].cluster.server}'
           found=1
           break
         fi
       done
-      if [ $found -eq 0 -a -d /var/lib/origin/openshift.local.config ] ; then
-        for file in /var/lib/origin/openshift.local.config/node*/*.kubeconfig ; do
-          if [ -f "$file" ] ; then
-            oc --config="$file" config view -o jsonpath='{.clusters[0].cluster.server}'
-            break
-          fi
-        done
+      if [ $found -eq 0 ] ; then
+          oc config view -o jsonpath='{.clusters[0].cluster.server}'
       fi
     register: k8s_api_url
     when:

--- a/hack/testing/rsyslog/prio_to_level.json
+++ b/hack/testing/rsyslog/prio_to_level.json
@@ -1,0 +1,16 @@
+{ "version" : 1,
+  "nomatch" : "UNKNOWN",
+  "type" : "array",
+  "table" : [
+    {"index": 0, "value": "emerg"},
+    {"index": 1, "value": "alert"},
+    {"index": 2, "value": "crit"},
+    {"index": 3, "value": "err"},
+    {"index": 4, "value": "warning"},
+    {"index": 5, "value": "notice"},
+    {"index": 6, "value": "info"},
+    {"index": 7, "value": "debug"},
+    {"index": 8, "value": "trace"},
+    {"index": 9, "value": "unknown"}
+  ]
+}

--- a/hack/testing/rsyslog/rsyslog2es.te
+++ b/hack/testing/rsyslog/rsyslog2es.te
@@ -1,0 +1,13 @@
+
+module rsyslog2es 1.0;
+
+require {
+	type syslogd_t;
+	type unreserved_port_t;
+	class tcp_socket name_connect;
+}
+
+#============= syslogd_t ==============
+
+#!!!! This avc can be allowed using the boolean 'nis_enabled'
+allow syslogd_t unreserved_port_t:tcp_socket name_connect;

--- a/hack/testing/rsyslog/rsyslog2k8s.te
+++ b/hack/testing/rsyslog/rsyslog2k8s.te
@@ -1,0 +1,13 @@
+
+module rsyslog2k8s 1.0;
+
+require {
+	type syslogd_t;
+	type http_port_t;
+	class tcp_socket name_connect;
+}
+
+#============= syslogd_t ==============
+
+#!!!! This avc can be allowed using the boolean 'nis_enabled'
+allow syslogd_t http_port_t:tcp_socket name_connect;

--- a/hack/testing/rsyslog/rsyslogaccessnssdb.te
+++ b/hack/testing/rsyslog/rsyslogaccessnssdb.te
@@ -1,0 +1,13 @@
+
+module rsyslogaccessnssdb 1.0;
+
+require {
+	type syslogd_t;
+	type cert_t;
+	class dir write;
+	class file write;
+}
+
+#============= syslogd_t ==============
+allow syslogd_t cert_t:dir write;
+allow syslogd_t cert_t:file write;

--- a/hack/testing/rsyslog/valgrind-rsyslogd
+++ b/hack/testing/rsyslog/valgrind-rsyslogd
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+QUIETMODE="-q"
+outputfile=/var/log/rsyslogd.$$.vg
+
+valgrind $QUIETMODE --trace-children=yes --tool=memcheck --track-origins=yes \
+  --read-var-info=yes --leak-check=yes --leak-resolution=high \
+  --num-callers=50 --log-file=$outputfile rsyslogd "$@"

--- a/hack/testing/rsyslog/varlibdockercont.te
+++ b/hack/testing/rsyslog/varlibdockercont.te
@@ -1,0 +1,13 @@
+
+module varlibdockercont 1.0;
+
+require {
+    type syslogd_t;
+    type container_var_lib_t;
+    class dir { search getattr };
+    class file { getattr ioctl open read };
+}
+
+#============= syslogd_t ==============
+allow syslogd_t container_var_lib_t:dir { search getattr };
+allow syslogd_t container_var_lib_t:file { getattr ioctl open read };

--- a/hack/testing/rsyslog/viaq_formatting.conf
+++ b/hack/testing/rsyslog/viaq_formatting.conf
@@ -1,0 +1,253 @@
+lookup_table(name="prio_to_level" file="/etc/rsyslog.d/viaq/prio_to_level.json")
+lookup_table(name="normalize_level" file="/etc/rsyslog.d/viaq/normalize_level.json")
+
+template(name="cnvt_to_viaq_timestamp" type="list") {
+    property(name="TIMESTAMP" dateFormat="rfc3339")
+}
+
+if strlen($!_MACHINE_ID) > 0 then {
+    # convert from imjournal to viaq systemd format
+    # https://github.com/ViaQ/elasticsearch-templates/blob/master/namespaces/systemd.yml
+
+    set $!systemd!t!MACHINE_ID = $!_MACHINE_ID;
+    unset $!_MACHINE_ID;
+    if strlen($!CODE_FILE) > 0 then {
+        set $!systemd!u!CODE_FILE = $!CODE_FILE;
+    }
+    unset $!CODE_FILE;
+    if strlen($!CODE_FUNCTION) > 0 then {
+        set $!systemd!u!CODE_FUNCTION = $!CODE_FUNCTION;
+    }
+    unset $!CODE_FUNCTION;
+    if strlen($!CODE_LINE) > 0 then {
+        set $!systemd!u!CODE_LINE = $!CODE_LINE;
+    }
+    unset $!CODE_LINE;
+    if strlen($!ERRNO) > 0 then {
+        set $!systemd!u!ERRNO = $!ERRNO;
+    }
+    unset $!ERRNO;
+    if strlen($!MESSAGE_ID) > 0 then {
+        set $!systemd!u!MESSAGE_ID = $!MESSAGE_ID;
+    }
+    unset $!MESSAGE_ID;
+    if strlen($!RESULT) > 0 then {
+        set $!systemd!u!RESULT = $!RESULT;
+    }
+    unset $!RESULT;
+    if strlen($!UNIT) > 0 then {
+        set $!systemd!u!UNIT = $!UNIT;
+    }
+    unset $!UNIT;
+    if strlen($!SYSLOG_FACILITY) > 0 then {
+        set $!systemd!u!SYSLOG_FACILITY = $!SYSLOG_FACILITY;
+    }
+    unset $!SYSLOG_FACILITY;
+    if strlen($!SYSLOG_IDENTIFIER) > 0 then {
+        set $!systemd!u!SYSLOG_IDENTIFIER = $!SYSLOG_IDENTIFIER;
+    }
+    unset $!SYSLOG_IDENTIFIER;
+    if strlen($!SYSLOG_PID) > 0 then {
+        set $!systemd!u!SYSLOG_PID = $!SYSLOG_PID;
+    }
+    unset $!SYSLOG_PID;
+    if strlen($!_AUDIT_LOGINUID) > 0 then {
+        set $!systemd!t!AUDIT_LOGINUID = $!_AUDIT_LOGINUID;
+    }
+    unset $!_AUDIT_LOGINUID;
+    if strlen($!_AUDIT_SESSION) > 0 then {
+        set $!systemd!t!AUDIT_SESSION = $!_AUDIT_SESSION;
+    }
+    unset $!_AUDIT_SESSION;
+    if strlen($!_BOOT_ID) > 0 then {
+        set $!systemd!t!BOOT_ID = $!_BOOT_ID;
+    }
+    unset $!_BOOT_ID;
+    if strlen($!_CAP_EFFECTIVE) > 0 then {
+        set $!systemd!t!CAP_EFFECTIVE = $!_CAP_EFFECTIVE;
+    }
+    unset $!_CAP_EFFECTIVE;
+    if strlen($!_CMDLINE) > 0 then {
+        set $!systemd!t!CMDLINE = $!_CMDLINE;
+    }
+    unset $!_CMDLINE;
+    if strlen($!_COMM) > 0 then {
+        set $!systemd!t!COMM = $!_COMM;
+    }
+    unset $!_COMM;
+    if strlen($!_EXE) > 0 then {
+        set $!systemd!t!EXE = $!_EXE;
+    }
+    unset $!_EXE;
+    if strlen($!_GID) > 0 then {
+        set $!systemd!t!GID = $!_GID;
+    }
+    unset $!_GID;
+    if strlen($!_HOSTNAME) > 0 then {
+        set $!systemd!t!HOSTNAME = $!_HOSTNAME;
+    }
+    unset $!_HOSTNAME;
+    if strlen($!_PID) > 0 then {
+        set $!systemd!t!PID = $!_PID;
+    }
+    unset $!_PID;
+    if strlen($!_SELINUX_CONTEXT) > 0 then {
+        set $!systemd!t!SELINUX_CONTEXT = $!_SELINUX_CONTEXT;
+    }
+    unset $!_SELINUX_CONTEXT;
+    if strlen($!_SOURCE_REALTIME_TIMESTAMP) > 0 then {
+        set $!systemd!t!SOURCE_REALTIME_TIMESTAMP = $!_SOURCE_REALTIME_TIMESTAMP;
+    }
+    unset $!_SOURCE_REALTIME_TIMESTAMP;
+    if strlen($!_SYSTEMD_CGROUP) > 0 then {
+        set $!systemd!t!SYSTEMD_CGROUP = $!_SYSTEMD_CGROUP;
+    }
+    unset $!_SYSTEMD_CGROUP;
+    if strlen($!_SYSTEMD_OWNER_UID) > 0 then {
+        set $!systemd!t!SYSTEMD_OWNER_UID = $!_SYSTEMD_OWNER_UID;
+    }
+    unset $!_SYSTEMD_OWNER_UID;
+    if strlen($!_SYSTEMD_SESSION) > 0 then {
+        set $!systemd!t!SYSTEMD_SESSION = $!_SYSTEMD_SESSION;
+    }
+    unset $!_SYSTEMD_SESSION;
+    if strlen($!_SYSTEMD_SLICE) > 0 then {
+        set $!systemd!t!SYSTEMD_SLICE = $!_SYSTEMD_SLICE;
+    }
+    unset $!_SYSTEMD_SLICE;
+    if strlen($!_SYSTEMD_UNIT) > 0 then {
+        set $!systemd!t!SYSTEMD_UNIT = $!_SYSTEMD_UNIT;
+    }
+    unset $!_SYSTEMD_UNIT;
+    if strlen($!_SYSTEMD_USER_UNIT) > 0 then {
+        set $!systemd!t!SYSTEMD_USER_UNIT = $!_SYSTEMD_USER_UNIT;
+    }
+    unset $!_SYSTEMD_USER_UNIT;
+    if strlen($!_TRANSPORT) > 0 then {
+        set $!systemd!t!TRANSPORT = $!_TRANSPORT;
+    }
+    unset $!_TRANSPORT;
+    if strlen($!_UID) > 0 then {
+        set $!systemd!t!UID = $!_UID;
+    }
+    unset $!_UID;
+    if strlen($!_KERNEL_DEVICE) > 0 then {
+        set $!systemd!k!KERNEL_DEVICE = $!_KERNEL_DEVICE;
+    }
+    unset $!_KERNEL_DEVICE;
+    if strlen($!_KERNEL_SUBSYSTEM) > 0 then {
+        set $!systemd!k!KERNEL_SUBSYSTEM = $!_KERNEL_SUBSYSTEM;
+    }
+    unset $!_KERNEL_SUBSYSTEM;
+    if strlen($!_UDEV_SYSNAME) > 0 then {
+        set $!systemd!k!UDEV_SYSNAME = $!_UDEV_SYSNAME;
+    }
+    unset $!_UDEV_SYSNAME;
+    if strlen($!_UDEV_DEVNODE) > 0 then {
+        set $!systemd!k!UDEV_DEVNODE = $!_UDEV_DEVNODE;
+    }
+    unset $!_UDEV_DEVNODE;
+    if strlen($!_UDEV_DEVLINK) > 0 then {
+        set $!systemd!k!UDEV_DEVLINK = $!_UDEV_DEVLINK;
+    }
+    unset $!_UDEV_DEVLINK;
+
+    # these fields require special handling
+    if strlen($!level) == 0 then {
+        if strlen($!PRIORITY) > 0 then {
+            set $!level = lookup("prio_to_level", $!PRIORITY);
+        }
+    }
+    unset $!PRIORITY;
+    if strlen($!message) == 0 then {
+        if strlen($!MESSAGE) > 0 then {
+            set $!message = $!MESSAGE;
+        } else {
+            if strlen($!log) > 0 then {
+                set $!message = $!log;
+            }
+        }
+    }
+    unset $!MESSAGE;
+    if strlen($!hostname) == 0 then {
+        if strlen($!kubernetes!host) > 0 then {
+            set $!hostname = $!kubernetes!host;
+        } else {
+            if strlen($!_HOSTNAME) > 0 then {
+                set $!hostname = $!_HOSTNAME;
+            } else {
+                set $!hostname = $hostname;
+            }
+        }
+    }
+    unset $!_HOSTNAME;
+    if strlen($!@timestamp) == 0 then {
+        # need to figure out how to convert _SOURCE_REALTIME_TIMESTAMP
+        # in the meantime . . .
+        set $!@timestamp = exec_template('cnvt_to_viaq_timestamp');
+    }
+    unset $!_SOURCE_REALTIME_TIMESTAMP;
+    unset $!__REALTIME_TIMESTAMP;
+    # end of block that converts imjournal to viaq format
+} else if strlen($!kubernetes!namespace_name) > 0 then {
+    # clean up container log formatting
+    if (strlen($!message) == 0) and (strlen($!log) > 0) then {
+        set $!message = $!log;
+    }
+    if strlen($!hostname) == 0 then {
+        if strlen($!kubernetes!host) > 0 then {
+            set $!hostname = $!kubernetes!host;
+        } else {
+            set $!hostname = $hostname;
+        }
+    }
+    if strlen($!@timestamp) == 0 then {
+        if strlen($!time) > 0 then {
+            set $!@timestamp = $!time;
+        } else {
+            set $!@timestamp = $TIMESTAMP;
+        }
+    }
+}
+
+# normalize level
+if strlen($!level) > 0 then {
+    set $.lclevel = tolower($!level);
+    set $.normlevel = lookup("normalize_level", $.lclevel);
+    if $.normlevel == "unknown" then {
+        continue # do nothing - preserve original value
+    } else {
+        set $!level = $.normlevel;
+    }
+    unset $.lclevel;
+    unset $.normlevel;
+} else {
+    if $!stream == "stdout" then {
+        set $!level = "info";
+    } else {
+        if $!stream == "stderr" then {
+            set $!level = "err";
+        } else {
+            set $!level = "unknown";
+        }
+    }
+}
+
+# add eventrouter
+# add pipeline_metadata
+
+if strlen($!kubernetes!namespace_name) > 0 then {
+    # see if this is an operations namespace
+    if ($!kubernetes!namespace_name == "default") or ($!kubernetes!namespace_name == "openshift") or
+        ($!kubernetes!namespace_name startswith "openshift-") then {
+            set $.viaq_index_prefix = ".operations.";
+    } else {
+        if strlen($!kubernetes!namespace_id) > 0 then {
+            set $.viaq_index_prefix = "project." & $!kubernetes!namespace_name & "." & $!kubernetes!namespace_id & ".";
+        } else {
+            set $.viaq_index_prefix = ".orphaned.";
+        }
+    } 
+} else {
+    set $.viaq_index_prefix = ".operations.";
+}

--- a/hack/testing/rsyslog/viaq_main.conf
+++ b/hack/testing/rsyslog/viaq_main.conf
@@ -1,0 +1,10 @@
+module(load="mmjsonparse")
+module(load="mmnormalize")
+module(load="omelasticsearch")
+module(load="imfile" mode="inotify")
+
+$IncludeConfig /etc/rsyslog.d/viaq/mmk8s.conf
+
+$IncludeConfig /etc/rsyslog.d/viaq/viaq_formatting.conf
+
+$IncludeConfig /etc/rsyslog.d/viaq/elasticsearch.conf

--- a/hack/testing/templates/test-template.yaml
+++ b/hack/testing/templates/test-template.yaml
@@ -29,7 +29,7 @@ objects:
         done
 parameters:
 - description: Namespace name to create pod in
-  value: logging
+  value: openshift-logging
   name: TEST_NAMESPACE_NAME
 - description: name of test pod to create
   value: test

--- a/hack/testing/test-zzz-rsyslog.sh
+++ b/hack/testing/test-zzz-rsyslog.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/zzz-rsyslog.sh

--- a/hack/testing/test-zzzz-bulk-rejection.sh
+++ b/hack/testing/test-zzzz-bulk-rejection.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/zzzz-bulk_rejection.sh

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -4,7 +4,7 @@ if ! type -t os::log::info > /dev/null ; then
     source "${OS_O_A_L_DIR:-..}/hack/lib/init.sh"
 fi
 
-LOGGING_NS=${LOGGING_NS:-logging}
+LOGGING_NS=${LOGGING_NS:-openshift-logging}
 
 function get_es_dcs() {
     oc get dc --selector logging-infra=elasticsearch -o name
@@ -205,7 +205,7 @@ function wait_for_fluentd_to_catch_up() {
     local uuid_es_ops=$( uuidgen | sed 's/[-]//g' )
     local expected=${3:-1}
     local timeout=${TIMEOUT:-600}
-    local project=${4:-logging}
+    local project=${4:-openshift-logging}
     local priority=${TEST_REC_PRIORITY:-info}
 
     wait_for_fluentd_ready
@@ -239,14 +239,18 @@ function wait_for_fluentd_to_catch_up() {
     artifact_log added es-ops message $uuid_es_ops
 
     local rc=0
+    logging_index=".operations.*"
+    if [ ${LOGGING_NS} = "logging" ] ; then
+      logging_index="project.logging.*"
+    fi
 
     # poll for logs to show up
     local qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-    if os::cmd::try_until_text "curl_es ${es_pod} /project.logging.*/_count -X POST -d '$qs' | get_count_from_json" $expected $(( timeout * second )); then
-        os::log::debug good - $FUNCNAME: found $expected record project logging for \'$fullmsg\'
+    if os::cmd::try_until_text "curl_es ${es_pod} /${logging_index}/_count -X POST -d '$qs' | get_count_from_json" $expected $(( timeout * second )); then
+        os::log::debug good - $FUNCNAME: found $expected record $logging_index for \'$fullmsg\'
     else
-        os::log::error $FUNCNAME: not found $expected record project logging for \'$fullmsg\' after $timeout seconds
-        os::log::debug "$( curl_es ${es_pod} /project.logging.*/_search -X POST -d "$qs" )"
+        os::log::error $FUNCNAME: not found $expected record $logging_index for \'$fullmsg\' after $timeout seconds
+        os::log::debug "$( curl_es ${es_pod} /${logging_index}/_search -X POST -d "$qs" )"
         if [ -s $ARTIFACT_DIR/es_out.txt ] ; then
             os::log::error "$( cat $ARTIFACT_DIR/es_out.txt )"
         else

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -331,11 +331,12 @@ internal_artifact_log() {
     echo \[${ts}\] "$@" >> $extra_artifacts
 }
 artifact_log() {
-    internal_artifact_log "$( date --rfc-3339=ns )" "$@"
+    internal_artifact_log "$( date +%Y-%m-%dT%H:%M:%S.%3N%z )" "$@"
 }
 artifact_out() {
-    local ts="$( date --rfc-3339=ns )"
-    while read line ; do
+    local ts="$( date +%Y-%m-%dT%H:%M:%S.%3N%z )"
+    local line
+    while IFS= read -r line ; do
         internal_artifact_log "${ts}" "$line"
     done
 }

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -205,7 +205,7 @@ function wait_for_fluentd_to_catch_up() {
     local uuid_es_ops=$( uuidgen | sed 's/[-]//g' )
     local expected=${3:-1}
     local timeout=${TIMEOUT:-600}
-    local project=${4:-openshift-logging}
+    local appsproject=${4:-$LOGGING_NS}
     local priority=${TEST_REC_PRIORITY:-info}
 
     wait_for_fluentd_ready
@@ -222,13 +222,13 @@ function wait_for_fluentd_to_catch_up() {
                 BEGIN{RS="";FS="\n"};
                 $0 ~ es {print > es_out; found += 1};
                 $0 ~ es_ops {print > es_ops_out; found += 1};
-                {if (found == 2) {exit 0}}' & checkpids=$!
+                {if (found == 2) {exit 0}}' > /dev/null 2>&1 & checkpids=$!
     else
         sudo journalctl -f -o export | \
             awk -v es_ops=$uuid_es_ops -v es_ops_out=$ARTIFACT_DIR/es_ops_out.txt '
                 BEGIN{RS="";FS="\n"};
-                $0 ~ es_ops {print > es_ops_out; exit 0}' & checkpids=$!
-        while ! sudo grep -b -n "$fullmsg" /var/log/containers/*.log > $ARTIFACT_DIR/es_out.txt ; do
+                $0 ~ es_ops {print > es_ops_out; exit 0}' > /dev/null 2>&1 & checkpids=$!
+        while ! sudo find /var/log/containers -name \*.log -exec grep -b -n "$fullmsg" {} /dev/null \; > $ARTIFACT_DIR/es_out.txt ; do
             sleep 1
         done & checkpids="$checkpids $!"
     fi
@@ -239,15 +239,19 @@ function wait_for_fluentd_to_catch_up() {
     artifact_log added es-ops message $uuid_es_ops
 
     local rc=0
-    logging_index=".operations.*"
-    if [ ${LOGGING_NS} = "logging" ] ; then
-      logging_index="project.logging.*"
-    fi
+    local qs='{"query":{"bool":{"filter":{"match_phrase":{"message":"'"${fullmsg}"'"}},"must":{"term":{"kubernetes.container_name":"kibana"}}}}}'
+    case "${appsproject}" in
+    default|openshift|openshift-*) logging_index=".operations.*" ; es_pod=$es_ops_pod ;;
+    *) logging_index="project.${appsproject}.*" ;;
+    esac
 
     # poll for logs to show up
-    local qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
     if os::cmd::try_until_text "curl_es ${es_pod} /${logging_index}/_count -X POST -d '$qs' | get_count_from_json" $expected $(( timeout * second )); then
         os::log::debug good - $FUNCNAME: found $expected record $logging_index for \'$fullmsg\'
+        if [ -n "${1:-}" ] ; then
+            curl_es ${es_pod} "/${logging_index}/_search" -X POST -d "$qs" | jq . > $ARTIFACT_DIR/apps.json
+            $1 $uuid_es $ARTIFACT_DIR/apps.json
+        fi
     else
         os::log::error $FUNCNAME: not found $expected record $logging_index for \'$fullmsg\' after $timeout seconds
         os::log::debug "$( curl_es ${es_pod} /${logging_index}/_search -X POST -d "$qs" )"
@@ -268,9 +272,13 @@ function wait_for_fluentd_to_catch_up() {
 
     qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${uuid_es_ops}"'"}}}'
     if os::cmd::try_until_text "curl_es ${es_ops_pod} /.operations.*/_count -X POST -d '$qs' | get_count_from_json" $expected $(( timeout * second )); then
-        os::log::debug good - $FUNCNAME: found $expected record project .operations for $uuid_es_ops
+        os::log::debug good - $FUNCNAME: found $expected record .operations for $uuid_es_ops
+        if [ -n "${2:-}" ] ; then
+            curl_es ${es_ops_pod} "/.operations.*/_search" -X POST -d "$qs" | jq . > $ARTIFACT_DIR/ops.json
+            $2 $uuid_es_ops $ARTIFACT_DIR/ops.json
+        fi
     else
-        os::log::error $FUNCNAME: not found $expected record project .operations for $uuid_es_ops after $timeout seconds
+        os::log::error $FUNCNAME: not found $expected record .operations for $uuid_es_ops after $timeout seconds
         os::log::debug "$( curl_es ${es_ops_pod} /.operations.*/_search -X POST -d "$qs" )"
         os::log::error "Checking journal for $uuid_es_ops..."
         if [ -s $ARTIFACT_DIR/es_ops_out.txt ] ; then
@@ -286,12 +294,6 @@ function wait_for_fluentd_to_catch_up() {
     kill $checkpids > /dev/null 2>&1 || :
     kill -9 $checkpids > /dev/null 2>&1 || :
 
-    if [ -n "${1:-}" ] ; then
-        $1 $uuid_es
-    fi
-    if [ -n "${2:-}" ] ; then
-        $2 $uuid_es_ops
-    fi
     local endtime=`date +%s`
     os::log::debug END wait_for_fluentd_to_catch_up took `expr $endtime - $starttime` seconds at `date -u --rfc-3339=ns`
     return $rc
@@ -305,7 +307,7 @@ docker_uses_journal() {
     # if "log-driver" is set in /etc/docker/daemon.json, assume that it is
     # authoritative
     # otherwise, look for /etc/sysconfig/docker
-    if type -p docker > /dev/null && sudo docker info | grep -q 'Logging Driver: journald' ; then
+    if type -p docker > /dev/null && sudo docker info 2>&1 | grep -q 'Logging Driver: journald' ; then
         return 0
     elif sudo grep -q '^[^#].*"log-driver":' /etc/docker/daemon.json 2> /dev/null ; then
         if sudo grep -q '^[^#].*"log-driver":.*journald' /etc/docker/daemon.json 2> /dev/null ; then

--- a/test/access_control.sh
+++ b/test/access_control.sh
@@ -245,7 +245,7 @@ LOG_ADMIN_USER=${LOG_ADMIN_USER:-admin}
 LOG_ADMIN_PW=${LOG_ADMIN_PW:-admin}
 
 if oc get users "$LOG_ADMIN_USER" > /dev/null 2>&1 ; then
-    Using existing admin user $LOG_ADMIN_USER 2>&1 | artifact_out
+    echo Using existing admin user $LOG_ADMIN_USER 2>&1 | artifact_out
 else
     os::log::info Creating cluster-admin user $LOG_ADMIN_USER
     current_project="$( oc project -q )"
@@ -255,6 +255,7 @@ else
 fi
 oc adm policy add-cluster-role-to-user cluster-admin $LOG_ADMIN_USER 2>&1 | artifact_out
 os::log::info workaround access_control admin failures - sleep 60 seconds to allow system to process cluster role setting
+sleep 60
 oc policy can-i '*' '*' --user=$LOG_ADMIN_USER 2>&1 | artifact_out
 oc get users 2>&1 | artifact_out
 

--- a/test/access_control.sh
+++ b/test/access_control.sh
@@ -287,9 +287,11 @@ fi
 
 os::log::info now auth using admin + token
 get_test_user_token $LOG_ADMIN_USER $LOG_ADMIN_PW
-nrecs=$( curl_es_with_token $espod "/${logging_index}/_count" $test_name $test_token | \
-         get_count_from_json )
-os::cmd::expect_success "test $nrecs -gt 1"
+if [ ${LOGGING_NS} = "logging" ] && [ $espod != $esopspod] ; then
+  nrecs=$( curl_es_with_token $espod "/${logging_index}/_count" $test_name $test_token | \
+           get_count_from_json )
+  os::cmd::expect_success "test $nrecs -gt 1"
+fi
 nrecs=$( curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | \
          get_count_from_json )
 os::cmd::expect_success "test $nrecs -gt 1"

--- a/test/access_control.sh
+++ b/test/access_control.sh
@@ -65,7 +65,8 @@ function add_message_to_index() {
     # espod is $3
     local project_uuid=$( oc get project $1 -o jsonpath='{ .metadata.uid }' )
     local index="project.$1.$project_uuid.$(date -u +'%Y.%m.%d')"
-    curl_es "$3" "/$index/access-control-test/" -XPOST -d '{"message":"'${2:-"access-control message"}'"}' | python -mjson.tool 2>&1 | artifact_out
+    local espod=$3
+    curl_es "$espod" "/$index/access-control-test/" -XPOST -d '{"message":"'${2:-"access-control message"}'"}' | python -mjson.tool 2>&1 | artifact_out
 }
 
 function check_es_acls() {
@@ -265,10 +266,10 @@ oc get users 2>&1 | artifact_out
 # error: The server was unable to respond - verify you have provided the correct host and port and that the server is currently running.
 # or - set REUSE=true
 LOG_NORMAL_USER=${LOG_NORMAL_USER:-loguserac-$RANDOM}
-LOG_NORMAL_PW=${LOG_NORMAL_PW:-loguserac}
+LOG_NORMAL_PW=${LOG_NORMAL_PW:-loguserac-$RANDOM}
 
 LOG_USER2=${LOG_USER2:-loguser2ac-$RANDOM}
-LOG_PW2=${LOG_PW2:-loguser2ac}
+LOG_PW2=${LOG_PW2:-loguser2ac-$RANDOM}
 
 create_user_and_assign_to_projects $LOG_NORMAL_USER $LOG_NORMAL_PW access-control-1 access-control-2
 create_user_and_assign_to_projects $LOG_USER2 $LOG_PW2 access-control-2 access-control-3
@@ -279,9 +280,14 @@ oc project ${LOGGING_NS} > /dev/null
 test_user_has_proper_access $LOG_NORMAL_USER $LOG_NORMAL_PW access-control-1 access-control-2 -- access-control-3
 test_user_has_proper_access $LOG_USER2 $LOG_PW2 access-control-2 access-control-3 -- access-control-1
 
+logging_index=".operations.*"
+if [ ${LOGGING_NS} = "logging" ] ; then
+  logging_index="project.logging.*"
+fi
+
 os::log::info now auth using admin + token
 get_test_user_token $LOG_ADMIN_USER $LOG_ADMIN_PW
-nrecs=$( curl_es_with_token $espod "/project.${LOGGING_NS}.*/_count" $test_name $test_token | \
+nrecs=$( curl_es_with_token $espod "/${logging_index}/_count" $test_name $test_token | \
          get_count_from_json )
 os::cmd::expect_success "test $nrecs -gt 1"
 nrecs=$( curl_es_with_token $esopspod "/.operations.*/_count" $test_name $test_token | \

--- a/test/access_control.sh
+++ b/test/access_control.sh
@@ -21,7 +21,7 @@ function cleanup() {
     set +e
     if [ "${REUSE:-false}" = false ] ; then
         for user in $delete_users ; do
-            os::log::debug "$( oc delete user $user )"
+            oc delete user $user 2>&1 | artifact_out
         done
     fi
     if [ -n "${espod:-}" ] ; then
@@ -49,11 +49,11 @@ function create_user_and_assign_to_projects() {
         oc login --username=$user --password=$pw 2>&1 | artifact_out
         delete_users="$delete_users $user"
     fi
-    os::log::debug "$( oc login --username=system:admin 2>&1 )"
+    oc login --username=system:admin 2>&1 | artifact_out
     os::log::info Assigning user to projects "$@"
     while [ -n "${1:-}" ] ; do
-        os::log::debug "$( oc project $1 2>&1 )"
-        os::log::debug "$( oc adm policy add-role-to-user view $user 2>&1 )"
+        oc project $1 2>&1 | artifact_out
+        oc adm policy add-role-to-user view $user 2>&1 | artifact_out
         shift
     done
     oc project "${current_project}" > /dev/null
@@ -65,7 +65,7 @@ function add_message_to_index() {
     # espod is $3
     local project_uuid=$( oc get project $1 -o jsonpath='{ .metadata.uid }' )
     local index="project.$1.$project_uuid.$(date -u +'%Y.%m.%d')"
-    os::log::debug $( curl_es "$3" "/$index/access-control-test/" -XPOST -d '{"message":"'${2:-"access-control message"}'"}' | python -mjson.tool 2>&1 )
+    curl_es "$3" "/$index/access-control-test/" -XPOST -d '{"message":"'${2:-"access-control message"}'"}' | python -mjson.tool 2>&1 | artifact_out
 }
 
 function check_es_acls() {
@@ -230,7 +230,7 @@ function test_user_has_proper_access() {
     os::cmd::expect_success_and_text "curl_es_from_kibana $kpod $esopshost '/.operations.*/_count' $LOG_ADMIN_USER $test_token -w '%{response_code}\n'" '}403$'
 }
 
-os::log::debug "$( curl_es $espod /project.access-control-* -XDELETE )"
+curl_es $espod /project.access-control-* -XDELETE 2>&1 | artifact_out
 
 for proj in access-control-1 access-control-2 access-control-3 ; do
     os::log::info Creating project $proj
@@ -245,15 +245,18 @@ LOG_ADMIN_USER=${LOG_ADMIN_USER:-admin}
 LOG_ADMIN_PW=${LOG_ADMIN_PW:-admin}
 
 if oc get users "$LOG_ADMIN_USER" > /dev/null 2>&1 ; then
-    os::log::debug Using existing admin user $LOG_ADMIN_USER
+    Using existing admin user $LOG_ADMIN_USER 2>&1 | artifact_out
 else
     os::log::info Creating cluster-admin user $LOG_ADMIN_USER
     current_project="$( oc project -q )"
-    os::log::debug "$( oc login --username=$LOG_ADMIN_USER --password=$LOG_ADMIN_PW )"
-    os::log::debug "$( oc login --username=system:admin )"
-    os::log::debug "$( oc project $current_project )"
+    oc login --username=$LOG_ADMIN_USER --password=$LOG_ADMIN_PW 2>&1 | artifact_out
+    oc login --username=system:admin 2>&1 | artifact_out
+    oc project $current_project 2>&1 | artifact_out
 fi
-os::log::debug "$( oc adm policy add-cluster-role-to-user cluster-admin $LOG_ADMIN_USER )"
+oc adm policy add-cluster-role-to-user cluster-admin $LOG_ADMIN_USER 2>&1 | artifact_out
+os::log::info workaround access_control admin failures - sleep 60 seconds to allow system to process cluster role setting
+oc policy can-i '*' '*' --user=$LOG_ADMIN_USER 2>&1 | artifact_out
+oc get users 2>&1 | artifact_out
 
 # if you ever want to run this test again on the same machine, you'll need to
 # use different usernames, otherwise you'll get this odd error:

--- a/test/cluster/rollout.sh
+++ b/test/cluster/rollout.sh
@@ -17,11 +17,12 @@
 source "$(dirname "${BASH_SOURCE[0]}" )/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
+LOGGING_NS=${LOGGING_NS:-openshift-logging}
 FLUENTD_WAIT_TIME=$(( 2 * minute ))
 
 os::test::junit::declare_suite_start "test/cluster/rollout"
 
-os::cmd::expect_success "oc project logging"
+os::cmd::expect_success "oc project ${LOGGING_NS}"
 
 os::log::info "Checking for DeploymentConfigurations..."
 for deploymentconfig in ${OAL_EXPECTED_DEPLOYMENTCONFIGS}; do

--- a/test/debug_level_logs.sh
+++ b/test/debug_level_logs.sh
@@ -6,17 +6,10 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::test::junit::declare_suite_start "test/debug_level_logs"
 
-get_logmessage() {
-    logmessage="$1"
-}
 get_logmessage2() {
     logmessage2="$1"
+    cat > $ARTIFACT_DIR/debug_level_logs-ops.json
 }
 
-es_pod=$( get_es_pod es )
-es_ops_pod=$( get_es_pod es-ops )
-es_ops_pod=${es_ops_pod:-$es_pod}
-
-TEST_REC_PRIORITY=debug wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es ${es_ops_pod} /.operations.*/_count -X POST -d '$qs' | jq '.count > 0'"
+TEST_REC_PRIORITY=debug wait_for_fluentd_to_catch_up '' get_logmessage2
+os::cmd::expect_success "cat $ARTIFACT_DIR/debug_level_logs-ops.json | jq '.hits.hits[0]._source.level == \"debug\"'"

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -57,6 +57,10 @@ update_current_fluentd() {
       else
     # edit so we don't send to ES
     oc get configmap/logging-fluentd -o yaml | sed '/## matches/ a\
+      <filter **>\
+        @type record_transformer\
+        remove_keys _id, viaq_msg_id\
+      </filter>\
       <match **>\
         @type copy\
         @include configs.d/user/secure-forward1.conf\

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -249,16 +249,16 @@ os::log::info Starting fluentd-forward test at $( date )
 # make sure fluentd is working normally
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
-os::cmd::expect_success wait_for_fluentd_to_catch_up
+wait_for_fluentd_to_catch_up
 
 # FORWARDCNT must be 1 or 2
 FORWARDCNT=1
 create_forwarding_fluentd
 update_current_fluentd
-os::cmd::expect_success wait_for_fluentd_to_catch_up
+wait_for_fluentd_to_catch_up
 cleanup
 
 FORWARDCNT=2
 create_forwarding_fluentd
 update_current_fluentd
-os::cmd::expect_success "wait_for_fluentd_to_catch_up '' '' 2"
+wait_for_fluentd_to_catch_up '' '' 2

--- a/test/json-parsing.sh
+++ b/test/json-parsing.sh
@@ -36,13 +36,12 @@ os::log::info Starting json-parsing test at $( date )
 # logging should parse this and make "type", "tags", "statusCode", etc. as top level fields
 # the "message" field should contain only the embedded message and not the entire JSON blob
 
-get_uuid_es() {
+get_record() {
     json_test_uuid=$1
+    cp $2 $ARTIFACT_DIR/json-parsing-output.json
 }
-wait_for_fluentd_to_catch_up get_uuid_es
-
-es_pod=$( get_es_pod es )
+wait_for_fluentd_to_catch_up get_record
 
 os::log::info Testing if record is in correct format . . .
-os::cmd::expect_success "curl_es $es_pod /project.logging.*/_search?q=message:$json_test_uuid | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/json-parsing-output.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-json-parsing.py $json_test_uuid"

--- a/test/mux-client-mode.sh
+++ b/test/mux-client-mode.sh
@@ -8,9 +8,9 @@ os::util::environment::use_sudo
 
 # only works if there is a mux dc
 if oc get dc/logging-mux > /dev/null 2>&1 ; then
-    os::log::debug "$( oc get dc/logging-mux )"
+    oc get dc/logging-mux 2>&1 | artifact_out
 else
-    os::log::debug "$( oc get dc/logging-mux )"
+    oc get dc/logging-mux 2>&1 | artifact_out
     os::log::info dc/logging-mux is not present - skipping test
     exit 0
 fi
@@ -28,19 +28,19 @@ cleanup() {
     set +e
     # dump the pods before we restart them
     if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod > $ARTIFACT_DIR/$fpod.log 2>&1
+        oc logs $fpod > $ARTIFACT_DIR/mux-client-mode-fluentd-pod.log 2>&1
     fi
     if [ -n "${muxpod:-}" ] ; then
-        oc logs $muxpod > $ARTIFACT_DIR/$muxpod.log 2>&1
+        oc logs $muxpod > $ARTIFACT_DIR/mux-client-mode-mux-pod.log 2>&1
     fi
     if [ -n "${saveds:-}" ] ; then
         if [ -f "${saveds:-}" ]; then
-            os::log::debug "$( oc replace --force -f $saveds )"
+            oc replace --force -f $saveds 2>&1 | artifact_out
             rm -f $saveds
         fi
     fi
     os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true || : )"
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
@@ -52,8 +52,8 @@ reset_fluentd_daemonset() {
   muxcerts=$( oc get daemonset logging-fluentd -o yaml | egrep muxcerts ) || :
 
   if [ "$muxcerts" = "" ]; then
-      os::log::debug "$( oc set volumes daemonset/logging-fluentd --add --overwrite \
-               --name=muxcerts --default-mode=0400 -t secret -m /etc/fluent/muxkeys --secret-name logging-mux 2>&1 )"
+      oc set volumes daemonset/logging-fluentd --add --overwrite \
+               --name=muxcerts --default-mode=0400 -t secret -m /etc/fluent/muxkeys --secret-name logging-mux 2>&1 | artifact_out
   fi
 }
 
@@ -61,24 +61,24 @@ fpod=$( get_running_pod fluentd )
 muxpod=$( get_running_pod mux )
 
 os::log::info configure fluentd to use MUX_CLIENT_MODE=minimal - verify logs get through
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
 os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-os::log::debug "$( oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=minimal )"
+oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=minimal 2>&1 | artifact_out
 reset_fluentd_daemonset
 os::cmd::expect_success flush_fluentd_pos_files
-os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up
 
 # configure fluentd to use MUX_CLIENT_MODE=maximal - verify logs get through
 os::log::info configure fluentd to use MUX_CLIENT_MODE=maximal - verify logs get through
-os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
 os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
-os::log::debug "$( oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=maximal )"
+oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=maximal 2>&1 | artifact_out
 reset_fluentd_daemonset
 os::cmd::expect_success flush_fluentd_pos_files
-os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up

--- a/test/pre-upgrade.sh
+++ b/test/pre-upgrade.sh
@@ -6,16 +6,14 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::test::junit::declare_suite_start "test/pre-upgrade"
 
-LOGGING_NS=:${LOGGING_NS:-openshift-logging}
-
 #store log messages to file so post-upgrade can validate their existence
 store_upgrade_test_uuid() {
+    cp $2 $ARTIFACT_DIR/pre-upgrade-record.json
     upgrade_test_uuid="$1"
     echo "$1" > /tmp/upgrade_test_uuid
 }
 
 wait_for_fluentd_to_catch_up store_upgrade_test_uuid
-es_pod=$( get_es_pod es )
 
-os::cmd::expect_success "curl_es $es_pod /project.logging.*/_search?q=message:$upgrade_test_uuid | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/pre-upgrade-record.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-json-parsing.py $upgrade_test_uuid"

--- a/test/upgrade.sh
+++ b/test/upgrade.sh
@@ -10,12 +10,13 @@ LOGGING_NS=${LOGGING_NS:-openshift-logging}
 
 get_upgrade_test_uuid() {
     upgrade_test_uuid="$1"
+    cp $2 $ARTIFACT_DIR/upgrade-record.json
 }
 
 wait_for_fluentd_to_catch_up get_upgrade_test_uuid
 es_pod=$( get_es_pod es )
 
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search?q=message:$upgrade_test_uuid | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/upgrade-record.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-json-parsing.py $upgrade_test_uuid"
 
 old_upgrade_test_uuid=$(cat /tmp/upgrade_test_uuid)

--- a/test/viaq-data-model.sh
+++ b/test/viaq-data-model.sh
@@ -114,20 +114,19 @@ fpod=$( get_running_pod fluentd )
 
 get_logmessage() {
     logmessage="$1"
+    cp $2 $ARTIFACT_DIR/viaq-data-model-test.json
 }
 get_logmessage2() {
     logmessage2="$1"
+    cp $2 $ARTIFACT_DIR/viaq-data-model-test-ops.json
 }
 
 # TEST 1
 # default - undefined fields are passed through untouched
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-fullmsg="GET /${logmessage} 404 "
-qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test1"
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test-ops.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test1"
 
 # these fields are present because it is a kibana log message - we
@@ -143,12 +142,9 @@ os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-fullmsg="GET /${logmessage} 404 "
-qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test2"
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test-ops.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test2"
 
 # TEST 3
@@ -158,13 +154,9 @@ os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-fullmsg="GET /${logmessage} 404 "
-qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test3"
-
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test-ops.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test3"
 
 # TEST 4
@@ -174,13 +166,9 @@ os::cmd::try_until_failure "oc get pod $fpod"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-fullmsg="GET /${logmessage} 404 "
-qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test4"
-
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test-ops.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test4"
 
 # TEST 5
@@ -198,13 +186,9 @@ if [ -n "$is_maximal" ] ; then
 fi
 fpod=$( get_running_pod fluentd )
 wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
-fullmsg="GET /${logmessage} 404 "
-qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
-os::cmd::expect_success "curl_es $es_pod /project.${LOGGING_NS}.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test5 allow_empty"
-
-qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
-os::cmd::expect_success "curl_es $es_ops_pod /.operations.*/_search -X POST -d '$qs' | \
+os::cmd::expect_success "cat $ARTIFACT_DIR/viaq-data-model-test-ops.json | \
                          python $OS_O_A_L_DIR/hack/testing/test-viaq-data-model.py test5 allow_empty"
 
 if [ -n "$is_maximal" ] ; then

--- a/test/zzz-correct-index-names.sh
+++ b/test/zzz-correct-index-names.sh
@@ -37,7 +37,7 @@ for project in $OPS_NAMESPACES ; do
     else
         os::log::info Creating project $project
         oc adm new-project $project --node-selector='' 2>&1 | artifact_out
-        os::cmd::try_until_success "oc get project $project" ${timeout} 2>&1 | artifact_out
+        os::cmd::try_until_success "oc get project $project" "${timeout}" 2>&1 | artifact_out
         delete_project="$project"
     fi
     message_uuid=$( uuidgen | sed 's/[-]//g' )
@@ -47,17 +47,17 @@ for project in $OPS_NAMESPACES ; do
         -p TEST_POD_SLEEP_TIME=1 \
         -p TEST_NAMESPACE_NAME=${project} \
         -p TEST_ITERATIONS=1 | oc create -f - 2>&1 | artifact_out
-    os::cmd::try_until_text "oc get -n ${project} pods test-pod" "^test-pod.* Running " ${timeout}
+    os::cmd::try_until_text "oc get -n ${project} pods test-pod" "^test-pod.* Running " "${timeout}"
     # The query part will return more than one if successful - due to the fuzzy matching,
     # it may return results from more than one namespace - the jq select will ensure that
     # the namespace name matches exactly
     os::cmd::try_until_text "curl_es $es_ops_pod /.operations.*/_search?q=message:$message_uuid | \
-        jq '.hits.hits | map(select(._source.kubernetes.namespace_name == \"${project}\")) | length | . > 0'" "^true\$"  ${timeout}
+        jq '.hits.hits | map(select(._source.kubernetes.namespace_name == \"${project}\")) | length | . > 0'" "^true\$"  "${timeout}"
     oc delete -n ${project} --force pod test-pod 2>&1 | artifact_out
-    os::cmd::try_until_failure "oc get -n ${project} pod test-pod" ${timeout}
+    os::cmd::try_until_failure "oc get -n ${project} pod test-pod" "${timeout}"
     if [ -n "$delete_project" ] ; then
         oc delete project $delete_project 2>&1 | artifact_out
-        os::cmd::try_until_failure "oc get project $delete_project" ${timeout} 2>&1 | artifact_out
+        os::cmd::try_until_failure "oc get project $delete_project" "${timeout}" 2>&1 | artifact_out
     fi
 done
 

--- a/test/zzz-rsyslog.sh
+++ b/test/zzz-rsyslog.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# This is a test suite for testing basic log processing
+# functionality and Kubernetes processing for rsyslog
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+os::util::environment::use_sudo
+
+os::test::junit::declare_suite_start "test/zzz-rsyslog"
+
+es_pod=$( get_es_pod es )
+es_ops_pod=$( get_es_pod es-ops )
+es_ops_pod=${es_ops_pod:-$es_pod}
+
+cleanup() {
+    local return_code="$?"
+    set +e
+    if [ -n "${tmpinv}" -a -f "${tmpinv}" ] ; then
+        rm -f $tmpinv
+    fi
+    if [ -n "${rsyslog_save}" -a -d "${rsyslog_save}" ] ; then
+        sudo rm -rf /etc/rsyslog.d/*
+        sudo cp -p ${rsyslog_save}/* /etc/rsyslog.d
+        rm -rf ${rsyslog_save}
+        sudo systemctl restart rsyslog
+    fi
+    # cleanup fluentd pos file and restart
+    flush_fluentd_pos_files
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
+
+# turn off fluentd
+oc label node --all logging-infra-fluentd- 2>&1 | artifact_out || :
+os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $((second * 120))
+
+if [ $es_pod = $es_ops_pod ] ; then
+    use_es_ops=False
+else
+    use_es_ops=True
+fi
+rsyslog_save=$( mktemp -d )
+sudo cp -p /etc/rsyslog.d/* $rsyslog_save
+pushd $OS_O_A_L_DIR/hack/testing/rsyslog > /dev/null
+tmpinv=$( mktemp )
+cat > $tmpinv <<EOF
+localhost ansible_ssh_user=${RSYSLOG_ANSIBLE_SSH_USER:-ec2-user} openshift_logging_use_ops=$use_es_ops openshift_logging_namespace=${LOGGING_NS:-logging}
+EOF
+os::cmd::expect_success "ansible-playbook -vvv --become --become-user root --connection local \
+    -e use_mmk8s=True -i $tmpinv playbook.yaml > $ARTIFACT_DIR/zzz-rsyslog-ansible.log 2>&1"
+rm -f $tmpinv
+popd > /dev/null
+
+get_logmessage() {
+    logmessage="$1"
+}
+get_logmessage2() {
+    logmessage2="$1"
+}
+sudo systemctl stop rsyslog
+# make test run faster by resetting journal cursor to "now"
+sudo journalctl -n 1 --show-cursor | awk '/^-- cursor/ {printf("%s",$3)}' | sudo tee /var/lib/rsyslog/imjournal.state > /dev/null
+sudo systemctl start rsyslog
+sleep 10
+# we're actually waiting for rsyslog instead . . .
+wait_for_fluentd_to_catch_up get_logmessage get_logmessage2
+fullmsg="GET /${logmessage} 404 "
+qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
+proj=$ARTIFACT_DIR/rsyslog-proj.json
+curl_es $es_pod /project.logging.*/_search -X POST -d "$qs" | jq .hits.hits[0] > $proj 2>&1
+qs='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${logmessage2}"'"}}}'
+ops=$ARTIFACT_DIR/rsyslog-ops.json
+curl_es $es_ops_pod /.operations.*/_search -X POST -d "$qs" | jq .hits.hits[0] > $ops 2>&1
+
+# see if the kubernetes metadata matches
+actual_pod_name=$( cat $proj | jq -r ._source.kubernetes.pod_name )
+actual_ns_name=$( cat $proj | jq -r ._source.kubernetes.namespace_name )
+actual_pod_id=$( cat $proj | jq -r ._source.kubernetes.pod_id )
+actual_ns_id=$( cat $proj | jq -r ._source.kubernetes.namespace_id )
+actual_pod_host=$( cat $proj | jq -r ._source.kubernetes.host )
+os::cmd::expect_success "test $actual_pod_id = $( oc get pod $actual_pod_name -o jsonpath='{.metadata.uid}' )"
+os::cmd::expect_success "test $actual_pod_host = $( oc get pod $actual_pod_name -o jsonpath='{.spec.nodeName}' )"
+os::cmd::expect_success "test $actual_ns_id = $( oc get project $actual_ns_name -o jsonpath='{.metadata.uid}' )"
+oc get pod $actual_pod_name -o json | jq -S .metadata.labels | \
+    jq 'with_entries(.key |= gsub("[.]";"_"))' > $ARTIFACT_DIR/zzz-rsyslog-expected-labels.json
+cat $proj | jq -S ._source.kubernetes.labels > $ARTIFACT_DIR/zzz-rsyslog-actual-labels.json
+os::cmd::expect_success "diff $ARTIFACT_DIR/zzz-rsyslog-expected-labels.json $ARTIFACT_DIR/zzz-rsyslog-actual-labels.json"
+
+oc get pod $actual_pod_name -o json | jq -S .metadata.annotations | \
+    jq 'with_entries(.key |= gsub("[.]";"_"))' > $ARTIFACT_DIR/zzz-rsyslog-expected-annotations.json
+cat $proj | jq -S ._source.kubernetes.annotations > $ARTIFACT_DIR/zzz-rsyslog-actual-annotations.json
+os::cmd::expect_success "diff $ARTIFACT_DIR/zzz-rsyslog-expected-annotations.json $ARTIFACT_DIR/zzz-rsyslog-actual-annotations.json"
+
+if [ -n "$( oc get project $actual_ns_name -o jsonpath='{.metadata.labels}')" ] ; then
+    oc get project $actual_ns_name -o json | jq -S .metadata.labels | \
+        jq 'with_entries(.key |= gsub("[.]";"_"))' > $ARTIFACT_DIR/zzz-rsyslog-expected-nslabels.json
+    cat $proj | jq -S ._source.kubernetes.namespace_labels > $ARTIFACT_DIR/zzz-rsyslog-actual-nslabels.json
+    os::cmd::expect_success "diff $ARTIFACT_DIR/zzz-rsyslog-expected-nslabels.json $ARTIFACT_DIR/zzz-rsyslog-actual-nslabels.json"
+else
+    os::cmd::expect_success_and_text "cat $proj | jq ._source.metadata.namespace_labels" "^null\$"
+fi
+
+if [ -n "$( oc get project $actual_ns_name -o jsonpath='{.metadata.annotations}')" ] ; then
+    oc get project $actual_ns_name -o json | jq -S .metadata.annotations | \
+        jq 'with_entries(.key |= gsub("[.]";"_"))' > $ARTIFACT_DIR/zzz-rsyslog-expected-nsannotations.json
+    cat $proj | jq -S ._source.kubernetes.namespace_annotations > $ARTIFACT_DIR/zzz-rsyslog-actual-nsannotations.json
+    os::cmd::expect_success "diff $ARTIFACT_DIR/zzz-rsyslog-expected-nsannotations.json $ARTIFACT_DIR/zzz-rsyslog-actual-nsannotations.json"
+else
+    os::cmd::expect_success_and_text "cat $proj | jq ._source.metadata.namespace_annotations" "^null\$"
+fi
+
+# see if ops fields are present
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.systemd.t.TRANSPORT" "^null$"
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.systemd.t.SELINUX_CONTEXT" "^null$"
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.systemd.u.SYSLOG_FACILITY" "^null$"
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.systemd.u.SYSLOG_PID" "^null$"
+os::cmd::expect_success_and_text "cat $ops | jq -r ._source.message" "^${logmessage2}\$"
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.level" "^null$"
+os::cmd::expect_success_and_not_text "cat $ops | jq -r ._source.hostname" "^null$"
+ts=$( cat $ops | jq -r '._source."@timestamp"' )
+os::cmd::expect_success "test ${ts} != null"

--- a/test/zzz-rsyslog.sh
+++ b/test/zzz-rsyslog.sh
@@ -19,6 +19,7 @@ cleanup() {
     if [ -n "${tmpinv}" -a -f "${tmpinv}" ] ; then
         rm -f $tmpinv
     fi
+    sudo journalctl -u rsyslog --since="-1hour" > $ARTIFACT_DIR/rsyslog-rsyslog.log 2>&1
     if [ -n "${rsyslog_save}" -a -d "${rsyslog_save}" ] ; then
         sudo rm -rf /etc/rsyslog.d/*
         sudo cp -p ${rsyslog_save}/* /etc/rsyslog.d

--- a/test/zzzz-bulk_rejection.sh
+++ b/test/zzzz-bulk_rejection.sh
@@ -1,0 +1,265 @@
+#!/bin/bash
+
+# test bulk rejection handling
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+trap os::test::junit::reconcile_output EXIT
+os::util::environment::use_sudo
+
+os::test::junit::declare_suite_start "test/bulk_rejection"
+
+espod=$( get_es_pod es )
+esopspod=$( get_es_pod es-ops )
+esopspod=${esopspod:-$espod}
+
+function cleanup() {
+    local result_code="$?"
+    set +e
+    if [ -n "${bulkdonefile:-}" ] ; then
+        echo done > $bulkdonefile
+    fi
+    if [ -n "${bulktestjson:-}" -a -f "${bulktestjson:-}" ] ; then
+        rm -f $bulktestjson
+    fi
+    if [ -f "${es_settings:-}" ] ; then
+        echo restore settings | artifact_out
+        cat $es_settings | artifact_out
+        cat $es_settings | curl_es_input $espod /_cluster/settings -XPUT --data-binary @- | jq . | artifact_out
+        rm -f $es_settings
+    fi
+    curl_es $espod /bulkindextest -XDELETE | jq . | artifact_out
+    fpod=$( get_running_pod fluentd )
+    if [ -f /var/log/fluentd.log ] ; then
+        cp /var/log/fluentd.log $ARTIFACT_DIR/fluentd-with-bulk-index-rejections.log
+    else
+        oc logs $fpod > $ARTIFACT_DIR/fluentd-with-bulk-index-rejections.log
+    fi
+    if [ -n "${f_cm:-}" -a -f "${f_cm:-}" ] ; then
+        oc replace --force -f $f_cm
+    fi
+    if [ -n "${f_ds:-}" -a -f "${f_ds:-}" ] ; then
+        oc replace --force -f $f_ds
+    fi
+    os::cmd::try_until_failure "oc describe pod $fpod"
+    sleep 1
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+    if [ -n "${bulkdonefile:-}" -a -f "${bulkdonefile:-}" ] ; then
+        rm -f $bulkdonefile
+    fi
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $result_code
+}
+
+trap cleanup EXIT
+
+# save current fluentd settings
+f_cm=$( mktemp )
+f_ds=$( mktemp )
+
+oc get cm/logging-fluentd -o yaml > $f_cm
+oc get ds/logging-fluentd -o yaml > $f_ds
+
+# turn on debug output
+cat $f_cm | \
+    sed -e 's,@include configs.d/openshift/system.conf,<system>\
+      log_level debug\
+    </system>,' | oc replace --force -f -
+
+oc set env ds/logging-fluentd DEBUG=true
+
+# save current es settings
+
+es_settings=$( mktemp )
+curl_es $espod /_cluster/settings | jq . > $es_settings
+
+# change bulk queue_size and size to 1 to make it easy to overload
+curl_es $espod /_cluster/settings -XPUT -d '{
+    "transient" : {
+        "threadpool.bulk.queue_size" : 1,
+        "threadpool.bulk.size": 1
+    }
+}' | jq . | artifact_out
+
+# check settings
+curl_es $espod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs | artifact_out
+
+# create a really large bulk index request json file:
+bulktestjson=$( mktemp )
+python -c 'import sys
+for ii in xrange(0,int(sys.argv[1])):
+    print """
+{{"index":{{"_index":"bulkindextest","_type":"bulkindextest"}}}}
+{{"field0":"value value value {0}"}}
+""".format(ii)
+' 100000 > $bulktestjson
+wc $bulktestjson | artifact_out
+ls -al $bulktestjson | artifact_out
+
+# start curl doing many bulk index ops
+bulkdonefile=$( mktemp )
+echo $bulkdonefile | artifact_out
+do_curl_bulk_index() {
+    local parallel_curls=6
+    local ii
+    local bulkpids=""
+    for ii in $( seq 1 $parallel_curls ) ; do
+        while [ ! -s $bulkdonefile -a -n "${bulktestjson:-}" -a -f "${bulktestjson:-}" ] ; do
+            cat $bulktestjson | curl_es_input $espod /_bulk -XPOST --data-binary @- > /dev/null
+        done & bulkpids="$bulkpids $!"
+    done
+    curl_es $espod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs | artifact_out
+    wait $bulkpids
+    curl_es $espod /_cat/thread_pool?v\&h=bc,br,ba,bq,bs | artifact_out
+}
+
+do_curl_bulk_index & curlpid=$!
+# wait for elasticsearch to report bulk index rejections
+os::cmd::try_until_not_text "curl_es $espod /_cat/thread_pool?h=br" "^0\$"
+
+# restart fluentd to make sure the logs are clear
+os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+fpod=$( get_running_pod fluentd )
+oc delete pod --force $fpod
+os::cmd::try_until_failure "oc describe pod $fpod"
+sleep 1
+os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
+fpod=$( get_running_pod fluentd )
+
+# wait for BulkIndexQueueFull errors in fluentd log
+flog=/var/log/fluentd.log
+os::cmd::try_until_success "grep -q BulkIndexQueueFull /var/log/fluentd.log" $(( 300 * second ))
+
+# write some messages
+uuid_es=$( openssl rand -hex 64 )
+uuid_es_ops=$( openssl rand -hex 64 )
+
+wait_for_fluentd_ready
+count=40
+countops=500
+os::log::info Adding $count project log records and $countops operations log records . . .
+starttime=$( date +%s )
+# not sure why, but it seems the operations messages get sent
+# to es much faster - so add more of them to see if we can get
+# them to be rejected
+for jj in $( seq 1 $count ) ; do
+    add_test_message "$uuid_es-$jj"
+    os::log::debug added es message $uuid_es-$jj
+done
+
+opsloglines=$( mktemp )
+python -c 'import sys
+for ii in xrange(1,int(sys.argv[1])+1):
+    print "{0}-{1}".format(sys.argv[2], ii)
+' $countops $uuid_es_ops > $opsloglines
+logger -i -p local6.info -t $uuid_es_ops -f $opsloglines
+os::log::debug added es-ops message $uuid_es_ops-$jj
+rm -f $opsloglines
+
+os::log::info Finished adding $count project and $countops operation log records
+
+fullmsg="GET /${uuid_es}-"
+qs='{"query":{"match_phrase":{"message":"'"${fullmsg}"'"}}}'
+firstcount=$( curl_es ${espod} /project.logging.*/_count -X POST -d "$qs" | get_count_from_json )
+if [ "${firstcount:-0}" -eq $count ] ; then
+    os::log::warning All project records added - some should have been queued due to bulk index rejection
+else
+    os::log::info Found $firstcount of $count project records in Elasticsearch
+fi
+qsops='{"query":{"term":{"systemd.u.SYSLOG_IDENTIFIER":"'"${uuid_es_ops}"'"}}}'
+firstcount=$( curl_es ${esopspod} /.operations.*/_count -X POST -d "$qsops" | get_count_from_json )
+if [ "${firstcount:-0}" -eq $countops ] ; then
+    os::log::warning All operations records added - some should have been queued due to bulk index rejection
+else
+    os::log::info Found $firstcount of $countops operations records in Elasticsearch
+fi
+
+#curl_es ${esopspod} "/.operations.*/_search?q=systemd.u.SYSLOG_IDENTIFIER:$uuid_es_ops&sort=@timestamp:asc&size=1" | jq .
+#curl_es ${esopspod} "/.operations.*/_search?q=systemd.u.SYSLOG_IDENTIFIER:$uuid_es_ops&sort=@timestamp:desc&size=1" | jq .
+
+# shutdown the do_curl_bulk_index
+echo done > $bulkdonefile
+wait $curlpid
+endtime=$( date +%s )
+
+# check the logs to see if there are bulk index rejection errors between starttime and endtime
+found=
+founderr=0
+foundsuc=0
+lasterr=
+lastsuc=
+while read datestr timestr tz logline ; do
+    iserr=
+    if echo "$logline" | grep -q 'Fluent::ElasticsearchErrorHandler::BulkIndexQueueFull' ; then
+        founderr=$( expr $founderr + 1 )
+        iserr=1
+    elif echo "$logline" | grep -q 'retry succeeded.' ; then
+        foundsuc=$( expr $foundsuc + 1 )
+    else
+        continue
+    fi
+    dt=$( date --date="$datestr $timestr $tz" +%s )
+    if [ -n "$dt" -a "$dt" -ge $starttime -a "$dt" -le $endtime ] ; then
+        if [ -n "${iserr:-}" ] ; then
+            found=1
+            os::log::debug "Found a BulkIndexQueueFull error during test run: $datestr $timestr $tz $logline"
+            lasterr=$dt
+        else
+            lastsuc=$dt
+        fi
+    fi
+done < $flog
+
+if [ -z "${found:-}" ] ; then
+    os::log::error There were no bulk index errors recorded by fluentd during the test run between $( date --date=@$starttime ) and $( date --date=@$endtime )
+    exit 1
+fi
+
+os::log::info There were $founderr bulk index errors and $foundsuc successful retries recorded by fluentd during the test run between $( date --date=@$starttime ) and $( date --date=@$endtime )
+
+if [ -z "$lastsuc" ] ; then
+    os::log::info There were no successful retries during the test run between $( date --date=@$starttime ) and $( date --date=@$endtime )
+elif [ $lasterr -lt $lastsuc ] ; then
+    os::log::info Last successful retry at $( date --date=@$lastsuc ) was after last error at $( date --date=@$lasterr )
+else
+    os::log::info Last error at $( date --date=@$lasterr ) was at or after last successful retry at $( date --date=@$lastsuc )
+fi
+
+rc=0
+timeout=$(( 180 * second ))
+# duplicates can be added when bulk ops are retried, so greater than or equal
+if os::cmd::try_until_success "curl_es ${espod} /project.logging.*/_count -X POST -d '$qs' | jq '.count >= ${count}'" $timeout ; then
+    os::log::debug good - found $count record project logging for \'$fullmsg\'
+else
+    os::log::error not found $count record project logging for \'$fullmsg\' after timeout
+    os::log::debug "$( curl_es ${espod} /project.logging.*/_search -X POST -d "$qs" )"
+    os::log::error "Checking journal for '$fullmsg' ..."
+    if sudo journalctl | grep -q "$fullmsg" ; then
+        os::log::error "Found '$fullmsg' in journal"
+        os::log::debug "$( sudo journalctl | grep "$fullmsg" )"
+    elif sudo grep -q "$fullmsg" /var/log/containers/* ; then
+        os::log::error "Found '$fullmsg' in /var/log/containers/*"
+        os::log::debug "$( sudo grep -q "$fullmsg" /var/log/containers/* )"
+    else
+        os::log::error "Unable to find '$fullmsg' in journal or /var/log/containers/*"
+    fi
+
+    rc=1
+fi
+
+if os::cmd::try_until_success "curl_es ${esopspod} /.operations.*/_count -X POST -d '$qsops' | jq '.count >= ${countops}'" $timeout ; then
+    os::log::debug good - found $countops record project .operations for $uuid_es_ops
+else
+    os::log::error not found $countops record project .operations for $uuid_es_ops after timeout
+    os::log::debug "$( curl_es ${esopspod} /.operations.*/_search -X POST -d "$qsops" )"
+    os::log::error "Checking journal for $uuid_es_ops..."
+    if sudo journalctl | grep -q $uuid_es_ops ; then
+        os::log::error "Found $uuid_es_ops in journal"
+        os::log::debug "$( sudo journalctl | grep $uuid_es_ops )"
+    else
+        os::log::error "Unable to find $uuid_es_ops in journal"
+    fi
+    rc=1
+fi
+
+exit $rc


### PR DESCRIPTION
make bulk rejection test work with ES5; use es-ops instead of es

Due to
https://www.elastic.co/guide/en/elasticsearch/reference/5.1/breaking_50_settings_changes.html#_threadpool_settings
we cannot dynamically update the bulk threadpool settings, so have to hack
the es configmap and rollout. Only run tests against es-ops to avoid having
to create another namespace/pod for the es instance (since logging could be
openshift-logging).

ES5 also changed the _cat api for the bulk thread_pool, so add some utility
functions to get the ES version and the bulk thread_pool url.

support logging-xxx5 images

debug remote-syslog test
(cherry picked from commit 78325ee4216126b13f6aeba215f5174131429fdd)

Sort events by timestamp
(cherry picked from commit e01bae2e0f864aecb68bc29fe02fcf27c49f0df1)

Take both forward and secure_forward into account for NUM_OUTPUTS
Reported-by: Ludovic Juaneda
(cherry picked from commit 1ee717be49cf31b5d9755e4addd6bdb10921f46f)

fluentd: determine if openshift uses cri-o from nodeconfig
Parse `etc/origin/node/node-config.yaml` config file for
`kubeletArguments -> container-runtime-endpoint` if it contains `crio`.
Change generation of `in_tail` plugin config to don't try parsing as json
but as a regex instead if crio is identified.
The regex used is:
/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<message>.*)$/
and is based on the parsing logic in cri-o for 1.8 and 1.9:
https://github.com/kubernetes-incubator/cri-o/blob/release-1.8/oci/oci.go#L363
https://github.com/kubernetes-incubator/cri-o/blob/release-1.9/oci/oci.go#L363
NOTE: the logtag was introduced in 1.9 so it is put as optional here, and
currently doesn't appear to be working well with Elasticsearch logs so this
PR doesn't try to append and reconstruct multiline logs.
(cherry picked from commit d79019b5edcd42be98aab7b9777b253da9f65515)

Bug 1550842 - Embed json logs when using cri-o
(cherry picked from commit 49d82d2cfa417a84ae10ec343018b8e88e4a8ef7)

Bug 1548720 - fluent-plugin-secure-forward couldn't read the Environment
${HOSTNAME}
Replacing the self_hostname value ${HOSTNAME} with the placeholder
${hostname}.
(cherry picked from commit 99175ee3a99f5faf15b9b8e3b89b2cbf4d6d0bc1)

fluentd: cri-o config env variables
(cherry picked from commit f4ed20c8d56053585d2d12531473ba748f55b677)

many, many fixes for openshift-logging and related code cleanup
(cherry picked from commit 7db3a9426ae1e7a8d7ddbb7468161dd0115f2a4b)

bug 1548104. Generate record uuids upon ingestion to minimize duplicates
(cherry picked from commit 5e1e372658b57f916af9543efb3f096cc2936bfc)

check logging namespace for actual resources
(cherry picked from commit d68cc2126ddba1e938d58495dcb183993a84ee5a)

add openshift/origin-aggregated-logging/pull/1067

use LOGGING_NS
hack for docker hostmount problem
(cherry picked from commit 47bdd7fef7df63474adeb832db14a9c526f109e4)

better way to save and restore bulk config
(cherry picked from commit f4afda0e7c52ffb72e27a04c8f58270fa5a4558c)

bug 1535300. modify the default namespace for logging
(cherry picked from commit 06925e7159824df0c0c7fe63e6aeabb9aec2a166)

add bulk index rejection test
This tests the ability of fluentd to handle bulk index rejections. The test
starts up several curl processes which hammer Elasticsearch with bulk index
requests which causes fluentd to receive bulk rejections. The methodology
is to add some messages for both projects and operations indices which
should be rejected and queued and eventually resent successfully. The test
will ensure that Elasticsearch is rejecting bulk requests and fluentd is
receiving bulk rejections. The test has to run last because it will cause
other CI tests to have test flakes due to bulk index rejections, which
somehow become persistent after this test runs.
(cherry picked from commit 9c89068ac9dadfd3837781b196e992164bc8de80)

ignore errors for bulk index monitor
(cherry picked from commit d9b66001290a8b9a80791baaa6af655d02e191e9)

improve mux-client-mode debugging
(cherry picked from commit 17db82836e24252766b84bc8d71f7445552f1930)

efficiently look for source record to report missing records
(cherry picked from commit cb491a314ff2ae589a46e5a8c62ea8975b593548)

add errorfile to rsyslog test to capture elasticsearch errors
(cherry picked from commit d1cdaa83296bc56b4f08d41706460827a1210aa2)

new location for node kubeconfig; dump rsyslog log at end of test
(cherry picked from commit 41b6325a53d9d41b1de0beaa7296e2c1d3aa05f7)

rsyslog testing - test k8s, es tls, viaq formatting
This tests the ability of rsyslog to do kubernetes metadata annotation,
elasticsearch with client cert auth, and some basic viaq data model
formatting
This currently uses pre-release rsyslog built in fedora copr, but that
should move into more official repos soon.
(cherry picked from commit 2b6366b3b6b852b13e94f1a2707355289e05ba97)

add bulk indexing stats monitor to CI
(cherry picked from commit 4b24e0b1948bdcaacf3aae2d8b28acc54ee43059)

fix bugs
(cherry picked from commit ed147175e0e8fb86d7a36e5c0ba7c875a31e8475)

sleep to allow cluster admin user to be processed; more debugging
(cherry picked from commit 667ac5b5176b1da5880a8e10f74aa7391616fad4)