### PR TITLE
bug 1626491. Dont peg replicas to a node for searchguard

### DIFF
--- a/elasticsearch/utils/es_seed_acl
+++ b/elasticsearch/utils/es_seed_acl
@@ -57,6 +57,3 @@ sgadmin -dra
 
 info "Updating replica count to ${REPLICA_SHARDS}"
 sgadmin -us ${REPLICA_SHARDS}
-
-info "Setting filters to allocate shard to this node only"
-es_util --query="$index/_settings" -XPUT -d "{\"index.routing.allocation.include._name\": \"$index\"}"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1626491

This reverts a prior addition that was needed when individual SG indices were pegged to a node