### PR TITLE
bump fluentd to 0.12.43 to support whats downstream

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -4,7 +4,7 @@ FROM rhel7:7-released
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
 ENV DATA_VERSION=1.6.0 \
-    FLUENTD_VERSION=0.12.42 \
+    FLUENTD_VERSION=0.12.43 \
     FLUENTD_ES=1.13.0-1 \
     FLUENTD_KUBE_METADATA=1.0.1-1 \
     FLUENTD_REWRITE_TAG=1.5.6-1 \

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -3,7 +3,7 @@ FROM centos:centos7
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
 ENV DATA_VERSION=1.6.0 \
-    FLUENTD_VERSION=0.12.42 \
+    FLUENTD_VERSION=0.12.43 \
     GEM_HOME=/opt/app-root/src \
     HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \


### PR DESCRIPTION
Requested by @adammhaile  because thats the rpm avialable in 3.11