### PR TITLE
Make allocate-shard node argument optional

### DIFF
--- a/elasticsearch/utils/allocate-shard
+++ b/elasticsearch/utils/allocate-shard
@@ -38,7 +38,13 @@ MSG
 }
 
 index=${1:-}
-node=${2:-"$DC_NAME"}
+
+if [[ "$2" == --* ]];
+then
+    node="$DC_NAME"
+else
+    node="$2"
+fi
 
 if [ -z "${index}" ]; then
     helpMsg


### PR DESCRIPTION
if user issues allocate-shard index --shard=1 the script shouldn't
try to reroute to node named --shard=1