### PR TITLE
Set log level on module loggers instead of on root logger

### DIFF
--- a/curator/src/util.py
+++ b/curator/src/util.py
@@ -5,5 +5,6 @@ import logging
 
 def create_logger(name):
     lvl = logging._levelNames.get(os.getenv('CURATOR_SCRIPT_LOG_LEVEL', 'INFO'))
-    logging.basicConfig(level=lvl)
-    return logging.getLogger(name)
+    logger = logging.getLogger(name)
+    logger.setLevel(lvl)
+    return logger


### PR DESCRIPTION
The idea was to inherit log level from root logger but that doesn't seem to work.