### PR TITLE
[release-3.7] bug 1562004. Add retry logic

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -20,24 +20,13 @@ ENV DATA_VERSION=1.6.0 \
 
 ARG TEST_REPO
 
-LABEL io.k8s.description="Fluentd container for collecting of docker container logs" \
-      io.k8s.display-name="Fluentd ${FLUENTD_VERSION}" \
-      io.openshift.tags="logging,elk,fluentd" \
-      com.redhat.component=logging-fluentd-docker \
-      name="openshift3/logging-fluentd" \
-      version="v3.9.0" \
-      release="1" \
-      architecture=x86_64
-
-USER 0
-
-RUN test -n "${TEST_REPO}" && curl -s -o /etc/yum.repos.d/test.repo ${TEST_REPO}
-
-RUN yum-config-manager --enable rhel-7-server-ose-3.9-rpms && \
+RUN yum-config-manager --enable rhel-7-server-ose-3.7-rpms && \
   INSTALL_PKGS="fluentd-${FLUENTD_VERSION} \
                 hostname \
                 bc \
                 iproute \
+                rubygem-syslog_protocol \
+                rubygem-fluent-mixin-config-placeholders \
                 rubygem-fluent-plugin-elasticsearch \
                 rubygem-fluent-plugin-flatten-hash \
                 rubygem-fluent-plugin-kubernetes_metadata_filter \
@@ -68,3 +57,14 @@ RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
 WORKDIR ${HOME}
 
 CMD ["sh", "run.sh"]
+
+LABEL \
+        io.k8s.description="Fluentd container for collecting of container logs" \
+        com.redhat.component="logging-fluentd-container" \
+        vendor="Red Hat" \
+        name="openshift3/logging-fluentd" \
+        License="GPLv2+" \
+        io.k8s.display-name="Fluentd" \
+        version="v3.7.46" \
+        architecture="x86_64" \
+        io.openshift.tags="logging,elk,fluentd"

--- a/fluentd/configs.d/openshift/output-applications.conf
+++ b/fluentd/configs.d/openshift/output-applications.conf
@@ -1,3 +1,7 @@
+<match retry_es>
+   @type copy
+   @include output-es-retry.conf
+</match>
 <match **>
    @type copy
    @include output-es-config.conf

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -3,6 +3,7 @@
       host "#{ENV['ES_HOST']}"
       port "#{ENV['ES_PORT']}"
       scheme https
+      ssl_version TLSv1_2
       target_index_key viaq_index_name
       id_key viaq_msg_id
       remove_keys viaq_index_name

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -14,6 +14,7 @@
       ca_file "#{ENV['OPS_CA']}"
 
       type_name com.redhat.viaq.common
+      retry_tag "retry_es_ops"
 
       # there is currently a bug in the es plugin + excon - cannot
       # recreate/reload connections

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -3,6 +3,7 @@
       host "#{ENV['OPS_HOST']}"
       port "#{ENV['OPS_PORT']}"
       scheme https
+      ssl_version TLSv1_2
       target_index_key viaq_index_name
       id_key viaq_msg_id
       remove_keys viaq_index_name

--- a/fluentd/configs.d/openshift/output-es-ops-retry.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-retry.conf
@@ -1,7 +1,7 @@
     <store>
       @type elasticsearch
-      host "#{ENV['ES_HOST']}"
-      port "#{ENV['ES_PORT']}"
+      host "#{ENV['OPS_HOST']}"
+      port "#{ENV['OPS_PORT']}"
       scheme https
       target_index_key viaq_index_name
       id_key viaq_msg_id
@@ -9,22 +9,21 @@
       user fluentd
       password changeme
 
-      client_key "#{ENV['ES_CLIENT_KEY']}"
-      client_cert "#{ENV['ES_CLIENT_CERT']}"
-      ca_file "#{ENV['ES_CA']}"
+      client_key "#{ENV['OPS_CLIENT_KEY']}"
+      client_cert "#{ENV['OPS_CLIENT_CERT']}"
+      ca_file "#{ENV['OPS_CA']}"
 
       type_name com.redhat.viaq.common
-      retry_tag "retry_es"
 
       # there is currently a bug in the es plugin + excon - cannot
       # recreate/reload connections
       reload_connections false
       reload_on_failure false
-      flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
-      max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"
+      flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '1s'}"
+      max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_type file
-      buffer_path '/var/lib/fluentd/buffer-output-es-config'
+      buffer_path '/var/lib/fluentd/es-ops-retry'
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
       buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"

--- a/fluentd/configs.d/openshift/output-es-ops-retry.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-retry.conf
@@ -3,6 +3,7 @@
       host "#{ENV['OPS_HOST']}"
       port "#{ENV['OPS_PORT']}"
       scheme https
+      ssl_version TLSv1_2
       target_index_key viaq_index_name
       id_key viaq_msg_id
       remove_keys viaq_index_name

--- a/fluentd/configs.d/openshift/output-es-retry.conf
+++ b/fluentd/configs.d/openshift/output-es-retry.conf
@@ -3,6 +3,7 @@
       host "#{ENV['ES_HOST']}"
       port "#{ENV['ES_PORT']}"
       scheme https
+      ssl_version TLSv1_2
       target_index_key viaq_index_name
       id_key viaq_msg_id
       remove_keys viaq_index_name

--- a/fluentd/configs.d/openshift/output-es-retry.conf
+++ b/fluentd/configs.d/openshift/output-es-retry.conf
@@ -14,7 +14,6 @@
       ca_file "#{ENV['ES_CA']}"
 
       type_name com.redhat.viaq.common
-      retry_tag "retry_es"
 
       # there is currently a bug in the es plugin + excon - cannot
       # recreate/reload connections
@@ -24,7 +23,7 @@
       max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"
       disable_retry_limit true
       buffer_type file
-      buffer_path '/var/lib/fluentd/buffer-output-es-config'
+      buffer_path '/var/lib/fluentd/es-retry'
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
       buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"

--- a/fluentd/configs.d/openshift/output-operations.conf
+++ b/fluentd/configs.d/openshift/output-operations.conf
@@ -1,3 +1,7 @@
+<match retry_es_ops>
+  @type copy
+  @include ../dynamic/output-es-ops-retry.conf
+</match>
 <match output_ops_tag journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops audit.log**>
   @type copy
   @include ../dynamic/output-es-ops-config.conf


### PR DESCRIPTION
(cherry picked from commit 7ba1206d71dd2fc6e75f370221fe15abdee0c75f)

This backports the retry logic.  Should additionally address https://bugzilla.redhat.com/show_bug.cgi?id=1511116 along with tagging fluent-plugin-elasticsearch-1.16.1 into puddle

3.7 backport of #1139 