### PR TITLE
Changed analyzer on project, operations and orphaned index templates

### DIFF
--- a/elasticsearch/index_templates/com.redhat.viaq-openshift-operations.template.json
+++ b/elasticsearch/index_templates/com.redhat.viaq-openshift-operations.template.json
@@ -39,6 +39,7 @@
           "message_field": {
             "mapping": {
               "index": "analyzed",
+              "analyzer": "whitespace",
               "norms": {
                 "enabled": false
               },
@@ -439,6 +440,7 @@
         "message": {
           "doc_values": false,
           "index": "analyzed",
+          "analyzer": "whitespace",
           "norms": {
             "enabled": false
           },

--- a/elasticsearch/index_templates/com.redhat.viaq-openshift-orphaned.template.json
+++ b/elasticsearch/index_templates/com.redhat.viaq-openshift-orphaned.template.json
@@ -11,6 +11,7 @@
           "message_field": {
             "mapping": {
               "index": "analyzed",
+              "analyzer": "whitespace",
               "omit_norms": true,
               "type": "string"
             },
@@ -436,6 +437,7 @@
         "message": {
           "doc_values": false,
           "index": "analyzed",
+          "analyzer": "whitespace",
           "norms": {
             "enabled": false
           },

--- a/elasticsearch/index_templates/com.redhat.viaq-openshift-project.template.json
+++ b/elasticsearch/index_templates/com.redhat.viaq-openshift-project.template.json
@@ -39,6 +39,7 @@
           "message_field": {
             "mapping": {
               "index": "analyzed",
+              "analyzer": "whitespace",
               "norms": {
                 "enabled": false
               },
@@ -439,6 +440,7 @@
         "message": {
           "doc_values": false,
           "index": "analyzed",
+          "analyzer": "whitespace",
           "norms": {
             "enabled": false
           },


### PR DESCRIPTION
Using the "whitespace" analyzer [0] on the message field instead of the standard one used by ES (when no analyzer is set [1]) allows to perform search for upper-case characters.

[0] https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-whitespace-analyzer.html
[1] https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-analyzer.html

BZ [1610204](https://bugzilla.redhat.com/show_bug.cgi?id=1610204)