### PR TITLE
[release-3.9] Bug 1489533 - logging-fluentd needs to periodically reconnect to logging-mux or elasticsearch to help balance sessions

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -21,7 +21,7 @@ ENV DATA_VERSION=1.6.0 \
 
 ARG TEST_REPO
 
-RUN yum-config-manager --enable rhel-7-server-ose-3.10-rpms && \
+RUN yum-config-manager --enable rhel-7-server-ose-3.9-rpms && \
   INSTALL_PKGS="fluentd-${FLUENTD_VERSION} \
                 hostname \
                 bc \
@@ -55,6 +55,13 @@ RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
     chmod 777 /etc/fluent/configs.d/dynamic && \
     ln -s /etc/fluent/configs.d/user/fluent.conf /etc/fluent/fluent.conf
 
+# for some reason, this isn't able to be loaded from the gem
+RUN if [ ! -d /etc/fluent/plugin ] ; then \
+      mkdir -p /etc/fluent/plugin ; \
+    fi ; \
+    sniffer=$( gem contents fluent-plugin-elasticsearch|grep elasticsearch_simple_sniffer.rb ) ; \
+    cp $sniffer /etc/fluent/plugin/
+
 WORKDIR ${HOME}
 
 CMD ["sh", "run.sh"]
@@ -68,7 +75,7 @@ LABEL \
         name="openshift3/logging-fluentd" \
         License="GPLv2+" \
         io.k8s.display-name="Fluentd" \
-        version="v3.10.0" \
+        version="v3.9.0" \
         architecture="x86_64" \
         release="0.37.0.0" \
         io.openshift.tags="logging,elk,fluentd"

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -58,6 +58,12 @@ RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
     chmod 777 /etc/fluent/configs.d/dynamic && \
     ln -s /etc/fluent/configs.d/user/fluent.conf /etc/fluent/fluent.conf
 
+RUN if [ ! -d /etc/fluent/plugin ] ; then \
+      mkdir -p /etc/fluent/plugin ; \
+    fi ; \
+    sniffer=$( gem contents fluent-plugin-elasticsearch|grep elasticsearch_simple_sniffer.rb ) ; \
+    cp $sniffer /etc/fluent/plugin/
+
 ADD jemalloc/ ${HOME}/jemalloc/
 # note - make dist "fails" here
 # false -o doc/jemalloc.html doc/html.xsl doc/jemalloc.xml

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -17,9 +17,11 @@
       type_name com.redhat.viaq.common
       retry_tag "retry_es"
 
-      # there is currently a bug in the es plugin + excon - cannot
-      # recreate/reload connections
-      reload_connections false
+      reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+      reload_after "#{ENV['ES_RELOAD_AFTER'] || '100'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+      sniffer_class_name "#{ENV['ES_SNIFFER_CLASS_NAME'] || 'Fluent::ElasticsearchSimpleSniffer'}"
       reload_on_failure false
       flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
       max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -17,9 +17,11 @@
       type_name com.redhat.viaq.common
       retry_tag "retry_es_ops"
 
-      # there is currently a bug in the es plugin + excon - cannot
-      # recreate/reload connections
-      reload_connections false
+      reload_connections "#{ENV['OPS_RELOAD_CONNECTIONS'] || ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+      reload_after "#{ENV['OPS_RELOAD_AFTER'] || ENV['ES_RELOAD_AFTER'] || '100'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+      sniffer_class_name "#{ENV['OPS_SNIFFER_CLASS_NAME'] || ENV['ES_SNIFFER_CLASS_NAME'] || 'Fluent::ElasticsearchSimpleSniffer'}"
       reload_on_failure false
       flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '1s'}"
       max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"

--- a/fluentd/configs.d/openshift/output-es-ops-retry.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-retry.conf
@@ -16,9 +16,11 @@
 
       type_name com.redhat.viaq.common
 
-      # there is currently a bug in the es plugin + excon - cannot
-      # recreate/reload connections
-      reload_connections false
+      reload_connections "#{ENV['OPS_RELOAD_CONNECTIONS'] || ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+      reload_after "#{ENV['OPS_RELOAD_AFTER'] || ENV['ES_RELOAD_AFTER'] || '100'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+      sniffer_class_name "#{ENV['OPS_SNIFFER_CLASS_NAME'] || ENV['ES_SNIFFER_CLASS_NAME'] || 'Fluent::ElasticsearchSimpleSniffer'}"
       reload_on_failure false
       flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '1s'}"
       max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"

--- a/fluentd/configs.d/openshift/output-es-retry.conf
+++ b/fluentd/configs.d/openshift/output-es-retry.conf
@@ -16,9 +16,11 @@
 
       type_name com.redhat.viaq.common
 
-      # there is currently a bug in the es plugin + excon - cannot
-      # recreate/reload connections
-      reload_connections false
+      reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+      reload_after "#{ENV['ES_RELOAD_AFTER'] || '100'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+      sniffer_class_name "#{ENV['ES_SNIFFER_CLASS_NAME'] || 'Fluent::ElasticsearchSimpleSniffer'}"
       reload_on_failure false
       flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
       max_retry_wait "#{ENV['ES_RETRY_WAIT'] || '300'}"


### PR DESCRIPTION
3.9 bz - https://bugzilla.redhat.com/show_bug.cgi?id=1616354

https://github.com/uken/fluent-plugin-elasticsearch/pull/459
implements support for reloading connections when the
Elasticsearch is behind a proxy/load balancer, as in our case,
and allows specifying the reload interval in terms of the
number of operations.

This PR adds support for the following env. vars which can be
set in the fluentd daemonset/mux deployment.  The ability to
set these is provided primarily for experimentation, not something
which will ordinarily require tuning in production.
`ES_RELOAD_CONNECTIONS` - boolean - default `true`
`ES_RELOAD_AFTER` - integer - default `100`
`ES_SNIFFER_CLASS_NAME` - string - default `Fluent::Plugin::ElasticsearchSimpleSniffer`
There are also `OPS_` named env. vars which will override the
corresponding `ES_` named env. var.

That is, by default, fluentd will reload connections to
Elasticsearch every 100 operations (NOTE: not every 100 records!)
These include internal `ping` operations, so will not exactly
correspond to each bulk index request.

(cherry picked from commit f084fee4de8c32f83c53694058320e6dc3e5d170)