### PR TITLE
re-enable bulk rejection test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build-images:
 .PHONY: build-images
 
 test:
-	EXCLUDE_SUITE="upgrade|test-zzzz-bulk-rejection" hack/testing/entrypoint.sh
+	EXCLUDE_SUITE="upgrade" hack/testing/entrypoint.sh
 .PHONY: test
 
 test-upgrade:


### PR DESCRIPTION
re-enable the bulk rejection test now that there is a fix and
a release for https://github.com/uken/fluent-plugin-elasticsearch/pull/406