### PR TITLE
add fluentd unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
-sudo: required
+matrix:
+  include:
+    - env: NAME='fluentd - generate_throttle_configs test'
+      language: ruby
+      rvm:
+      - 2.0
+      before_script:
+        cd fluentd/lib/generate_throttle_configs
+      script:
+        rake test
 
-language: ruby
-
-services:
-  - docker
-
-script:
-  - cd hack && PREFIX="openshift/origin-" ./build-images.sh

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -49,7 +49,8 @@ ADD configs.d/ /etc/fluent/configs.d/
 ADD filter_k8s_meta_for_mux_client.rb /etc/fluent/plugin/
 ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb /etc/fluent/plugin/
 ADD parser_viaq_docker_audit.rb viaq_docker_audit.rb /etc/fluent/plugin/
-ADD run.sh generate_throttle_configs.rb generate_syslog_config.rb ${HOME}/
+ADD run.sh generate_syslog_config.rb ${HOME}/
+ADD lib/*/lib/*.rb ${HOME}/
 
 RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
     chmod 777 /etc/fluent/configs.d/dynamic && \

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -52,7 +52,8 @@ ADD configs.d/ /etc/fluent/configs.d/
 ADD filter_k8s_meta_for_mux_client.rb /etc/fluent/plugin/
 ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb /etc/fluent/plugin/
 ADD parser_viaq_docker_audit.rb viaq_docker_audit.rb /etc/fluent/plugin/
-ADD run.sh generate_throttle_configs.rb generate_syslog_config.rb ${HOME}/
+ADD run.sh generate_syslog_config.rb ${HOME}/
+ADD lib/*/lib/*.rb ${HOME}/
 
 RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
     chmod 777 /etc/fluent/configs.d/dynamic && \

--- a/fluentd/lib/generate_throttle_configs/Rakefile
+++ b/fluentd/lib/generate_throttle_configs/Rakefile
@@ -1,0 +1,9 @@
+#require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+    t.test_files = FileList['test/**/*_test.rb']
+end
+desc "Run tests"
+
+task default: :test

--- a/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
+++ b/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
@@ -3,19 +3,19 @@ require 'date'
 require 'logger'
 
 log_level = ENV['LOG_LEVEL'] || 'WARN'
-@log = Logger.new(STDOUT)
+log = Logger.new(STDOUT)
 
 begin
-  @log.level = eval("Logger::#{log_level}")
+  log.level = eval("Logger::#{log_level}")
 rescue
-  @log.level = Logger::WARN
-  @log.warn "#{log_level} is not a valid value. Must be one of: DEBUG, WARN, INFO, ERROR"
-  @log.warn "Setting log level to WARN"
+  log.level = Logger::WARN
+  log.warn "#{log_level} is not a valid value. Must be one of: DEBUG, WARN, INFO, ERROR"
+  log.warn "Setting log level to WARN"
 end
 
 ENV.sort.each do |entry|
-  @log.debug entry
-end if @log.debug?
+  log.debug entry
+end if log.debug?
 
 DEFAULT_OPS_PROJECTS = !ENV['OCP_OPERATIONS_PROJECTS'].nil? ? ENV['OCP_OPERATIONS_PROJECTS'].split(' ') : ['default', 'openshift', 'openshift-infra']
 DEFAULT_FILENAME = "/etc/fluent/configs.d/user/throttle-config.yaml"
@@ -31,14 +31,15 @@ def cont_pos_file
 end
 
 def get_cont_pos_file_name(name)
-  return "/var/log/es-container-#{name}.log.pos"
+  prefix = ENV['CONT_POS_FILE_PREFIX']||'/var/log/es-container-' 
+  "#{prefix}#{name}.log.pos"
 end
 
 def get_file_name(name)
   ## file_name follows pattern: gen-#{name}-YYYYMMDD.conf ##
 
-  file_name = '/etc/fluent/configs.d/dynamic/input-docker-'
-  file_name << name
+  file_name = ENV['THROTTLE_PREFIX']||'/etc/fluent/configs.d/dynamic/input-docker-'
+  file_name = file_name + name
   file_name << '-'
   file_name << Date.today.strftime('%Y%m%d')
   file_name << '.conf'
@@ -51,8 +52,8 @@ def get_all_throttle_files()
   return Dir.glob('/var/log/es-container-*.log.pos')
 end
 
