### PR TITLE
Cleaning up fluentd warnings for the USE_CRIO case

### DIFF
--- a/fluentd/configs.d/openshift/filter-k8s-meta.conf
+++ b/fluentd/configs.d/openshift/filter-k8s-meta.conf
@@ -7,7 +7,6 @@
   ca_file /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
   use_journal "#{ENV['USE_JOURNAL'] || 'false'}"
   container_name_to_kubernetes_regexp '^(?<name_prefix>[^_]+)_(?<container_name>[^\._]+)(\.(?<container_hash>[^_]+))?_(?<pod_name>[^_]+)_(?<namespace>[^_]+)_[^_]+_[^_]+$'
-  merge_json_log false # use parse_json_field instead
 </filter>
 
 <filter kubernetes.**>

--- a/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
+++ b/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
@@ -168,7 +168,7 @@ def create_default_docker(input_conf_file, excluded, log, options={})
   @label @INGRESS
   path "#{cont_logs_path}"
   pos_file "#{cont_pos_file}"
-  time_format %Y-%m-%dT%H:%M:%S.%N%Z
+  time_format #{use_crio == 'true' ? '%Y-%m-%dT%H:%M:%S.%N%:z' : '%Y-%m-%dT%H:%M:%S.%N%Z'}
   tag kubernetes.*
   format #{use_crio == 'true' ? '/^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/' : 'json'}
   keep_time_key true

--- a/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
+++ b/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
@@ -75,7 +75,7 @@ describe 'generate_throttle_configs' do
   @label @INGRESS
   path "/var/log/containers/*.log"
   pos_file "/var/log/es-containers.log.pos"
-  time_format %Y-%m-%dT%H:%M:%S.%N%Z
+  time_format %Y-%m-%dT%H:%M:%S.%N%:z
   tag kubernetes.*
   format /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
   keep_time_key true

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -286,7 +286,8 @@ fi
 # pods unable to be terminated because fluentd has them busy
 if [ "${USE_MUX:-}" = "true" ] ; then
     : # skip umount
-else
+elif [ "${USE_CRIO:false}" = "false" ] ; then
+    # If oci-umount is fixed, we can remove this. 
     echo "umounts of dead containers will fail. Ignoring..."
     umount /var/lib/docker/containers/*/shm || :
 fi


### PR DESCRIPTION
crio time format: %Y-%m-%dT%H:%M:%S.%N%:z
Sample log:
  2018-08-16T21:01:20.746130681+00:00 stdout F loader seq - f39a9bb445804d97bf1690581c3ddbf2 - ...

Removing "umount /var/lib/docker/containers/*/shm", if USE_CRIO.

Removing merge_json_log from kubernetes_metadata config.