### PR TITLE
Modify the check for logging namespace

### DIFF
--- a/hack/logging-dump.sh
+++ b/hack/logging-dump.sh
@@ -46,7 +46,7 @@ then
     components=( "kibana" "fluentd" "curator" "elasticsearch" "project_info" )
 fi
 
-if [ -z "${NAMESPACE:-''}" ] && oc get project logging > /dev/null ; then
+if [ -z "${NAMESPACE:-}" ] && oc get project logging > /dev/null ; then
   NAMESPACE=logging
 fi
 


### PR DESCRIPTION
The script fails to capture the logging data if the namespace openshift-logging does not exist or if the user is not a member of this project.
[root@master ~]# ./logging-dump.sh
error: You are not a member of project "openshift-logging".

[root@master ~]# ./logging-dump.sh
error: A project named "openshift-logging" does not exist on "https://master.example.com:443"

The script is trying to check logging project but the test condition is wrong.

if [ -z "${NAMESPACE:-''}" ] && oc get project logging > /dev/null ; then

It should be:

if [ -z "${NAMESPACE:-}" ] && oc get project logging > /dev/null ; then


This was fixed earlier. Looks like, this is a regression.