-def move_pos_file_project_entry(source_file, dest_file, project)
-
+def move_pos_file_project_entry(source_file, dest_file, project, log)
+  log.debug "moving project #{project} pos entry from #{source_file} to #{dest_file}"
   if File.file?(source_file)
     project_pattern = ".*_#{project}_.*\.log"
 
@@ -60,6 +61,7 @@ def move_pos_file_project_entry(source_file, dest_file, project)
     File.open(source_file) { |file|
       file.grep(/#{project_pattern}/) { |match| matches << match }
     }
+    log.debug("Found #{matches.length} in position file for project #{project}")
 
     update = ""
     update = File.read(dest_file) if File.file?(dest_file)
@@ -78,16 +80,18 @@ def move_pos_file_project_entry(source_file, dest_file, project)
       update.gsub!(/#{log_file_pattern}.*$\n/, "")
     }
     File.open(source_file, "w") { |file| file.write update }
+  else
+    log.info("#{source_file} position file does not exist")
   end
 
 end
 
 ## This will copy the pos entries from the throttle configs back to the default pos file
-def revert_throttle()
-  get_all_throttle_files.each { |file_name| move_pos_file_project_entry(file_name, cont_pos_file, '.*') }
+def revert_throttle(log)
+  get_all_throttle_files.each { |file_name| move_pos_file_project_entry(file_name, cont_pos_file, '.*', log) }
 end
 
-def seed_file(file_name, project)
+def seed_file(file_name, project, log)
 
   if project.eql?('.operations')
     path = DEFAULT_OPS_PROJECTS.map{|p| get_project_pattern(p)}.join(',')
@@ -102,7 +106,7 @@ def seed_file(file_name, project)
   end
 
   File.open(file_name, 'w') { |file|
-    @log.debug "Seeding #{file_name} with path: '#{path}' and pos_file: '#{pos_file}'"
+    log.debug "Seeding #{file_name} with path: '#{path}' and pos_file: '#{pos_file}'"
     file.write(<<-CONF)
 <source>
   @type tail
@@ -114,19 +118,19 @@ def seed_file(file_name, project)
   }
 
   # Set up the initial pos file in case we had already read from container files
-  move_pos_file_project_entry(cont_pos_file, pos_file, project) unless project.eql?('.operations')
-  DEFAULT_OPS_PROJECTS.each{ |ops_project| move_pos_file_project_entry(cont_pos_file, pos_file, ops_project) } if project.eql?('.operations')
+  move_pos_file_project_entry(cont_pos_file, pos_file, project, log) unless project.eql?('.operations')
+  DEFAULT_OPS_PROJECTS.each{ |ops_project| move_pos_file_project_entry(cont_pos_file, pos_file, ops_project, log) } if project.eql?('.operations')
 end
 
-def write_to_file(project, key, value)
+def write_to_file(project, key, value, log)
 
   file_name = get_file_name(project)
 
   # check if the file already exists, if not create it
-  seed_file(file_name, project) if !File.exist?(file_name)
+  seed_file(file_name, project, log) if !File.exist?(file_name)
 
   File.open(file_name, 'a') { |file|
-    @log.debug "Writing key: '#{key}' value: '#{value}' to file: #{file_name}"
+    log.debug "Writing key: '#{key}' value: '#{value}' to file: #{file_name}"
     file.write(<<-CONF)
   #{key} #{value}
     CONF
@@ -134,11 +138,11 @@ def write_to_file(project, key, value)
 
 end
 
-def close_file(project)
+def close_file(project, log)
   file_name = get_file_name(project)
 
   File.open(file_name, 'a') { |file|
-    @log.debug "Closing file: #{file_name}"
+    log.debug "Closing file: #{file_name}"
     file.write(<<-CONF)
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
@@ -150,31 +154,33 @@ def close_file(project)
   } if File.exist?(file_name)
 end
 
-def create_default_docker(excluded)
+def create_default_docker(input_conf_file, excluded, log, options={})
+  cont_logs_path = options[:cont_logs_path] || '/var/log/containers/*.log'
+  cont_pos_file = options[:cont_pos_file] || '/var/log/es-containers.log.pos'
+  use_crio = options[:use_crio]
 
-  file_name = '/etc/fluent/configs.d/dynamic/input-docker-default-docker.conf'
-
-  File.open(file_name, 'w') { |file|
-    @log.debug "Creating default docker input config file #{file_name}"
+  File.open(input_conf_file, 'w') { |file|
+    log.debug "Creating default docker input config file #{input_conf_file}"
     file.write(<<-CONF)
 <source>
   @type tail
   @id docker-input
   @label @INGRESS
-  path "#{ENV[CONT_LOGS_PATH] || '/var/log/containers/*.log'}"
-  pos_file "#{ENV[POS_FILE] || '/var/log/es-containers.log.pos'}"
+  path "#{cont_logs_path}"
+  pos_file "#{cont_pos_file}"
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
-  format #{ENV['USE_CRIO'] == 'true' ? '/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/' : 'json'}
+  format #{use_crio == 'true' ? '/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/' : 'json'}
   keep_time_key true
-  read_from_head "#{ENV[READ_FROM_HEAD] || 'true'}"
+  read_from_head "#{options[:read_from_head] || 'true'}"
   exclude_path #{excluded}
 </source>
     CONF
   }
+    log.debug "Created default docker input config file"
 end
 
-def validate(key, value)
+def validate(key, value, log)
   # if the key is in valid settings, validate the value by required type
   if VALID_SETTINGS.keys.include?(key)
     case VALID_SETTINGS[key]
@@ -191,31 +197,32 @@ def validate(key, value)
       return false
     end
   else
-    @log.warn "Unknown option \"#{key}\""
+    log.warn "Unknown option \"#{key}\""
     return false
   end
 
   if !valid
-    @log.warn "Invalid value type matched for \"#{value}\""
+    log.warn "Invalid value type matched for \"#{value}\""
   end
 
   return valid
 end
 
 def get_project_pattern(name)
-  "/var/log/containers/*_#{name}_*.log"
+  dir = ENV['CONT_LOG_DIR']||'/var/log/containers'
+  "#{dir}/*_#{name}_*.log"
 end
 
-filename = ENV['THROTTLE_CONF_LOCATION'] || DEFAULT_FILENAME
+def generate_throttle_configs(input_conf, throttle_conf_file, log, init_options={})
 begin
-  parsed = if File.exists?(filename) && (hsh = YAML.load_file(filename)) && hsh.respond_to?(:map)
-             @log.debug "throttle hash #{hsh}"
+  parsed = if File.exist?(throttle_conf_file) && (hsh = YAML.load_file(throttle_conf_file)) && hsh.respond_to?(:map)
+             log.debug "throttle hash #{hsh}"
              Hash[hsh.map{|k,v|[k,v]}]
            else
              Hash.new
            end
 rescue Exception => ex
-  @log.warn "Could not parse YAML file #{filename} : #{ex} - ignoring..."
+  log.warn "Could not parse YAML file #{throttle_conf_file} : #{ex} - ignoring..."
   parsed = Hash.new
 end
 
@@ -224,28 +231,28 @@ throttling = false
 # We do not yet support throttling logs read from the journal
 # So we don't support throttling operations logs here - use the journald
 # journald.conf to do that
-parsed.each { |name,options|
-  @log.info("Evaluating log throttle settings from #{filename} #{name} #{options}...")
+parsed.each do |name,options|
+  log.info("Evaluating log throttle settings from #{throttle_conf_file} #{name} #{options}...")
   # YAML parser allows some strange things . . .
   unless name.class.eql?(String)
-    @log.warn "Invalid value #{name} for project name -- ignoring..."
+    log.warn "Invalid value #{name} for project name -- ignoring..."
     next
   end
   unless options.class.eql?(Hash)
-    @log.warn "Invalid value #{options} for options project #{name} -- ignoring..."
+    log.warn "Invalid value #{options} for options project #{name} -- ignoring..."
     next
   end
 
   needclose = false
-  options.each_pair { |k,v|
-    @log.debug("Evaluating throttling for project '#{name}'")
-    if validate(k,v)
-      write_to_file(name, k, v)
+  options.each { |k,v|
+    log.debug("Evaluating throttling for project '#{name}'")
+    if validate(k,v, log)
+      write_to_file(name, k, v, log)
       needclose = true
       throttling = true if !throttling
 
       if name.eql?('.operations')
-        @log.debug("Found throttling settings for operations. Excluding projects: #{DEFAULT_OPS_PROJECTS}")
+        log.debug("Found throttling settings for operations. Excluding projects: #{DEFAULT_OPS_PROJECTS}")
         DEFAULT_OPS_PROJECTS.each do |p|
           excluded.push(get_project_pattern(p))
         end
@@ -253,14 +260,27 @@ parsed.each { |name,options|
         excluded.push(get_project_pattern(name))
       end
     else
-      @log.warn "Invalid key/value pair {\"#{k}\":\"#{v}\"} provided -- ignoring..."
+      log.warn "Invalid key/value pair {\"#{k}\":\"#{v}\"} provided -- ignoring..."
     end
   } if !options.nil?
 
   # if file was created, close it here
-  close_file(name) if needclose
-}
+  close_file(name, log) if needclose
+end
 
-revert_throttle if !throttling
+revert_throttle(log) unless throttling
 
-create_default_docker(excluded)
+create_default_docker(input_conf, excluded, log, init_options)
+
+end
+
+if __FILE__ == $0
+    generate_throttle_configs('/etc/fluent/configs.d/dynamic/input-docker-default-docker.conf',
+                              ENV['THROTTLE_CONF_LOCATION'] || DEFAULT_FILENAME,
+                              log,
+                              :cont_logs_path=>"#{ENV[CONT_LOGS_PATH] || '/var/log/containers/*.log'}",
+                              :cont_pos_file=>"#{ENV[POS_FILE] || '/var/log/es-containers.log.pos'}",
+                              :use_crio=>ENV['USE_CRIO']||false,
+                              :read_from_head=>ENV[READ_FROM_HEAD] || 'true')
+end
+

--- a/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
+++ b/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
@@ -1,0 +1,167 @@
+require_relative 'test_helper'
+
+describe 'generate_throttle_configs' do
+
+  before do
+    @log_messages = {:warn=>[]}
+    @log = Logger.new(STDOUT)
+    @log.level = eval("Logger::#{ENV['LOG_LEVEL'] || 'ERROR'}")
+    @log.instance_variable_set(:@log_messages, @log_messages)
+
+    def @log.warn(msg)
+      @log_messages[:warn] << msg
+      super(msg)
+    end
+
+    @throttle_conf = create_test_file
+    @input_conf = create_test_file
+  end
+
+  describe 'when throttle config exists and is empty' do
+
+    it 'should produce a config with no exclusions' do
+      generate_throttle_configs(@input_conf, @throttle_conf, @log)
+      act = File.read(@input_conf)
+      act.must_equal '<source>
+  @type tail
+  @id docker-input
+  @label @INGRESS
+  path "/var/log/containers/*.log"
+  pos_file "/var/log/es-containers.log.pos"
+  time_format %Y-%m-%dT%H:%M:%S.%N%Z
+  tag kubernetes.*
+  format json
+  keep_time_key true
+  read_from_head "true"
+  exclude_path []
+</source>
+'
+    end
+
+    describe 'and is configured to use alternate path and position files' do
+        it 'should use the specified path and position' do
+          options = {
+            :cont_logs_path => '/tmp/foo/*.logs',
+            :cont_pos_file => '/tmp/foo/*.logs.pos',
+            :read_from_head => "false"
+          }
+
+      generate_throttle_configs(@input_conf, @throttle_conf, @log, options)
+      act = File.read(@input_conf)
+      act.must_equal '<source>
+  @type tail
+  @id docker-input
+  @label @INGRESS
+  path "/tmp/foo/*.logs"
+  pos_file "/tmp/foo/*.logs.pos"
+  time_format %Y-%m-%dT%H:%M:%S.%N%Z
+  tag kubernetes.*
+  format json
+  keep_time_key true
+  read_from_head "false"
+  exclude_path []
+</source>
+'
+        end
+    end
+
+    describe 'and is configured to use CRIO' do
+        it 'should use the CRIO log format' do
+      generate_throttle_configs(@input_conf, @throttle_conf, @log, :use_crio=>'true')
+      act = File.read(@input_conf)
+      act.must_equal'<source>
+  @type tail
+  @id docker-input
+  @label @INGRESS
+  path "/var/log/containers/*.log"
+  pos_file "/var/log/es-containers.log.pos"
+  time_format %Y-%m-%dT%H:%M:%S.%N%Z
+  tag kubernetes.*
+  format /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+  keep_time_key true
+  read_from_head "true"
+  exclude_path []
+</source>
+'
+        end
+    end
+  end
+
+  describe 'when throttle config exists and is not empty' do
+#/var/log/containers/docker-registry-1-8md2d_default_registry-50192f5ef340512c3621d2122bbd995f738a654e0378646284008cdef0c3b143.log	00000000000830be	00000000021db8b3
+    before do
+      @throttle_conf = create_test_file('
+firstproject:
+  some_value_in_error: "abc"
+  read_lines_limit: 100
+secondproject:
+  read_lines_limit: 200
+')
+      @pos_file = create_test_file('
+/var/log/containers/docker-registry-1-8md2d_firstproject_registry-50192f5ef340512c3621d2122bbd995f738a654e0378646284008cdef0c3b143.log	00000000000830be	00000000021db8b3
+/var/log/containers/docker-registry-1-8md2d_other_registry-50192f5ef340512c3621d2122bbd995f738a654e0378646284008cdef0c3b143.log	00000000000830be	00000000021db8b3
+')
+      @input_conf = create_test_file
+      ENV['THROTTLE_PREFIX'] = '/tmp/test-input-docker-'
+      ENV['CONT_POS_FILE_PREFIX'] = '/tmp/test-pos-file-'
+      ENV['JSON_FILE_POS_FILE'] = @pos_file
+      ENV['CONT_LOG_DIR'] = '/tmp'
+      ENV['POS_FILE'] = @pos_file
+    end
+
+    after do
+      ENV['THROTTLE_PREFIX'] = nil
+      ENV['CONT_POS_FILE_PREFIX'] = nil
+      ENV['JSON_FILE_POS_FILE'] = nil
+      ENV['CONT_LOG_DIR'] = nil
+      ENV['POS_FILE'] = nil
+      FileUtils.rm_r Dir.glob('/tmp/test-input-docker-*')
+      FileUtils.rm_r Dir.glob('/tmp/test-pos-file*')
+    end
+
+    it 'should produce a config with exclusions' do
+      cont_log_dir = ENV['CONT_LOG_DIR']
+      generate_throttle_configs(@input_conf, @throttle_conf, @log, :cont_pos_file=>@pos_file)
+      act = File.read(@input_conf)
+      act.must_equal"<source>
+  @type tail
+  @id docker-input
+  @label @INGRESS
+  path \"/var/log/containers/*.log\"
+  pos_file \"#{@pos_file}\"
+  time_format %Y-%m-%dT%H:%M:%S.%N%Z
+  tag kubernetes.*
+  format json
+  keep_time_key true
+  read_from_head \"true\"
+  exclude_path [\"#{cont_log_dir}/*_firstproject_*.log\", \"#{cont_log_dir}/*_secondproject_*.log\"]
+</source>
+"
+      {"firstproject"=>100, "secondproject"=>200}.each do |project,limit|
+        throttle_file = "#{ENV['THROTTLE_PREFIX']}#{project}-#{Date.today.strftime('%Y%m%d')}.conf"
+        pos_file = "#{ENV['CONT_POS_FILE_PREFIX']}#{project}.log.pos"
+        File.exist?(throttle_file).wont_be_nil
+        File.exist?(pos_file).wont_be_nil
+        act = File.read(throttle_file)
+        act.must_equal "<source>
+  @type tail
+  @id #{project}-input
+  @label @INGRESS
+  path /tmp/*_#{project}_*.log
+  pos_file #{pos_file}
+  read_lines_limit #{limit}
+  time_format %Y-%m-%dT%H:%M:%S.%N%Z
+  tag kubernetes.*
+  format json
+  keep_time_key true
+  read_from_head \"true\"
+</source>
+"
+        act =  File.read("#{ENV['CONT_POS_FILE_PREFIX']}firstproject.log.pos")
+        act.must_equal "/var/log/containers/docker-registry-1-8md2d_firstproject_registry-50192f5ef340512c3621d2122bbd995f738a654e0378646284008cdef0c3b143.log	00000000000830be	00000000021db8b3\n"
+      end
+
+   end
+  end
+
+end

--- a/fluentd/lib/generate_throttle_configs/test/test_helper.rb
+++ b/fluentd/lib/generate_throttle_configs/test/test_helper.rb
@@ -1,0 +1,18 @@
+require File.join(File.dirname(__FILE__), '..', 'lib/generate_throttle_configs') 
+require 'minitest/autorun'
+require 'fileutils'
+
+def create_test_file(content=nil)
+    filename = "/tmp/generate_throttle_configs_testfile-#{rand(0...10000)}"
+    if content
+      File.open(filename, 'w') do |f|
+        f.write(content)
+      end
+    else
+      FileUtils.touch(filename).first
+    end
+    at_exit do
+      FileUtils.rm(filename)
+    end
+    filename
+end


### PR DESCRIPTION
This PR provides a 'proof' of concept of how we might utilize travis to 'unit test' parts of the logging stack.  The basic assumption here:
* Early testing of dependencies (e.g. start scripts)
* No cluster dependency (or use of mocks)

It provides a bases by which we can refactor if needed when unit tests are in place

If we desire to move forward we may wish to hold merging this until master is open for 3.11