### PR TITLE
bump dist-git dockerfiles

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -1,4 +1,13 @@
-FROM rhel7.3:7.3-released
+#oit## This file is managed by the OpenShift Image Tool: https://github.com/openshift/enterprise-images
+#oit## by the OpenShift Continuous Delivery team (#aos-cd-team on IRC).
+#oit## 
+#oit## Any yum repos listed in this file will effectively be ignored during CD builds.
+#oit## Yum repos must be enabled in the oit configuration files.
+#oit## The content of this file is managed from an external source.
+#oit## Changes made directly in distgit will be lost during the next
+#oit## reconciliation process.
+#oit## 
+FROM rhel7:7-released
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
@@ -17,22 +26,17 @@ ENV HOME=/opt/app-root/src \
     CURATOR_TIMEOUT=300
 
 ARG LOCAL_REPO
-ADD sources /tmp/lib/
-WORKDIR /tmp/lib
-RUN while read -r hash file ; do \
-      curl -s -o $file http://pkgs.devel.redhat.com/repo/containers/logging-curator5-container/$file/$hash/$file ; \
-    done <sources
-
 RUN if [ -n "${LOCAL_REPO}" ] ; then \
      curl -s -o /etc/yum.repos.d/local.repo ${LOCAL_REPO} ; \
     fi
 
