### PR TITLE
version lock fluent so to still get merge_json feature if needed

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -40,7 +40,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
      'elasticsearch:<6' \
       fluentd:${FLUENTD_VERSION} \
      'fluent-plugin-elasticsearch:<2.0.0' \
-     'fluent-plugin-kubernetes_metadata_filter:1.0.1' \
+     'fluent-plugin-kubernetes_metadata_filter:<1.1.0' \
       'fluent-plugin-record-modifier:<1.0.0' \
       'fluent-plugin-rewrite-tag-filter:<1.6.0' \
       fluent-plugin-secure-forward \


### PR DESCRIPTION
This PR locks fluent metadata plugin less then 1.1.x so we still pull in a version that supports merge_json which is removed by https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/131