### PR TITLE
cannot have empty field name in es5

### DIFF
--- a/test/viaq-data-model.sh
+++ b/test/viaq-data-model.sh
@@ -94,7 +94,7 @@ cat > $cfg <<EOF
     undefined12 \${true}
     empty1 ""
     undefined2 {"undefined2":"undefined2","":"","undefined22":2222,"undefined23":false}
-    undefined3 {"":""}
+    undefined3 {"emptyfield":""}
     undefined4 undefined4
     undefined5 undefined5
   </record>


### PR DESCRIPTION
change test so record sent to es5 does not have an empty field name