### PR TITLE
fix kibana permissions

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -1,8 +1,13 @@
 # Multi-tenant Support and Access Control
-Multi-tenant support and access control is provided by the [openshift-elasticsearch-plugin](https://github.com/fabric8io/openshift-elasticsearch-plugin).  This plugin utilizes [SearchGuard](https://github.com/floragunncom/search-guard) to define and maintain role based access control lists.  Roles are generated based upon the Openshift projects that are visible to an Openshift user.  The following is a brief explanation how roles and role mappings are generated.  Please see the [official SearchGuard documentation](http://floragunncom.github.io/search-guard-docs) for additional information related to SearchGuard.
+Multi-tenant support and access control is provided by the [openshift-elasticsearch-plugin](https://github.com/fabric8io/openshift-elasticsearch-plugin).
+This plugin utilizes [SearchGuard](https://github.com/floragunncom/search-guard) to define and maintain role based access control lists.  Roles are generated
+based upon the Openshift projects that are visible to an Openshift user.  The following is a brief explanation how roles and role mappings are generated.
+Please see the [official SearchGuard documentation](http://floragunncom.github.io/search-guard-docs) for additional information related to SearchGuard.
 
 ## Role Definitions and Permissions
-The permissions for a user are generated when an authenticated user makes their first request to Elasticsearch.  This request typically originates from the Kibana user interface provided by the Openshift logging stack.  The `openshift-elasticsearch-plugin` retrieves the list of projects, on behalf of a user, that are visible to the user.  The plugin will generate roles for each user similiar to:
+The permissions for a user are generated when an authenticated user makes their first request to Elasticsearch.  This request typically originates from
+the Kibana user interface provided by the Openshift logging stack.  The `openshift-elasticsearch-plugin` retrieves the list of projects, on behalf of a user,
+that are visible to the user.  The plugin will generate roles for each user similiar to:
 
 ```
 gen_ocp_kibana_shared:
@@ -17,34 +22,39 @@ gen_project_operations:
       '*': [INDEX_ANY_OPERATIONS]
     ?operations?:
       '*': [INDEX_OPERATIONS]
-gen_user_user2_bar_email_com:
+gen_kibana_4c54bf89fe913f39fc22d76309f80cdc6192928f:       #hash of the username
+  cluster: [USER_KIBANA_CLUSTER_OPERATIONS]
   indices:
-    .all_user2_bar_email_com:
-      '*': [INDEX_PROJECT]
-    ?kibana?994a33f6a157ba4a286395f81a4333db1e6cefb6:
+    '*':
+      '*': [USER_ALL_INDEX_OPS]
+    ?kibana?4c54bf89fe913f39fc22d76309f80cdc6192928f:
       '*': [INDEX_KIBANA]
-    project?foo?bar?*:
+gen_user_4c54bf89fe913f39fc22d76309f80cdc6192928f:         #hash of the username
+  cluster: [USER_CLUSTER_OPERATIONS]
+  indices:
+    ?kibana?4c54bf89fe913f39fc22d76309f80cdc6192928f:
+      '*': [INDEX_KIBANA]
+    ?project?foo?bar?*
       '*': [INDEX_PROJECT]
-    project?xyz?*:
-      '*': [INDEX_PROJECT]
-    foo?bar?*:
-      '*': [INDEX_PROJECT]
-    xyz?*:
+    distinguishedproj?*:
       '*': [INDEX_PROJECT]
 ```
 
 
-**Note:** Question marks replace dots in the ACL document.  In this example, the `gen_user_user2_bar_email_com` allows a given set of permissions to the `project.foo.bar.*` indices.
+**Note:** Question marks replace dots in the ACL document.  In this example, the `gen_user_4c54bf89fe913f39fc22d76309f80cdc6192928f`
+allows a given set of permissions to the `project.foo.bar.*` indices.
 
-**Note:** Index permissions that do not begin with 'project' are for legacy support.  Current releases of the Openshift logging stack rely upon the [common data model](https://github.com/ViaQ/fluent-plugin-viaq_data_model) (CDM) and adds the 'project' prefix.
+**Note:** Index permissions that do not begin with 'project' are for legacy support.  Current releases of the Openshift logging
+stack rely upon the [common data model](https://github.com/ViaQ/fluent-plugin-viaq_data_model) (CDM) and adds the 'project' prefix.
 
-
-Each role defines permissions for cluster and index related actions.  Within each index definition, the actions allowed for a given index are further declared based on the document type.  Additionally, each declaration uses an action group (e.g. `INDEX_OPERATIONS`) to abstract the allowed set of defined permissions.  Action groups are defined in a [separate document](../elasticsearch/sgconfig/sg_action_groups.yml) similar to:
+Each role defines permissions for cluster and index related actions.  Within each index definition, the actions allowed for a given
+index are further declared based on the document type.  Additionally, each declaration uses an action group (e.g. `INDEX_OPERATIONS`)
+to abstract the allowed set of defined permissions.  Action groups are defined in a
+[separate document](../elasticsearch/sgconfig/sg_action_groups.yml) similar to:
 
 ```
 ALL:
   - "indices:*"
-
 ...
 
 INDEX_KIBANA:
@@ -64,10 +74,12 @@ INDEX_PROJECT:
 The plugin will also generate mappings in order to assign users to the roles similar to:
 
 ```
+gen_kibana_994a33f6a157ba4a286395f81a4333db1e6cefb6:
+  users: [user2.bar@email.com]
 gen_ocp_kibana_shared:
   users: [user1, user3]
 gen_project_operations:
   users: [user1, user3]
-gen_user_user2_bar_email_com:
+gen_user_994a33f6a157ba4a286395f81a4333db1e6cefb6:
   users: [user2.bar@email.com]
 ```

--- a/elasticsearch/.gitignore
+++ b/elasticsearch/.gitignore
@@ -6,3 +6,4 @@
 /elasticsearch-cloud-kubernetes-5.6.9.zip
 /elasticsearch-prometheus-exporter-5.6.9.0.zip
 /openshift-elasticsearch-plugin-5.6.9.0-SNAPSHOT.zip
+/openshift-elasticsearch-plugin-5.6.9.0.zip

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -6,7 +6,7 @@ EXPOSE 9200
 EXPOSE 9300
 USER 0
 
-ENV ES_CLOUD_K8S_VER=5.6.9 \
+ENV ES_CLOUD_K8S_VER=5.6.9.2 \
     ES_CONF=/etc/elasticsearch/ \
     ES_JAVA_OPTS="-Dmapper.allow_dots_in_name=true" \
     ES_HOME=/usr/share/elasticsearch \
@@ -16,7 +16,7 @@ ENV ES_CLOUD_K8S_VER=5.6.9 \
     JAVA_VER=1.8.0 \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.9.1 \
+    OSE_ES_VER=5.6.9.0 \
     PROMETHEUS_EXPORTER_VER=5.6.9.0 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -24,8 +24,8 @@ ENV ES_CLOUD_K8S_VER=5.6.9 \
     RECOVER_AFTER_TIME=5m \
     RELEASE_STREAM=origin
 
-ARG ES_CLOUD_K8S_VER=5.6.9
-ARG OSE_ES_VER=5.6.9.1
+ARG ES_CLOUD_K8S_VER=5.6.9.2
+ARG OSE_ES_VER=5.6.9.0
 ARG SG_VER=5.6.9-19
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \
@@ -53,7 +53,7 @@ ADD run.sh prep-install.${RELEASE_STREAM} install.sh ${HOME}/
 COPY utils/** /usr/local/bin/
 
 ARG ES_CLOUD_K8S_URL
-ARG OSE_ES_URL=https://github.com/jcantrill/openshift-elasticsearch-plugin/releases/download/5.6.9.0/openshift-elasticsearch-plugin-5.6.9.0-SNAPSHOT.zip
+ARG OSE_ES_URL=https://github.com/fabric8io/openshift-elasticsearch-plugin/releases/download/openshift-elasticsearch-plugin-5.6.9.0/openshift-elasticsearch-plugin-5.6.9.0.zip
 ARG PROMETHEUS_EXPORTER_URL=https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/5.6.9.0/elasticsearch-prometheus-exporter-5.6.9.0.zip
 ARG SG_URL
 

--- a/elasticsearch/sgconfig/sg_action_groups.yml
+++ b/elasticsearch/sgconfig/sg_action_groups.yml
@@ -72,7 +72,10 @@ INDEX_ANY_ADMIN:
   - READ
 
 INDEX_KIBANA:
-  - ALL
+  - MANAGE
+  - INDEX
+  - READ
+  - DELETE
 INDEX_ANY_KIBANA:
   - INDEX_ANY_ADMIN
   - MANAGE
@@ -86,9 +89,15 @@ INDEX_PROJECT:
   - INDEX_ALL
 METRICS:
   - cluster:monitor/prometheus/metrics
+USER_ALL_INDEX_OPS:
+  - "indices:data/read/field_caps*"
 USER_CLUSTER_OPERATIONS:
   - "indices:data/read/scroll*"
   - CLUSTER_COMPOSITE_OPS_RO
+USER_KIBANA_CLUSTER_OPERATIONS:
+  - MONITOR
+  - CLUSTER_COMPOSITE_OPS
+
 
 ###### CLUSTER LEVEL ######
 

--- a/elasticsearch/sgconfig/sg_roles.yml
+++ b/elasticsearch/sgconfig/sg_roles.yml
@@ -1,7 +1,7 @@
 sg_role_kibana:
   cluster:
     - CLUSTER_MONITOR
-    - CLUSTER_COMPOSITE_OPS_RO
+    - CLUSTER_COMPOSITE_OPS
   indices:
     '?kibana':
       '*':

--- a/elasticsearch/sources
+++ b/elasticsearch/sources
@@ -1,4 +1,1 @@
-0ad83f6df1f72da8485ca6902ae682ee  elasticsearch-5.6.9.rpm
-30890c8abb9a22d83f3b7f1b4980541b  elasticsearch-cloud-kubernetes-5.6.9.zip
-4657cba41f37133c4aa1e2deae6b600b  elasticsearch-prometheus-exporter-5.6.9.0.zip
-879a3506ad9b32a7be6a920a7888895c  openshift-elasticsearch-plugin-5.6.9.0-SNAPSHOT.zip
+299342cb8e4194b7458a88cd69a809fe  openshift-elasticsearch-plugin-5.6.9.0.zip


### PR DESCRIPTION
The additional changes I wanted from my other PR to bump to 5.6.9.  This PR enables a kibana role with the same requirements defined by SearchGuard.  It also pulls in the first release of 5.6.9 of the multitenant plugin to match those changes.