### PR TITLE
[es5.x] oc rollout is unreliable for the error cases - use oc scale to ensure pods are stopped

### DIFF
--- a/test/curator.sh
+++ b/test/curator.sh
@@ -20,7 +20,7 @@ os::util::environment::use_sudo
 os::test::junit::declare_suite_start "test/curator"
 
 curl_output() {
-    python -mjson.tool | artifact_out > /dev/null 2>&1
+    python -mjson.tool 2>&1 | artifact_out
 }
 
 add_message_to_index() {


### PR DESCRIPTION
General clean up of test code, use artifact_out, etc.
The rest isn't really applicable to cronjobs

(cherry picked from commit 65e5db6d9780b61369f2f5bd985097b4b502f2c2)