### PR TITLE
fix logs util to retrieve logs from persistent dir.  Ref #1108

### DIFF
--- a/elasticsearch/utils/logs
+++ b/elasticsearch/utils/logs
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 CLUSTER_NAME=${CLUSTER_NAME:-logging-es}
-log_dir=/elasticsearch/${CLUSTER_NAME}/logs
+log_dir=/elasticsearch/persistent/${CLUSTER_NAME}/logs
 file=${1:-$CLUSTER_NAME.log}
 cmd=cat
 


### PR DESCRIPTION
This fixes the log utility to get logs from /elasticsearch/persistent ref #1108 