### PR TITLE
Bug 1595956 - Kibana dashboards do not work with Kibana5/Elasticsearch5

### DIFF
--- a/elasticsearch/utils/es_load_kibana_ui_objects
+++ b/elasticsearch/utils/es_load_kibana_ui_objects
@@ -49,7 +49,7 @@ info Adding the index pattern for "$INDEX_PATTERN" . . .
 
 cat $INDEX_PATTERN_FILE | \
     sed "s/[$]TITLE[$]/$INDEX_PATTERN/g" | \
-    QUERY="/$kibindex/$INDEX_PATTERN_TYPE/$INDEX_PATTERN" es_util -XPUT --data-binary @- | curl_output
+    es_util --query="$kibindex/$INDEX_PATTERN_TYPE/$INDEX_PATTERN" -XPUT --data-binary @- | curl_output
 
 info Adding the Kibana UI objects . . .
 {
@@ -71,6 +71,6 @@ for doc in obj:
   sys.stdout.write("\n")
 '
     done
-} | QUERY="/$kibindex/_bulk" es_util -XPOST --data-binary @- | curl_output
+} | es_util --query="$kibindex/_bulk" -H "Content-type: application/json" -XPOST --data-binary @- | curl_output
 
 info Success


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1595956
es5 does not like leading //