### PR TITLE
Version lock fluentd to make sure not to get kube gem that deprecates merge_json

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -40,7 +40,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
      'elasticsearch:<5' \
       fluentd:${FLUENTD_VERSION} \
      'fluent-plugin-elasticsearch:~>1.0' \
-     'fluent-plugin-kubernetes_metadata_filter:1.0.1' \
+     'fluent-plugin-kubernetes_metadata_filter:<1.1.0' \
       'fluent-plugin-record-modifier:<1.0.0' \
       'fluent-plugin-rewrite-tag-filter:<1.6.0' \
       fluent-plugin-secure-forward \


### PR DESCRIPTION
3.9 cherry pick of #1167 