### PR TITLE
mapper.allow_dots_in_name setting not needed (supported) in ES 5.x

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -17,7 +17,6 @@ USER 0
 
 ENV ES_CLOUD_K8S_VER=5.6.9.2 \
     ES_CONF=/etc/elasticsearch/ \
-    ES_JAVA_OPTS="-Dmapper.allow_dots_in_name=true" \
     ES_HOME=/usr/share/elasticsearch \
     ES_VER=5.6.9 \
     HOME=/opt/app-root/src \

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -8,7 +8,6 @@ USER 0
 
 ENV ES_CLOUD_K8S_VER=5.6.9.2 \
     ES_CONF=/etc/elasticsearch/ \
-    ES_JAVA_OPTS="-Dmapper.allow_dots_in_name=true" \
     ES_HOME=/usr/share/elasticsearch \
     ES_VER=5.6.9 \
     HOME=/opt/app-root/src \


### PR DESCRIPTION
Closes #1188