### PR TITLE
fluentd will detect json-file or crio logs automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,14 @@ matrix:
         cd fluentd/lib/filter_parse_json_field
       script:
         rake test
+    - name: fluentd - parser_json_or_crio test
+      env:
+        - FLUENTD_VERSION=0.12.0
+      language: ruby
+      rvm:
+      - 2.0
+      gemfile: fluentd/lib/parser_json_or_crio/Gemfile
+      before_script:
+        cd fluentd/lib/parser_json_or_crio
+      script:
+        rake test

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -56,6 +56,7 @@ ADD run.sh generate_syslog_config.rb ${HOME}/
 ADD lib/generate_throttle_configs/lib/*.rb ${HOME}/
 ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
 ADD patch/in_prometheus.rb ${GEM_HOME}/gems/fluent-plugin-prometheus-0.4.0/lib/fluent/plugin/
+ADD lib/parser_json_or_crio/lib/*.rb /etc/fluent/plugin/
 
 RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
     chmod 777 /etc/fluent/configs.d/dynamic && \

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -65,6 +65,7 @@ ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
 ADD patch/logger/log.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 ADD patch/logger/supervisor.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 COPY utils/** ${HOME}/utils/
+ADD lib/parser_json_or_crio/lib/*.rb /etc/fluent/plugin/
 ADD patch/in_prometheus.rb ${GEM_HOME}/gems/fluent-plugin-prometheus-0.4.0/lib/fluent/plugin/
 
 RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \

--- a/fluentd/lib/generate_throttle_configs/Gemfile
+++ b/fluentd/lib/generate_throttle_configs/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'codeclimate-test-reporter', :group => :test, :require => nil
+gem 'rubocop', require: false
+
+gemspec

--- a/fluentd/lib/generate_throttle_configs/generate_throttle_configs.gemspec
+++ b/fluentd/lib/generate_throttle_configs/generate_throttle_configs.gemspec
@@ -6,16 +6,17 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 FLUENTD_VERSION = ENV['FLUENTD_VERSION'] || "0.12.0"
 
 Gem::Specification.new do |gem|
-  gem.name          = "filter_parse_json_field"
+  gem.name          = "generate_throttle_configs"
   gem.version       = "0.0.1"
-  gem.authors       = ["Rich Megginson"]
-  gem.summary       = %q{Filter plugin to parse JSON valued fields in record}
+  gem.authors       = ["Jeff Cantrill"]
+  gem.summary       = %q{Generate container in_tail config}
 
   gem.required_ruby_version = '>= 2.0.0'
 
   gem.add_runtime_dependency "fluentd", "~> #{FLUENTD_VERSION}"
 
   gem.add_development_dependency "bundler"
+  gem.add_development_dependency "minitest"
   gem.add_development_dependency("fluentd", "~> #{FLUENTD_VERSION}")
   gem.add_development_dependency("rake", ["~> 11.0"])
   gem.add_development_dependency("rr", ["~> 1.0"])

--- a/fluentd/lib/parser_json_or_crio/Gemfile
+++ b/fluentd/lib/parser_json_or_crio/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'codeclimate-test-reporter', :group => :test, :require => nil
+gem 'rubocop', require: false
+
+gemspec

--- a/fluentd/lib/parser_json_or_crio/Rakefile
+++ b/fluentd/lib/parser_json_or_crio/Rakefile
@@ -1,0 +1,11 @@
+#require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+    t.test_files = FileList['test/**/*_test.rb']
+    t.warning = false
+    t.verbose = true
+end
+desc "Run tests"
+
+task default: :test

