### PR TITLE
change rsyslog test to use viaq/rsyslog image

### DIFF
--- a/hack/testing/rsyslog/k8s_filename.rulebase
+++ b/hack/testing/rsyslog/k8s_filename.rulebase
@@ -1,2 +1,1 @@
-rule=:/var/log/containers/%pod_name:char-to:.%.%container_hash:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log
 rule=:/var/log/containers/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log

--- a/hack/testing/rsyslog/playbook.yaml
+++ b/hack/testing/rsyslog/playbook.yaml
@@ -3,31 +3,25 @@
   hosts: all
   gather_facts: true
   tasks:
-  - name: get patched rsyslog repo
-    get_url:
-      url: https://copr.fedorainfracloud.org/coprs/rmeggins/rsyslog/repo/epel-7/rmeggins-rsyslog-epel-7.repo
-      dest: /etc/yum.repos.d/rmeggins-rsyslog-epel-7.repo
-      mode: 0444
-    when: use_mmk8s | default(True)
+  - set_fact:
+      rsyslog_image_prefix: "viaq/"
+      when: rsyslog_image_prefix is not defined
+
+  - set_fact:
+      rsyslog_image_version: "latest"
+      when: rsyslog_image_version is not defined
+
+  - name: get rsyslog image
+    command: docker pull {{ rsyslog_image_prefix }}rsyslog:{{ rsyslog_image_version }}
 
   - name: install prereqs
     yum: state=latest name={{ item }}
     with_items:
-    - rsyslog
-    - rsyslog-mmnormalize
-    - rsyslog-mmjsonparse
     - nmap-ncat
     - systemd-python
-    - rsyslog-elasticsearch
     - policycoreutils
     - checkpolicy
     - policycoreutils-python
-
-  - name: pkgs
-    yum: state=latest name={{ item }}
-    with_items:
-    - rsyslog-mmkubernetes
-    when: use_mmk8s | default(True)
 
   - name: create rsyslog viaq subdir
     file: path=/etc/rsyslog.d/viaq state=directory mode=0700
@@ -212,5 +206,18 @@
       regexp: '^\$IMJournalStateFile|^#\$IMJournalStateFile'
       line: '#$IMJournalStateFile imjournal.state'
 
-  - name: restart rsyslog
-    systemd: name=rsyslog state=restarted
+  - name: disable rsyslog
+    systemd:
+      name: rsyslog.service
+      enabled: no
+      state: stopped
+
+  - name: install rsyslog container systemd service
+    template: src=rsyslog-container.service.j2 dest=/usr/lib/systemd/system/rsyslog-container.service mode=0400
+
+  - name: enable and run rsyslog-container.service
+    systemd:
+      name: rsyslog-container.service
+      daemon_reload: yes
+      enabled: yes
+      state: started

--- a/hack/testing/rsyslog/rsyslog-container.service.j2
+++ b/hack/testing/rsyslog/rsyslog-container.service.j2
@@ -1,0 +1,27 @@
+[Unit]
+Description=rsyslog container
+After=docker.service
+Requires=docker.service
+Conflicts=rsyslog.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
+ExecStartPre=/usr/bin/docker pull {{ rsyslog_image_prefix }}rsyslog:{{ rsyslog_image_version }}
+ExecStart=/usr/bin/docker run --env /etc/sysconfig/rsyslog --privileged --name %n \
+--net=host --pid=host \
+-v /etc/pki/rsyslog:/etc/pki/rsyslog \
+-v /etc/rsyslog.conf:/etc/rsyslog.conf \
+-v /etc/sysconfig/rsyslog:/etc/sysconfig/rsyslog \
+-v /etc/rsyslog.d:/etc/rsyslog.d \
+-v /var/log:/var/log \
+-v /var/lib/rsyslog:/var/lib/rsyslog \
+-v /var/lib/docker:/var/lib/docker \
+-v /run:/run \
+-v /etc/machine-id:/etc/machine-id \
+-v /etc/localtime:/etc/localtime --rm {{ rsyslog_image_prefix }}rsyslog:{{ rsyslog_image_version }}
+
+[Install]
+WantedBy=multi-user.target

