### PR TITLE
modify curator WARN to WARNING

### DIFF
--- a/curator/run.sh
+++ b/curator/run.sh
@@ -4,6 +4,10 @@ if [ "$CURATOR_SCRIPT_LOG_LEVEL" = DEBUG ] ; then
     set -x
 fi
 
+if [ "$CURATOR_LOG_LEVEL" = WARN ] ; then
+    export CURATOR_LOG_LEVEL="WARNING"
+fi
+
 TIMES=60
 
 function waitForES() {


### PR DESCRIPTION
To fix:
```
No handlers could be found for logger "__main__"
No handlers could be found for logger "curator.validators.SchemaCheck"
Traceback (most recent call last):
  File "/usr/bin/curator", line 9, in <module>
    load_entry_point('elasticsearch-curator==5.2.0', 'console_scripts', 'curator')()
  File "/usr/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/curator/cli.py", line 211, in cli
    run(config, action_file, dry_run)
  File "/usr/lib/python2.7/site-packages/curator/cli.py", line 106, in run
    client_args = process_config(config)
  File "/usr/lib/python2.7/site-packages/curator/config_utils.py", line 45, in process_config
    config = test_config(yaml_file)
  File "/usr/lib/python2.7/site-packages/curator/config_utils.py", line 19, in test_config
    'Client Configuration', 'full configuration dictionary').result()
  File "/usr/lib/python2.7/site-packages/curator/validators/schemacheck.py", line 68, in result
    self.test_what, self.location, self.badvalue, self.error)
curator.exceptions.ConfigurationError: Configuration: Client Configuration: Location: full configuration dictionary: Bad Value: "{'loglevel': 'WARN', 'blacklist': ['elasticsearch', 'urllib3'], 'logformat': 'default'}", not a valid value for dictionary value @ data['logging']['loglevel']. Check configuration file.
```