### PR TITLE
disable non-PIC build; build only components used by fluentd

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -73,7 +73,7 @@ ADD jemalloc/ ${HOME}/jemalloc/
 # cannot use make install - will try to install docs - not only does that fail
 # for some reason, but we also don't want them here - use install_lib install_bin
 RUN cd ${HOME}/jemalloc && EXTRA_CFLAGS="$( rpm --eval '%{optflags}' )" ./autogen.sh && \
-    make dist ; make && make install_lib install_bin && cp COPYING ${HOME}/COPYING.jemalloc && \
+    make install_lib_shared install_bin && cp COPYING ${HOME}/COPYING.jemalloc && \
     cd .. && rm -rf jemalloc
 
 WORKDIR ${HOME}


### PR DESCRIPTION
disable non-PIC build; build only components used by fluentd
The builds of the non-PIC libraries are throwing off build
security detectors, so disable them.
jemalloc 5.1.0 makes it easy to build only the components we
actually use - the shared library and the jemalloc-config script