--- a/hack/testing/rsyslog/viaq_formatting.conf
+++ b/hack/testing/rsyslog/viaq_formatting.conf
@@ -159,16 +159,31 @@ if strlen($!_MACHINE_ID) > 0 then {
         }
     }
     unset $!PRIORITY;
-    if strlen($!message) == 0 then {
-        if strlen($!MESSAGE) > 0 then {
-            set $!message = $!MESSAGE;
+    # rsyslog 8.30.0 and later does case insensitive variable name comparison
+    # which means $!MESSAGE is the same as $!message - HOWEVER - the case
+    # of the variable name is preserved when outputting, so we need to "normalize"
+    # to all lower case so that the internal JSON to string conversion will output
+    # "message" in the outgoing record
+    if (strlen($!message) == 0) and (strlen($!MESSAGE) == 0) then {
+        if strlen($!log) > 0 then {
+            set $!message = $!log;
+        }
+    } else {
+        # see if we're using rsyslog with case sensitivity
+        if $!message == $!MESSAGE then {
+            # in case it is really $!MESSAGE - we have to completely unset it, then
+            # set it in lower case
+            set $.save_message = $!message;
+            unset $!message;
+            set $!message = $.save_message;
+            unset $.save_message;
         } else {
-            if strlen($!log) > 0 then {
-                set $!message = $!log;
+            if strlen($!message) == 0 then {
+                # case sensitive
+                set $!message = $!MESSAGE;
             }
         }
     }
-    unset $!MESSAGE;
     if strlen($!hostname) == 0 then {
         if strlen($!kubernetes!host) > 0 then {
             set $!hostname = $!kubernetes!host;
@@ -239,7 +254,8 @@ if strlen($!level) > 0 then {
 if strlen($!kubernetes!namespace_name) > 0 then {
     # see if this is an operations namespace
     if ($!kubernetes!namespace_name == "default") or ($!kubernetes!namespace_name == "openshift") or
-        ($!kubernetes!namespace_name startswith "openshift-") then {
+        ($!kubernetes!namespace_name startswith "openshift-") or
+        ($!kubernetes!namespace_name startswith "kube-") then {
             set $.viaq_index_prefix = ".operations.";
     } else {
         if strlen($!kubernetes!namespace_id) > 0 then {

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -315,6 +315,8 @@ function wait_for_fluentd_to_catch_up() {
     if os::cmd::try_until_text "curl_es ${es_svc} /${logging_index}/_count -X POST -d '$qs' | get_count_from_json" $expected $(( timeout * second )); then
         artifact_log good - $FUNCNAME: found $expected record $logging_index for \'$fullmsg\'
         if [ -n "${1:-}" ] ; then
+            curl_es ${es_svc} /${logging_index}/_count -X POST -d "$qs" 2>&1 | artifact_out
+            curl_es ${es_svc} /${logging_index}/_count -X POST -d "$qs" 2>&1 | get_count_from_json | artifact_out
             curl_es ${es_svc} "/${logging_index}/_search" -X POST -d "$qs" | jq . > $ARTIFACT_DIR/apps.json
             $1 $uuid_es $ARTIFACT_DIR/apps.json
         fi


### PR DESCRIPTION
Use the viaq/rsyslog container image instead of the copr
repo packages for the rsyslog tests.

Fix the k8s_filename.rulebase to workaround
https://github.com/rsyslog/rsyslog/pull/2824

rsyslog 8.30 uses case insensitive variable names, so we have
to do a little hacking around the way we handle MESSAGE/message
in order to make sure the final record sent uses "message", and
in order to support older versions of rsyslog if necessary.

kube-* projects are operations projects