### PR TITLE
fix downstream to depend on rpm

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -31,9 +31,7 @@ RUN if [ -n "${LOCAL_REPO}" ] ; then \
      curl -s -o /etc/yum.repos.d/local.repo ${LOCAL_REPO} ; \
     fi
 
-ADD *.rpm /tmp/lib/
-WORKDIR /tmp/lib
-RUN INSTALLED_PKGS="kibana-${KIBANA_VER}-x86_64.rpm" && \
+RUN INSTALLED_PKGS="kibana-${KIBANA_VER}*" && \
     yum install -y --setopt=tsflags=nodocs  ${INSTALLED_PKGS} && \
     yum clean all
 
@@ -43,8 +41,8 @@ ADD kibana.yml ${KIBANA_CONF_DIR}/
 ADD lib/* ${HOME}/
 ADD run.sh utils install.sh prep-install.${RELEASE_STREAM} ${HOME}/
 ADD logo-OCP-console-hdr-thin.svg ${KIBANA_HOME}/installedPlugins/origin-kibana/public/images/logo-origin-thin.svg
-RUN sh ${HOME}/install.sh
-RUN rm -r /tmp/lib
+RUN (type -p node || ln -s $(which $NODE_BIN) "/usr/bin/node") && \
+    sh ${HOME}/install.sh
 
 WORKDIR ${HOME}
 CMD ["./run.sh"]
@@ -56,9 +54,9 @@ LABEL \
         name="openshift3/ose-logging-kibana5" \
         License="GPLv2+" \
         io.k8s.display-name="Kibana" \
-        version="v3.10.0" \
+        version="v3.11.0" \
         architecture="x86_64" \
-        release="667" \
+        release="0.69.0.0" \
         io.openshift.expose-services="5601:http" \
         io.openshift.tags="logging,elk,kibana"
 

--- a/kibana/install.sh
+++ b/kibana/install.sh
@@ -6,10 +6,10 @@ set -o pipefail
 
 source "${HOME}/prep-install.${RELEASE_STREAM}"
 
-ORIGIN_KIBANA_PLUGIN=$(ls -t1 ${HOME}/origin-kibana-v$KIBANA_VER-*.zip | head -1)
+ORIGIN_KIBANA_PLUGIN=$(ls -t1 ${HOME}/origin-kibana-v${KIBANA_VER}*.zip | head -1)
 ${KIBANA_HOME}/bin/kibana-plugin install file://${ORIGIN_KIBANA_PLUGIN}
 
 chmod -R og+w "${HOME}"
 chmod -R og+rw "${KIBANA_HOME}"
-chmod -R og+rw /var/lib/kibana
+mkdir -m og+w -p /var/lib/kibana
 chmod -R og+w "${KIBANA_CONF_DIR}"

--- a/kibana/sources
+++ b/kibana/sources
@@ -1,1 +1,0 @@
-76f7399c5addbbdc0c1671b049b088bf  kibana-5.6.9-x86_64.rpm


### PR DESCRIPTION
This PR productizes downstream Kibana to rely on rpms instead of look aside cache:
* resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1590947
* addresses https://trello.com/c/406ULKGV