### PR TITLE
Reenabling prometheus metrics functionality test

### DIFF
--- a/elasticsearch/sgconfig/sg_action_groups.yml
+++ b/elasticsearch/sgconfig/sg_action_groups.yml
@@ -89,6 +89,8 @@ INDEX_PROJECT:
   - INDEX_ALL
 METRICS:
   - cluster:monitor/prometheus/metrics
+  - cluster:monitor/nodes/stats
+  - cluster:monitor/health
 USER_ALL_INDEX_OPS:
   - "indices:data/read/field_caps*"
 USER_CLUSTER_OPERATIONS:

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -153,6 +153,32 @@ function curl_es_pod_with_token() {
                              "https://localhost:9200${endpoint}"
 }
 
+function curl_es_pod_with_username_password() {
+    local pod="$1"
+    local endpoint="$2"
+    local test_name="$3"
+    local test_password="$4"
+    shift; shift; shift; shift
+    local args=( "${@:-}" )
+
+    oc -n $LOGGING_NS exec -c elasticsearch "${pod}" -- curl --silent --insecure "${args[@]}" \
+                             -H "Authorization: Basic $( echo -n ${test_name}:${test_password} | base64 -w 0 )" \
+                             "https://localhost:9200${endpoint}"
+}
+
+function curl_es_pod_with_username_password_not_silent() {
+    local pod="$1"
+    local endpoint="$2"
+    local test_name="$3"
+    local test_password="$4"
+    shift; shift; shift; shift
+    local args=( "${@:-}" )
+
+    oc -n $LOGGING_NS exec -c elasticsearch "${pod}" -- curl --insecure "${args[@]}" \
+                             -H "Authorization: Basic $( echo -n ${test_name}:${test_password} | base64 -w 0 )" \
+                             "https://localhost:9200${endpoint}"
+}
+
 function curl_es_with_token() {
     local svc_name="$1"
     local endpoint="$2"

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -135,10 +135,19 @@ for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARC
 	fi
 
 #	WIP, uncommented unless we figure out how to get user name
-#	os::log::info "Checking that Elasticsearch pod ${elasticsearch_pod} exports Prometheus metrics"
-#	user_name="prometheus" #?
-#	barer_token="_na_"     #?
-#	prometheus_metrics=$( curl_es_pod_with_token "${elasticsearch_pod}" '/_prometheus/metrics' "$user_name" "$barer_token" )
+	os::log::info "Checking that Elasticsearch pod ${elasticsearch_pod} exports Prometheus metrics"
+	passwd_contents="$(oc extract secret/logging-elasticsearch --keys=passwd.yml --to=-)"
+	user_name="$(echo ${passwd_contents} | cut -d'"' -f2)"
+	user_passwd="$(echo ${passwd_contents} | cut -d'"' -f4 | base64 -d)"
+
+	if os::cmd::expect_success_and_text "curl_es_pod_with_username_password '${elasticsearch_pod}' '/_prometheus/metrics' '$user_name' '$user_passwd' --output /dev/null --write-out '%{response_code}'" '200'; then
+		os::log::info "Received data from metrics endpoint"
+	else
+		artifact_log unable to connect to prometheus end point:
+		artifact_log $( curl_es_pod_with_username_password_not_silent "${elasticsearch_pod}" '/_prometheus/metrics' "$user_name" "$user_passwd" )
+		artifact_log $(oc exec -n $LOGGING_NS -c elasticsearch ${elasticsearch_pod} -- es_acl get --doc=actiongroups)
+		os::log::fatal "Failed while curling _prometheus/metrics endpoint"
+	fi
 
 done
 


### PR DESCRIPTION
This is to reenable the prometheus functionality test for ES to ensure that we don't break this functionality inadvertently.

Also adding in missing actions required for curling the prometheus endpoint