### PR TITLE
fix 1548640. Cluster admins can use all cat endpoints

### DIFF
--- a/elasticsearch/sgconfig/sg_action_groups.yml
+++ b/elasticsearch/sgconfig/sg_action_groups.yml
@@ -112,7 +112,7 @@ CLUSTER_MONITOR_KIBANA:
   - cluster:monitor/nodes/info
   - cluster:monitor/health
 CLUSTER_OPERATIONS:
-  - ALL
+  - CLUSTER_ALL
 
 CLUSTER_COMPOSITE_OPS_RO:
   - "indices:data/read/mget"


### PR DESCRIPTION
This PR fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1548640
* Corrects an insensible permission for cluster-admins
* Allows cluster admin full access to the cluster: actions