### PR TITLE
ignore red cluster when seeding

### DIFF
--- a/elasticsearch/utils/es_seed_acl
+++ b/elasticsearch/utils/es_seed_acl
@@ -23,6 +23,7 @@ function sgadmin {
     -tst JKS \
     -tspass tspass \
     -nhnv \
+    -arc \
     -icl \
     ${DEBUG:+-dg} ${@:-}
 }


### PR DESCRIPTION
This PR adds a switch to ignore red clusters when seeding which we have seen on some of the online and dedicated clusters where the seed script hangs on YELLOW.  This looks to unblock the health probe