--- a/fluentd/lib/parser_json_or_crio/lib/parser_json_or_crio.rb
+++ b/fluentd/lib/parser_json_or_crio/lib/parser_json_or_crio.rb
@@ -1,0 +1,35 @@
+require 'fluent/parser'
+
+module Fluent
+  class ParserJsonOrCrio < Parser
+    Plugin.register_parser("json_or_crio", self)
+
+    config_param :crio_format, :string, default: '/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/'
+    config_param :crio_time_format, :string, default: '%Y-%m-%dT%H:%M:%S.%N%:z'
+    config_param :json_time_format, :string, default: '%Y-%m-%dT%H:%M:%S.%N%Z'
+
+    def configure(conf={})
+      super
+      @crio_parser = Plugin.new_parser(@crio_format)
+      conf['time_format'] = @crio_time_format
+      @crio_parser.configure(conf)
+      @json_parser = Plugin.new_parser('json')
+      conf['time_format'] = @json_time_format
+      @json_parser.configure(conf)
+    end
+
+    def parse(text)
+      if text[0] == '{'.freeze && text[-1] == '}'.freeze
+        time, record = @json_parser.call(text)
+      else
+        time, record = @crio_parser.call(text)
+      end
+      if block_given?
+        yield time, record
+        return
+      else
+        return time, record
+      end
+    end
+  end
+end

--- a/fluentd/lib/parser_json_or_crio/parser_json_or_crio.gemspec
+++ b/fluentd/lib/parser_json_or_crio/parser_json_or_crio.gemspec
@@ -6,12 +6,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 FLUENTD_VERSION = ENV['FLUENTD_VERSION'] || "0.12.0"
 
 Gem::Specification.new do |gem|
-  gem.name          = "filter_parse_json_field"
+  gem.name          = "parser_json_or_crio"
   gem.version       = "0.0.1"
   gem.authors       = ["Rich Megginson"]
-  gem.summary       = %q{Filter plugin to parse JSON valued fields in record}
-
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.summary       = %q{Parser plugin for in_tail to determine if line is json or crio format and parse accordingly}
 
   gem.add_runtime_dependency "fluentd", "~> #{FLUENTD_VERSION}"
 

