### PR TITLE
Improve readiness probe

### DIFF
--- a/elasticsearch/init.sh
+++ b/elasticsearch/init.sh
@@ -17,11 +17,18 @@
 
 source "logging"
 
+wait_for_port_open
+failed=0
+
 pushd "${ES_HOME}/init"
   files=$(ls | sort)
   for init_file in ${files}; do
     if [ -f "${init_file}" ] ; then
-      ./"${init_file}"
+      ./"${init_file}" || failed=1
     fi
   done
 popd
+
+if [ $failed -eq 0 ]; then
+  touch ${HOME}/init_complete
+fi

--- a/elasticsearch/probe/readiness.sh
+++ b/elasticsearch/probe/readiness.sh
@@ -40,4 +40,9 @@ function check_if_ready() {
   fi
 }
 
+function check_for_init_complete() {
+  test -f ${HOME}/init_complete
+}
+
 check_if_ready "/" "Elasticsearch node is not ready to accept HTTP requests yet"
+check_for_init_complete

--- a/elasticsearch/utils/es_seed_acl
+++ b/elasticsearch/utils/es_seed_acl
@@ -55,8 +55,8 @@ info "Seeded the searchguard ACL index"
 info "Disabling auto replication"
 sgadmin -dra
 
-info "Updating replica count to 0"
-sgadmin -us 0
+info "Updating replica count to ${REPLICA_SHARDS}"
+sgadmin -us ${REPLICA_SHARDS}
 
 info "Setting filters to allocate shard to this node only"
 es_util --query="$index/_settings" -XPUT -d "{\"index.routing.allocation.include._name\": \"$index\"}"

--- a/elasticsearch/utils/logging
+++ b/elasticsearch/utils/logging
@@ -13,6 +13,22 @@ case $LOGLEVEL in
        exit 1 ;;
 esac
 
