### PR TITLE
[es5.x] fix bulk monitor; use keyname instead of hardcoded thread_pool

### DIFF
--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -102,10 +102,16 @@ monitor_es_bulk_stats() {
     cp $KUBECONFIG $ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
     export KUBECONFIG=$ARTIFACT_DIR/monitor_es_bulk_stats.kubeconfig
     oc project ${LOGGING_NS} > /dev/null
-    es_ver=$( get_es_major_ver )
+    # wait for espod
+    local espod=$( get_es_pod es 2> /dev/null ) || :
+    while [ -z "${espod}" ] ; do
+        sleep 1
+        espod=$( get_es_pod es 2> /dev/null ) || :
+    done
+    es_ver=$( get_es_major_ver ) || :
     bulk_url=$( get_bulk_thread_pool_url $es_ver "v" c r a q s qs )
     while true ; do
-        local espod=$( get_es_pod es 2> /dev/null ) || :
+        espod=$( get_es_pod es 2> /dev/null ) || :
         local esopspod=$( get_es_pod es-ops 2> /dev/null ) || :
         esopspod=${esopspod:-$espod}
         if [ -n "${espod}" ] ; then

--- a/test/zzzz-bulk_rejection.sh
+++ b/test/zzzz-bulk_rejection.sh
@@ -71,7 +71,7 @@ oc get cm/logging-elasticsearch -o yaml > $es_cm
 # change queue size and pool size to make it easy to hit limit
 oc get cm/logging-elasticsearch -o yaml | \
     sed '/^  elasticsearch.yml/a\
-    thread_pool:\
+    '$keyname':\
       bulk:\
         queue_size: 1\
         size: 1' | oc replace --force -f - 2>&1 | artifact_out


### PR DESCRIPTION
The setting in ES2 is `threadpool` and in ES5 is `thread_pool`

fix a flake in the bulk pool monitor - wait for es to be up

(cherry picked from commit 9a8849099710ea42ad8636cdd13f28ab0fdfc600)
(cherry picked from commit de2a6a5b929371645950a80dd848c6543b2d3e3b)