--- a/fluentd/lib/parser_json_or_crio/test/parser_json_or_crio_test.rb
+++ b/fluentd/lib/parser_json_or_crio/test/parser_json_or_crio_test.rb
@@ -1,0 +1,112 @@
+require_relative 'test_helper'
+require 'fluent/test'
+require 'test/unit/rr'
+require File.join(File.dirname(__FILE__), '..', 'lib/parser_json_or_crio') 
+
+class JsonOrCrioParserTest < Test::Unit::TestCase
+  include Fluent
+
+  def test_json
+    parser = Fluent::Test::ParserTestDriver.new(Fluent::ParserJsonOrCrio, nil)
+    parser.configure(
+      '@type'=>'tail',
+      '@id'=>'file-input',
+      'path'=>'/tmp/junk',
+      'pos_file'=>'/tmp/junk.pos',
+      'tag'=>'kubernetes.*',
+      'keep_time_key'=>'true',
+      'read_from_head'=>'true',
+      'exclude_path'=>'[]'
+    )
+    time, record = parser.parse('{"log":"{\"message\":\"a log record\"}","stream":"stdout","time":"2018-08-22T17:04:12.385850123Z"}')
+    assert_equal 1534957452, time
+    assert_equal '{"message":"a log record"}', record['log']
+    assert_equal "stdout", record['stream']
+  end
+  def test_json_with_custom_time_format
+    parser = Fluent::Test::ParserTestDriver.new(Fluent::ParserJsonOrCrio, nil)
+    parser.configure(
+      '@type'=>'tail',
+      '@id'=>'file-input',
+      'path'=>'/tmp/junk',
+      'pos_file'=>'/tmp/junk.pos',
+      'json_time_format'=>'%Y-%m-%dT%H:%M:%S%:z',
+      'tag'=>'kubernetes.*',
+      'keep_time_key'=>'true',
+      'read_from_head'=>'true',
+      'exclude_path'=>'[]'
+    )
+    time, record = parser.parse('{"log":"{\"message\":\"a log record\"}","stream":"stdout","time":"2018-08-22T17:04:12+00:00"}')
+    assert_equal 1534957452, time
+    assert_equal '{"message":"a log record"}', record['log']
+    assert_equal "stdout", record['stream']
+  end
+  def test_crio
+    parser = Fluent::Test::ParserTestDriver.new(Fluent::ParserJsonOrCrio, nil)
+    parser.configure(
+      '@type'=>'tail',
+      '@id'=>'file-input',
+      'path'=>'/tmp/junk',
+      'pos_file'=>'/tmp/junk.pos',
+      'tag'=>'kubernetes.*',
+      'keep_time_key'=>'true',
+      'read_from_head'=>'true',
+      'exclude_path'=>'[]'
+    )
+    time, record = parser.parse('2018-08-22T17:04:12.385850+00:00 stdout {"message":"a log record"}')
+    assert_equal 1534957452, time
+    assert_equal '{"message":"a log record"}', record['log']
+    assert_equal "stdout", record['stream']
+  end
+  def test_crio_with_custom_format
+    parser = Fluent::Test::ParserTestDriver.new(Fluent::ParserJsonOrCrio, nil)
+    parser.configure(
+      '@type'=>'tail',
+      '@id'=>'file-input',
+      'path'=>'/tmp/junk',
+      'pos_file'=>'/tmp/junk.pos',
+      'crio_time_format'=>'%Y-%m-%dT%H:%M:%S%Z',
+      'tag'=>'kubernetes.*',
+      'keep_time_key'=>'true',
+      'read_from_head'=>'true',
+      'exclude_path'=>'[]',
+      'crio_format'=>'/^(?<time>.+) (?<junk>.) (?<log>.*)$/'
+    )
+    time, record = parser.parse('2018-08-22T17:04:12Z A {"message":"a log record"}')
+    assert_equal 1534957452, time
+    assert_equal '{"message":"a log record"}', record['log']
+    assert_equal "A", record['junk']
+  end
+  def test_with_bogus_json
+    parser = Fluent::Test::ParserTestDriver.new(Fluent::ParserJsonOrCrio, nil)
+    parser.configure(
+      '@type'=>'tail',
+      '@id'=>'file-input',
+      'path'=>'/tmp/junk',
+      'pos_file'=>'/tmp/junk.pos',
+      'tag'=>'kubernetes.*',
+      'keep_time_key'=>'true',
+      'read_from_head'=>'true',
+      'exclude_path'=>'[]'
+    )
+    time, record = parser.parse('{not valid json}')
+    assert_equal nil, time
+    assert_equal nil, record
+  end
+  def test_with_empty_string
+    parser = Fluent::Test::ParserTestDriver.new(Fluent::ParserJsonOrCrio, nil)
+    parser.configure(
+      '@type'=>'tail',
+      '@id'=>'file-input',
+      'path'=>'/tmp/junk',
+      'pos_file'=>'/tmp/junk.pos',
+      'tag'=>'kubernetes.*',
+      'keep_time_key'=>'true',
+      'read_from_head'=>'true',
+      'exclude_path'=>'[]'
+    )
+    time, record = parser.parse('')
+    assert_equal nil, time
+    assert_equal nil, record
+  end
+end

--- a/fluentd/lib/parser_json_or_crio/test/test_helper.rb
+++ b/fluentd/lib/parser_json_or_crio/test/test_helper.rb
@@ -1,0 +1,16 @@
+require 'fileutils'
+
+def create_test_file(content=nil)
+    filename = "/tmp/parser_json_or_crio-#{rand(0...10000)}"
+    if content
+      File.open(filename, 'w') do |f|
+        f.write(content)
+      end
+    else
+      FileUtils.touch(filename).first
+    end
+    at_exit do
+      FileUtils.rm(filename)
+    end
+    filename
+end


### PR DESCRIPTION
This adds a new internal parser - json_or_crio - the way it
works is very simple - if the text begins with '{', assume it
is JSON formatted, otherwise, assume it is CRI-O formatted.
The assumption is that checking 1 character at the beginning of
the string is going to add negligible overhead to the already
expensive regexp or JSON parsing.
The nice thing is that it considerably simplifies our configuration.
We can even run on nodes where an upgrade from docker to cri-o
has occurred and there are mixed docker and cri-o log files.
There is a new config parameter for our in_tail plugins:
- `crio_format` - this is the regexp which matches the cri-o
log files - the default value is in the new parser plugin so
specifying this in the `in_tail` config is not necessary.