### PR TITLE
[release-3.7] version lock fluent so to still get merge_json feature if needed

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -39,7 +39,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
      'elasticsearch:<5' \
       fluentd:${FLUENTD_VERSION} \
      'fluent-plugin-elasticsearch:~>1.0' \
-     'fluent-plugin-kubernetes_metadata_filter:1.0.1' \
+     'fluent-plugin-kubernetes_metadata_filter:<1.1.0' \
       'fluent-plugin-record-modifier:<1.0.0' \
       'fluent-plugin-rewrite-tag-filter:<1.6.0' \
       fluent-plugin-secure-forward \

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -3,6 +3,7 @@
       host "#{ENV['ES_HOST']}"
       port "#{ENV['ES_PORT']}"
       scheme https
+      ssl_version TLSv1_2
       target_index_key viaq_index_name
       id_key viaq_msg_id
       remove_keys viaq_index_name

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -3,6 +3,7 @@
       host "#{ENV['OPS_HOST']}"
       port "#{ENV['OPS_PORT']}"
       scheme https
+      ssl_version TLSv1_2
       target_index_key viaq_index_name
       id_key viaq_msg_id
       remove_keys viaq_index_name


### PR DESCRIPTION
(cherry picked from commit b1924bcb31cf6daebe85cad0b2ea7d4827fb5cf5)

3.7  backport of #1167 