### PR TITLE
[release-3.7] fluentd must use TLSv1.2 or later to talk to Elasticsearch

### DIFF
--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -3,6 +3,7 @@
       host "#{ENV['ES_HOST']}"
       port "#{ENV['ES_PORT']}"
       scheme https
+      ssl_version TLSv1_2
       target_index_key viaq_index_name
       id_key viaq_msg_id
       remove_keys viaq_index_name

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -3,6 +3,7 @@
       host "#{ENV['OPS_HOST']}"
       port "#{ENV['OPS_PORT']}"
       scheme https
+      ssl_version TLSv1_2
       target_index_key viaq_index_name
       id_key viaq_msg_id
       remove_keys viaq_index_name


### PR DESCRIPTION
(cherry picked from commit f33cdc402275f16afd3bb784c4dddc737779b2ab)