### PR TITLE
Adding prometheus plugin, sources, and exposing endpoints

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -35,7 +35,8 @@ RUN yum-config-manager --enable rhel-7-server-ose-3.10-rpms && \
                 rubygem-fluent-plugin-rewrite-tag-filter \
                 rubygem-fluent-plugin-secure-forward \
                 rubygem-fluent-plugin-systemd \
-                rubygem-fluent-plugin-viaq_data_model" && \
+                rubygem-fluent-plugin-viaq_data_model \
+                rubygem-fluent-plugin-prometheus" && \
   yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
   rpm -V $INSTALL_PKGS && \
   yum clean all

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -45,7 +45,8 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
       fluent-plugin-secure-forward \
      'fluent-plugin-systemd:<0.1.0' \
       fluent-plugin-viaq_data_model \
-     'fluent-plugin-remote-syslog:1.1'
+     'fluent-plugin-remote-syslog:1.1' \
+     'fluent-plugin-prometheus:<1.0.0'
 
 ADD configs.d/ /etc/fluent/configs.d/
 ADD filter_k8s_meta_for_mux_client.rb /etc/fluent/plugin/

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -6,6 +6,7 @@ Following are the environment variables that can be modified to adjust the confi
 
 | Environment Variable | Description |Example|
 |----------------------|-------------|---|
+| `ENABLE_PROMETHEUS_ENDPOINT`| Enable or diable the prometheus endpoint (Default: true)| `ENABLE_PROMETHEUS_ENDPOINT=false`|
 | `MERGE_JSON_LOG`     | **DEPRECATED** Parse JSON log messages and merge them into the JSON payload to be indexed to Elasticsearch. **Default:** True | `MERGE_JSON_LOG=true`|
 | `OCP_OPERATIONS_PROJECTS`| The list of project or patterns for which messages will be sent to the operations indices|`OCP_OPERATIONS_PROJECTS="default openshift openshift- kube-*"`
 

--- a/fluentd/configs.d/openshift/input-pre-prometheus-metrics.conf
+++ b/fluentd/configs.d/openshift/input-pre-prometheus-metrics.conf
@@ -1,0 +1,26 @@
+<source>
+  @type prometheus
+</source>
+
+<source>
+  @type prometheus_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
+
+# This is considered experimental by the repo
+<source>
+  @type prometheus_tail_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
+
+# This is considered experimental by the repo
+<source>
+  @type prometheus_output_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -2,6 +2,7 @@
 
 export MERGE_JSON_LOG=${MERGE_JSON_LOG:-true}
 CFG_DIR=/etc/fluent/configs.d
+ENABLE_PROMETHEUS_ENDPOINT=${ENABLE_PROMETHEUS_ENDPOINT:-"true"}
 OCP_OPERATIONS_PROJECTS=${OCP_OPERATIONS_PROJECTS:-"default openshift openshift- kube-"}
 OCP_FLUENTD_TAGS=""
 for p in ${OCP_OPERATIONS_PROJECTS}; do
@@ -350,8 +351,12 @@ if [ "${COLLECT_JOURNAL_DEBUG_LOGS:-true}" = true ] ; then
   touch $CFG_DIR/openshift/filter-exclude-journal-debug.conf
 fi
 
-issue_deprecation_warnings
+if [ "${ENABLE_PROMETHEUS_ENDPOINT}" != "true" ] ; then
+  echo "INFO: Disabling Prometheus endpint"
+  rm -f ${CFG_DIR}/openshift/input-pre-prometheus-metrics.conf
+fi
 
+issue_deprecation_warnings
 if [[ $DEBUG ]] ; then
     exec fluentd $fluentdargs > /var/log/fluentd.log 2>&1
 else

--- a/hack/testing/check-zzz-fluentd-prometheus-scrape.sh
+++ b/hack/testing/check-zzz-fluentd-prometheus-scrape.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+
+os::test::junit::declare_suite_start "test/check-zzz-fluentd-prometheus-scrape"
+
+cleanup() {
+    local return_code="$?"
+    set +e
+
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
+
+LOGGING_NS=${LOGGING_NS:-openshift-logging}
+
+fpod="$(get_running_pod fluentd)"
+fpod_ip="$(oc get pod ${fpod} -o jsonpath='{.status.podIP}')"
+
+os::cmd::expect_success "curl http://${fpod_ip}:24231/metrics"
+curl http://${fpod_ip}:24231/metrics >> $ARTIFACT_DIR/${fpod}-metrics-scrape 2>&1 || :


### PR DESCRIPTION
This PR re-enables the prometheus endpoint for fluentd.  @mffiedler initial test results indicate 756m default seems to be enought to include the plugin.  Will need to up the default OOTB https://bugzilla.redhat.com/show_bug.cgi?id=1598990

The PR allows disabling the plugin via env var