### PR TITLE
fixes #1251. Move init to scripts

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -31,9 +31,10 @@ ARG MAVEN_REPO_URL=https://repo1.maven.org/maven2/
 ADD sgconfig/ ${HOME}/sgconfig/
 ADD index_templates/ ${ES_HOME}/index_templates/
 ADD index_patterns/ ${ES_HOME}/index_patterns/
+ADD init/ ${ES_HOME}/init/
 ADD kibana_ui_objects/ ${ES_HOME}/kibana_ui_objects/
 ADD probe/ ${ES_HOME}/probe/
-ADD run.sh prep-install.${RELEASE_STREAM} install.sh ${HOME}/
+ADD init.sh run.sh prep-install.${RELEASE_STREAM} install.sh ${HOME}/
 COPY utils/** /usr/local/bin/
 RUN ln -s /usr/local/bin/logging ${HOME}/logging
 

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -44,9 +44,10 @@ RUN rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch && \
 ADD sgconfig/ ${HOME}/sgconfig/
 ADD index_templates/ ${ES_HOME}/index_templates/
 ADD index_patterns/ ${ES_HOME}/index_patterns/
+ADD init/ ${ES_HOME}/init/
 ADD kibana_ui_objects/ ${ES_HOME}/kibana_ui_objects/
 ADD probe/ ${ES_HOME}/probe/
-ADD run.sh prep-install.${RELEASE_STREAM} install.sh ${HOME}/
+ADD init.sh run.sh prep-install.${RELEASE_STREAM} install.sh ${HOME}/
 COPY utils/** /usr/local/bin/
 
 ARG OSE_ES_URL

--- a/elasticsearch/init.sh
+++ b/elasticsearch/init.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+#
+# Copyright 2018 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "logging"
+
+pushd "${ES_HOME}/init"
+  files=$(ls | sort)
+  for init_file in ${files}; do
+    if [ -f "${init_file}" ] ; then
+      ./"${init_file}"
+    fi
+  done
+popd

--- a/elasticsearch/init/0010-seed-acl
+++ b/elasticsearch/init/0010-seed-acl
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+#
+# Copyright 2018 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "logging"
+
+force=${FORCE_SEED_ACL:-''}
+config=${ES_CONF}/elasticsearch.yml
+index=$(python -c "import yaml; print yaml.load(open('${config}'))['searchguard']['config_index_name']" | xargs -i sh -c "echo {}")
+
+if [ -n "${force}" ] ; then
+  docs=(roles rolesmapping actiongroups internalusers config)
+  for d in $docs; do
+    resp=$(es_util --query=${index}/$d/0 -w %{response_code} | cut -d '}' -f2)
+    #re-seed acls if any of them are missing
+    if [ "${resp}" != "200"]; then
+      info "Missing ACL document '${d}'. Reseeding all ACL documents"
+      force="true"
+      break
+    fi
+  done
+else
+  info "Forcing the seeding of ACL documents"
+fi
+
+if [ -z "${force}" ] ; then
+  es_seed_acl
+fi

--- a/elasticsearch/init/0100-seed-index-templates
+++ b/elasticsearch/init/0100-seed-index-templates
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+#
+# Copyright 2018 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "logging"
+
+info Adding index templates
+shopt -s failglob
+for template_file in ${ES_HOME}/index_templates/*.json
+do
+    sed -i "s,\$REPLICA_SHARDS,$REPLICA_SHARDS," $template_file
+    sed -i "s,\$PRIMARY_SHARDS,$PRIMARY_SHARDS," $template_file
+    template=`basename $template_file`
+    # Check if index template already exists
+    response_code=$(es_util --query=_template/$template \
+        ${DEBUG:+-v} -s \
+        --request HEAD --head --output /dev/null \
+        -w '%{response_code}')
+    if [ "${response_code}" == "200" ]; then
+        info "Index template '$template' found in the cluster, overriding it"
+    else
+        info "Create index template '$template'"
+    fi
+    es_util --query=_template/$template \
+        ${DEBUG:+-v} -s -X PUT \
+        -d@${template_file}
+
+done
+shopt -u failglob
+info Finished adding index templates

--- a/elasticsearch/utils/es_seed_acl
+++ b/elasticsearch/utils/es_seed_acl
@@ -2,6 +2,8 @@
 
 source "logging"
 
+ES_CLUSTER_HOST=${ES_CLUSTER_HOST:-"localhost"}
+ES_CLUSTER_PORT=${ES_CLUSTER_PORT:-9300}
 MAX_WAIT_SEED=${MAX_WAIT_SEED:-$((60*60*24*7))} #one week
 
 info "Seeding the searchguard ACL index.  Will wait up to $MAX_WAIT_SEED seconds."
@@ -12,6 +14,8 @@ index=$(python -c "import yaml; print yaml.load(open('${config}'))['searchguard'
 function sgadmin {
   ${ES_HOME}/plugins/openshift-elasticsearch/sgadmin.sh \
     -i $index \
+    -h ${ES_CLUSTER_HOST} \
+    -p ${ES_CLUSTER_PORT} \
     -ks /etc/elasticsearch/secret/admin.jks \
     -kst JKS \
     -kspass kspass \


### PR DESCRIPTION
This PR resolves #1251:
* creates init script that can be called from something like an operator
* moves init scripts to single scripts that can be called in order