### PR TITLE
fix allocate command that changed for 5.x

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -14,15 +14,26 @@ Example to retrieve the list of nodes
 $ oc exec -c elasticsearch $POD -- es_util --query=_cat/nodes?pretty
 ```
 
-### allocate-shard
-Manually allocate a shard to a given node in the Elasticsearch cluster.  The node
+### allocate-replica
+Manually allocate replica shard to a given node in the Elasticsearch cluster.  The node
 by default will be the one on which the command is executed. This command
-is used to explicitly [reroute and allocate](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-reroute.html)
-a shard
+is used to explicitly [reroute and allocate](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cluster-reroute.html#cluster-reroute)
+a replica shard.
 
 Example:
 ```
-$ oc exec -c elasticsearch $POD -- allocate-shard .kibana.02c55f18a892b365bcd1802db9e5c9df39c04674
+$ oc exec -c elasticsearch $POD -- allocate-replica .kibana.02c55f18a892b365bcd1802db9e5c9df39c04674
+```
+
+### allocate-stale-primary
+Manually allocate a stale primary shard to a given node in the Elasticsearch cluster.  The node
+by default will be the one on which the command is executed. This command
+is used to explicitly [reroute and allocate](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cluster-reroute.html#cluster-reroute)
+a primary shard. **NOTE:** There is a risk of data loss when using this command
+
+Example:
+```
+$ oc exec -c elasticsearch $POD -- allocate-stale-primary .kibana.02c55f18a892b365bcd1802db9e5c9df39c04674
 ```
 
 ### logs

--- a/elasticsearch/utils/allocate-replica
+++ b/elasticsearch/utils/allocate-replica
@@ -15,36 +15,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 set -euo pipefail
-source es_util_env
 
-shard=0
-allow_primary=true
+if [ -z "${OC_CMD:-}" ] ; then
+  source es_util_env
+fi
+
+shard=${SHARD:-0}
 
 helpMsg() {
 cat <<MSG
 
  Usage: $0 <index> [es_node] [options]
- Command to manually allocate a shard to a given Elasticsearch node
+ Command to manually allocate a replica shard
+   Ref: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cluster-reroute.html
 
    args:
      index                Required. The index to allocate(e.g. .kibana.02c55f18a892b365bcd1802db9e5c9df39c04674)
-     es_node              Optional. The name of the Elasticsearch node (Default: ${DC_NAME:-}
+     es_node              Optional. The name of the Elasticsearch node (Default: ${DC_NAME:-})
 
    options:
      --shard=<number>            The shard to allocate. (Default: ${shard})
-     --allow-primary=true|false  Default: true
      --help,-h                   This message.
 MSG
 }
 
 index=${1:-}
-
-if [[ "$2" == --* ]];
-then
-    node="$DC_NAME"
-else
-    node="$2"
-fi
+node="${2:-${DC_NAME:-}}"
 
 if [ -z "${index}" ]; then
     helpMsg
@@ -57,9 +53,6 @@ case $1 in
     --shard=*)
       shard=${1#*=}
       ;;
-    --allow-primary=*)
-      allow_primary=${1#*=}
-      ;;
     --help|-h)
       helpMsg
       exit 0
@@ -68,10 +61,7 @@ case $1 in
   shift
 done
 
-if [ "${allow_primary}" != "true" ] ; then
-  allow_primary='false'
-fi
+payload="{\"commands\":[{\"allocate_replica\":{\"index\":\"${index}\",\"shard\":${shard},\"node\":\"${node}\"}}]}"
 
-payload="{\"commands\":[{\"allocate\":{\"index\":\"${index}\",\"shard\":${shard},\"node\":\"${node}\",\"allow_primary\":\"${allow_primary}\"}}]}"
+${OC_CMD:-} es_util --query=_cluster/reroute?pretty -XPOST -d ${payload}
 
-es_util --query=_cluster/reroute?pretty -XPOST -d ${payload}

--- a/elasticsearch/utils/allocate-stale-primary
+++ b/elasticsearch/utils/allocate-stale-primary
@@ -20,29 +20,31 @@ if [ -z "${OC_CMD:-}" ] ; then
   source es_util_env
 fi
 
+shard=${SHARD:-0}
+
 helpMsg() {
 cat <<MSG
 
- Usage: $0 <index> <shard> <from_node> <to_node>
- Command to manually move a replica shard from one Elasticsearch node to another
+ Usage: $0 <index> [es_node] [options]
+ Command to manually allocate a stale primary shard
+
+ NOTE: Use of this commmand can lead to data loss.
+       Ref: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cluster-reroute.html
 
    args:
-     index                The index to move(e.g. .kibana.02c55f18a892b365bcd1802db9e5c9df39c04674)
-     shard                The shard to move
-     from_node            The node where the shard is currently assigned
-     to_node              The node where the shard is to be moved
+     index                Required. The index to allocate(e.g. .kibana.02c55f18a892b365bcd1802db9e5c9df39c04674)
+     es_node              Optional. The name of the Elasticsearch node (Default: ${DC_NAME:-})
 
    options:
-     --help,-h            This message.
+     --shard=<number>            The shard to allocate. (Default: ${shard})
+     --help,-h                   This message.
 MSG
 }
 
 index=${1:-}
-shard=${2:-}
-from_node=${3:-}
-to_node=${4:-}
+node="${2:-${DC_NAME:-}}"
 
-if [ -z "${index}" ] || [ -z "${shard}" ] || [ -z "${from_node}" ] || [ -z "${to_node}" ] ; then
+if [ -z "${index}" ]; then
     helpMsg
     exit 1
 fi
@@ -50,6 +52,9 @@ fi
 while (($#))
 do
 case $1 in
+    --shard=*)
+      shard=${1#*=}
+      ;;
     --help|-h)
       helpMsg
       exit 0
@@ -58,6 +63,7 @@ case $1 in
   shift
 done
 
-payload="{\"commands\":[{\"move\":{\"index\":\"${index}\",\"shard\":${shard},\"from_node\":\"${from_node}\",\"to_node\":\"${to_node}\"}}]}"
+payload="{\"commands\":[{\"allocate_stale_primary\":{\"index\":\"${index}\",\"shard\":${shard},\"node\":\"${node}\",\"accept_data_loss\":\"true\"}}]}"
 
 ${OC_CMD:-} es_util --query=_cluster/reroute?pretty -XPOST -d ${payload}
+


### PR DESCRIPTION
This command replaces the one in 2.x since the syntax changed and means something else.

Note: Additional changes should allow this script to be pulled from the image and used in conjunction with an oc binary on a host node