-RUN yum-config-manager --enable rhel-7-server-ose-3.8-rpms \
-                       --enable rhel-7-server-extras-rpms && \
-    INSTALL_PKGS="elasticsearch-curator-5.2.0-1.x86_64.rpm \
-                  python2-ruamel-yaml" && \
+ADD elasticsearch-curator-5.2.0-1.x86_64.rpm /tmp/ocp/
+
+RUN yum install -y --setopt=tsflags=nodocs /tmp/ocp/elasticsearch-curator-5.2.0-1.x86_64.rpm && \
+    INSTALL_PKGS="python2-ruamel-yaml" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V elasticsearch-curator python2-ruamel-yaml && \
+    rm -rf /tmp/ocp && \
     yum clean all
 
 COPY run.sh lib/oalconverter/* ${HOME}/
@@ -47,11 +51,15 @@ WORKDIR ${HOME}
 USER 1001
 CMD ["sh", "run.sh"]
 
-LABEL io.k8s.description="Curator elasticsearch container for elasticsearch deletion/archival" \
-  io.k8s.display-name="Curator ${CURATOR_VER}" \
-  io.openshift.tags="logging,elk,elasticsearch,curator" \
-  com.redhat.component=logging-curator-docker \
-  name="openshift3/logging-curator" \
-  version="3.9.0" \
-  release="1" \
-  architecture=x86_64
+LABEL \
+        io.k8s.description="Curator elasticsearch container for elasticsearch deletion/archival" \
+        com.redhat.component="logging-curator5-container" \
+        vendor="Red Hat" \
+        name="openshift3/ose-logging-curator5" \
+        License="GPLv2+" \
+        io.k8s.display-name="Curator 5" \
+        version="v3.10.0" \
+        architecture="x86_64" \
+        release="998" \
+        io.openshift.tags="logging,elk,elasticsearch,curator"
+

--- a/elasticsearch/.gitignore
+++ b/elasticsearch/.gitignore
@@ -7,3 +7,4 @@
 /elasticsearch-prometheus-exporter-5.6.9.0.zip
 /openshift-elasticsearch-plugin-5.6.9.0-SNAPSHOT.zip
 /openshift-elasticsearch-plugin-5.6.9.0.zip
+/elasticsearch-cloud-kubernetes-5.6.9.2.zip

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,3 +1,12 @@
+#oit## This file is managed by the OpenShift Image Tool: https://github.com/openshift/enterprise-images
+#oit## by the OpenShift Continuous Delivery team (#aos-cd-team on IRC).
+#oit## 
+#oit## Any yum repos listed in this file will effectively be ignored during CD builds.
+#oit## Yum repos must be enabled in the oit configuration files.
+#oit## The content of this file is managed from an external source.
+#oit## Changes made directly in distgit will be lost during the next
+#oit## reconciliation process.
+#oit## 
 FROM rhel7:7-released
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
@@ -6,7 +15,7 @@ EXPOSE 9200
 EXPOSE 9300
 USER 0
 
-ENV ES_CLOUD_K8S_VER=5.6.9 \
+ENV ES_CLOUD_K8S_VER=5.6.9.2 \
     ES_CONF=/etc/elasticsearch/ \
     ES_JAVA_OPTS="-Dmapper.allow_dots_in_name=true" \
     ES_HOME=/usr/share/elasticsearch \
@@ -23,31 +32,27 @@ ENV ES_CLOUD_K8S_VER=5.6.9 \
     RECOVER_AFTER_TIME=5m \
     RELEASE_STREAM=prod
 
-ARG ES_CLOUD_K8S_VER=5.6.9
-ARG OSE_ES_VER=5.6.9.1
+ARG ES_CLOUD_K8S_VER=5.6.9.2
+ARG OSE_ES_VER=5.6.9.0
 ARG ES_CLOUD_K8S_URL
 ARG OSE_ES_URL
 ARG PROMETHEUS_EXPORTER_URL
 ARG LOCAL_REPO
 
-ADD sources /tmp/lib/
-WORKDIR /tmp/lib
-RUN while read -r hash file ; do \
-      curl -s -o $file http://pkgs.devel.redhat.com/repo/containers/logging-elasticsearch5-container/$file/$hash/$file ; \
-    done <sources
-
 RUN if [ -n "${LOCAL_REPO}" ] ; then \
      curl -s -o /etc/yum.repos.d/local.repo ${LOCAL_REPO} ; \
     fi
 
-RUN yum-config-manager --enable rhel-7-server-ose-3.8-rpms \
-                   --enable rhel-7-server-extras-rpms  && \
-    packages="elasticsearch-${ES_VER}.rpm \
-              java-${JAVA_VER}-openjdk-headless \
+ADD *.rpm /tmp/ocp/
+ADD *.zip /tmp/lib/
+
+RUN yum install -y --setopt=tsflags=nodocs /tmp/ocp/*.rpm && \
+    packages="java-${JAVA_VER}-openjdk-headless \
               PyYAML  \
               zip" && \
     yum install -y --setopt=tsflags=nodocs ${packages} && \
-    yum clean all
+    yum clean all && \
+    rm -rf /tmp/ocp
 
 ADD sgconfig/ ${HOME}/sgconfig/
 ADD index_templates/ ${ES_HOME}/index_templates/
@@ -67,14 +72,14 @@ CMD ["sh", "/opt/app-root/src/run.sh"]
 
 LABEL \
         io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \
-        com.redhat.component="logging-elasticsearch-docker" \
+        com.redhat.component="logging-elasticsearch5-container" \
         vendor="Red Hat" \
-        name="openshift3/logging-elasticsearch" \
+        name="openshift3/ose-logging-elasticsearch5" \
         License="GPLv2+" \
         io.k8s.display-name="Elasticsearch 5" \
-        version="v3.9.16" \
+        version="v3.10.0" \
         architecture="x86_64" \
-        release="1" \
+        release="667" \
         io.openshift.expose-services="9200:https, 9300:https" \
         io.openshift.tags="logging,elk,elasticsearch"
 

--- a/elasticsearch/sources
+++ b/elasticsearch/sources
@@ -1,1 +1,4 @@
+0ad83f6df1f72da8485ca6902ae682ee  elasticsearch-5.6.9.rpm
+73274de81ce6becc6b4563a71d398193  elasticsearch-cloud-kubernetes-5.6.9.2.zip
+4657cba41f37133c4aa1e2deae6b600b  elasticsearch-prometheus-exporter-5.6.9.0.zip
 299342cb8e4194b7458a88cd69a809fe  openshift-elasticsearch-plugin-5.6.9.0.zip

--- a/kibana/.gitignore
+++ b/kibana/.gitignore
@@ -1,2 +1,1 @@
-/kibana-5.5.2-x86_64.rpm
 /kibana-5.6.9-x86_64.rpm

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -3,9 +3,9 @@
 #oit## 
 #oit## Any yum repos listed in this file will effectively be ignored during CD builds.
 #oit## Yum repos must be enabled in the oit configuration files.
-#oit## Some aspects of this file may be managed programmatically. For example, the image name, labels (version,
-#oit## release, and other), and the base FROM. Changes made directly in distgit may be lost during the next
-#oit## reconciliation.
+#oit## The content of this file is managed from an external source.
+#oit## Changes made directly in distgit will be lost during the next
+#oit## reconciliation process.
 #oit## 
 FROM rhscl/nodejs-6-rhel7
 
@@ -26,27 +26,21 @@ ENV ELASTICSEARCH_URL=https://logging-es:9200 \
 ARG LOCAL_REPO
 
 USER 0
-ADD sources /tmp/lib/
-WORKDIR /tmp/lib
-RUN while read -r hash file ; do \
-      curl -s -o $file http://pkgs.devel.redhat.com/repo/containers/logging-kibana5-container/$file/$hash/$file ; \
-    done <sources
 
 RUN if [ -n "${LOCAL_REPO}" ] ; then \
      curl -s -o /etc/yum.repos.d/local.repo ${LOCAL_REPO} ; \
     fi
 
-RUN yum repolist > /dev/null && \
-    yum-config-manager --enable rhel-7-server-ose-3.9-rpms && \
-    yum-config-manager --disable epel >/dev/null || : && \
-    INSTALLED_PKGS="kibana-${KIBANA_VER}-x86_64.rpm" && \
+ADD *.rpm /tmp/lib/
+WORKDIR /tmp/lib
+RUN INSTALLED_PKGS="kibana-${KIBANA_VER}-x86_64.rpm" && \
     yum install -y --setopt=tsflags=nodocs  ${INSTALLED_PKGS} && \
     yum clean all
 
 ADD nodescl-node /usr/bin
 ADD probe/ /usr/share/kibana/probe/
 ADD kibana.yml ${KIBANA_CONF_DIR}/
-ADD lib ${HOME}
+ADD lib/* ${HOME}/
 ADD run.sh utils install.sh prep-install.${RELEASE_STREAM} ${HOME}/
 ADD logo-OCP-console-hdr-thin.svg ${KIBANA_HOME}/installedPlugins/origin-kibana/public/images/logo-origin-thin.svg
 RUN sh ${HOME}/install.sh
@@ -57,14 +51,14 @@ CMD ["./run.sh"]
 
 LABEL \
         io.k8s.description="Kibana container for querying Elasticsearch for aggregated logs" \
-        com.redhat.component="logging-kibana-docker" \
+        com.redhat.component="logging-kibana5-container" \
         vendor="Red Hat" \
-        name="openshift3/logging-kibana" \
+        name="openshift3/ose-logging-kibana5" \
         License="GPLv2+" \
         io.k8s.display-name="Kibana" \
-        version="v3.9.16" \
+        version="v3.10.0" \
         architecture="x86_64" \
-        release="1" \
+        release="667" \
         io.openshift.expose-services="5601:http" \
         io.openshift.tags="logging,elk,kibana"
 


### PR DESCRIPTION
This PR:
* bumps dist-git to 5.6.9
* Fixes the Dockerfile to rely on the look-aside cache

cc @adammhaile My concern is the FROM in downstream was changes to a non scl image which means even if the build succeeds I do not have confidence it will run.