### PR TITLE
disable bulk rejection test until https://github.com/uken/fluent-plugin-elasticsearch/pull/406 fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build-images:
 .PHONY: build-images
 
 test:
-	EXCLUDE_SUITE=upgrade hack/testing/entrypoint.sh
+	EXCLUDE_SUITE="upgrade|test-zzzz-bulk-rejection" hack/testing/entrypoint.sh
 .PHONY: test
 
 test-upgrade:


### PR DESCRIPTION
enable when there is a release with the fix for
https://github.com/uken/fluent-plugin-elasticsearch/pull/406