+# the deployment mounts the secrets at this location - not necessarily the same
+# as $ES_CONF
+secret_dir=/etc/elasticsearch/secret
+provided_secret_dir=/etc/openshift/elasticsearch/secret
+
+PRIMARY_SHARDS=${PRIMARY_SHARDS:-1}
+REPLICA_SHARDS=${REPLICA_SHARDS:-0}
+
+RETRY_COUNT=${RETRY_COUNT:-300}		# how many times
+RETRY_INTERVAL=${RETRY_INTERVAL:-1}	# how often (in sec)
+ES_REST_BASEURL=${ES_REST_BASEURL:-https://localhost:9200}
+LOG_FILE=${LOG_FILE:-elasticsearch_connect_log.txt}
+retry=$RETRY_COUNT
+max_time=$(( RETRY_COUNT * RETRY_INTERVAL ))	# should be integer
+timedout=false
+
 log() {
     lvlint=$1
     if [ $loglevelint -ge $lvlint ] ; then
@@ -46,4 +62,129 @@ get_hash() {
 
 get_kibana_index_name() {
     echo .kibana.$(get_hash "$1")
+}
+
+# Pull in the certs provided in our secret and generate our necessary jks and truststore files
+build_jks_truststores() {
+
+  copy_keys_to_secretdir
+
+  info "Building required jks files and truststore"
+
+  # check for lack of admin.jks
+  if [[ ! -e $secret_dir/admin.jks ]]; then
+    build_jks_from_pem "admin" "admin-key" "admin-cert" "admin-ca"
+  fi
+
+  # check for elasticsearch.key and elasticsearch.crt
+  if [[ -e $secret_dir/elasticsearch.key && -e $secret_dir/elasticsearch.crt && ! -e $secret_dir/searchguard.key ]]; then
+    build_jks_from_pem "elasticsearch" "elasticsearch.key" "elasticsearch.crt" "admin-ca"
+    mv $secret_dir/elasticsearch.jks $secret_dir/searchguard.key
+  fi
+
+  # check for logging-es.key and logging-es.crt
+  if [[ -e $secret_dir/logging-es.key && -e $secret_dir/logging-es.crt && ! -e $secret_dir/key ]]; then
+    build_jks_from_pem "logging-es" "logging-es.key" "logging-es.crt" "admin-ca"
+    mv $secret_dir/logging-es.jks $secret_dir/key
+  fi
+
+  if [[ ! -e $secret_dir/truststore ]]; then
+    keytool                                        \
+      -import                                      \
+      -file $secret_dir/admin-ca                   \
+      -keystore $secret_dir/truststore             \
+      -storepass tspass                            \
+      -noprompt                                    \
+      -alias sig-ca
+  fi
+
+  if [[ ! -e $secret_dir/searchguard.truststore ]]; then
+    keytool                                        \
+      -import                                      \
+      -file $secret_dir/admin-ca                   \
+      -keystore $secret_dir/searchguard.truststore \
+      -storepass tspass                            \
+      -noprompt                                    \
+      -alias sig-ca
+  fi
+}
+
+# Wait for Elasticsearch port to be opened. Fail on timeout or if response from Elasticsearch is unexpected.
+wait_for_port_open() {
+    rm -f $LOG_FILE
+    # test for ES to be up first and that our SG index has been created
+    info "Checking if Elasticsearch is ready"
+    while ! response_code=$(es_util --query=/ \
+        ${DEBUG:+-v} -s \
+        --request HEAD --head \
+        --max-time $max_time \
+        -o $LOG_FILE -w '%{response_code}') || test $response_code != "200"
+    do
+        sleep $RETRY_INTERVAL
+        (( retry -= 1 )) || :
+        if (( retry == 0 )) ; then
+            timedout=true
+            break
+        fi
+    done
+
+    if [ $timedout = true ] ; then
+        error "Timed out waiting for Elasticsearch to be ready"
+    else
+        rm -f $LOG_FILE
+        info Elasticsearch is ready and listening
+        return 0
+    fi
+    cat $LOG_FILE
+    rm -f $LOG_FILE
+    exit 1
+}
+
+build_jks_from_pem() {
+
+  jks_name=$1
+  key_name=$2
+  cert_name=$3
+  ca_name=$4
+
+  openssl                                   \
+    pkcs12                                  \
+    -export                                 \
+    -in $secret_dir/$cert_name              \
+    -inkey $secret_dir/$key_name            \
+    -out $secret_dir/$jks_name.p12          \
+    -passout pass:kspass
+
+  keytool                                   \
+    -importkeystore                         \
+    -srckeystore $secret_dir/$jks_name.p12  \
+    -srcstoretype PKCS12                    \
+    -srcstorepass kspass                    \
+    -destkeystore $secret_dir/$jks_name.jks \
+    -deststoretype JKS                      \
+    -deststorepass kspass                   \
+    -noprompt
+
+  keytool                                   \
+    -changealias                            \
+    -keystore $secret_dir/$jks_name.jks     \
+    -storepass kspass                       \
+    -alias 1                                \
+    -destalias $jks_name
+
+  keytool                                   \
+    -import                                 \
+    -file $secret_dir/$ca_name              \
+    -keystore $secret_dir/$jks_name.jks     \
+    -storepass kspass                       \
+    -noprompt                               \
+    -alias sig-ca
+}
+
+copy_keys_to_secretdir() {
+
+  if [ -d $provided_secret_dir ] ; then
+    info "Copying certs from ${provided_secret_dir} to ${secret_dir}"
+    cp $provided_secret_dir/* $secret_dir/
+  fi
 }


### PR DESCRIPTION
Update the ES readiness probe script to gate on our initialization has been completed.
Since we have our `-cluster` service configured to publish end points prior to the pods being marked as ready we can form a cluster to seed data before being available to external components.

Addresses: 
* https://bugzilla.redhat.com/show_bug.cgi?id=1613156
* https://github.com/openshift/origin-aggregated-logging/pull/1323