### PR TITLE
Capture OpenShift audit logging into Fluentd and send it to ES.

### DIFF
--- a/fluentd/configs.d/input-ocp-audit.conf
+++ b/fluentd/configs.d/input-ocp-audit.conf
@@ -15,7 +15,7 @@
     enable_ruby true
     auto_typecast true
     <record>
-      audit ${record}
+      kubernetes {"audit":"${record}"}
       message "this is an audit event"
       level info
       time ${Time.parse(record['timestamp']).to_datetime.rfc3339(6)}

--- a/fluentd/configs.d/input-ocp-audit.conf
+++ b/fluentd/configs.d/input-ocp-audit.conf
@@ -27,12 +27,12 @@
 
     type_name com.redhat.ocp.auditlog
 
-    # there is currently a bug in the es plugin + excon - cannot
-    # recreate/reload connections
-    reload_connections false
-    reload_on_failure false
-    flush_interval 5s
-    max_retry_wait 300
+    reload_connections "#{ENV['OPS_RELOAD_CONNECTIONS'] || ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    reload_after "#{ENV['OPS_RELOAD_AFTER'] || ENV['ES_RELOAD_AFTER'] || '200'}"
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '1s'}"
+    max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
     disable_retry_limit true
     buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
     buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"

--- a/fluentd/configs.d/input-ocp-audit.conf
+++ b/fluentd/configs.d/input-ocp-audit.conf
@@ -18,11 +18,11 @@
       audit ${record}
       message "this is an audit event"
       level info
-      time ${Time.parse(record['timestamp'])}
+      time ${Time.parse(record['timestamp']).to_datetime.rfc3339(6)}
     </record>
   </filter>
   <match audit-ocp.log>
-    @type rewrite_tag
+    @type rewrite_tag_filter
     @label @INGRESS
     rewriterule1 message .+ audit.log
   </match>

--- a/fluentd/configs.d/input-ocp-audit.conf
+++ b/fluentd/configs.d/input-ocp-audit.conf
@@ -5,40 +5,25 @@
   # From 3.9, the advanced audits logs comes in json format by default.
   format json
   tag audit-ocp.log
+  @label @OCP_AUDIT
 </source>
 
-<match audit-ocp.log>
-  # @type stdout
-   @type copy
-  <store>
-    @type elasticsearch_dynamic
-    log_level debug
-    host "#{ENV['OPS_HOST']}"
-    port "#{ENV['OPS_PORT']}"
-    scheme https
-    index_name operations.ocp.auditlog.
-    
-    user fluentd
-    password changeme
-
-    client_key "#{ENV['OPS_CLIENT_KEY']}"
-    client_cert "#{ENV['OPS_CLIENT_CERT']}"
-    ca_file "#{ENV['OPS_CA']}"
-
-    type_name com.redhat.ocp.auditlog
-
-    reload_connections "#{ENV['OPS_RELOAD_CONNECTIONS'] || ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
-    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-    reload_after "#{ENV['OPS_RELOAD_AFTER'] || ENV['ES_RELOAD_AFTER'] || '200'}"
-    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
-    flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '1s'}"
-    max_retry_wait "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
-    disable_retry_limit true
-    buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-    buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
-    # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-    # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-    # buffer to the remote - default is 'exception' because in_tail handles that case
-    buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
-  </store>
-</match>
+<label @OCP_AUDIT>
+  <filter audit-ocp.log>
+    @type record_transformer
+    renew_record true
+    enable_ruby true
+    auto_typecast true
+    <record>
+      audit ${record}
+      message "this is an audit event"
+      level info
+      time ${Time.parse(record['timestamp'])}
+    </record>
+  </filter>
+  <match audit-ocp.log>
+    @type rewrite_tag
+    @label @INGRESS
+    rewriterule1 message .+ audit.log
+  </match>
+</label>

--- a/fluentd/configs.d/input-ocp-audit.conf
+++ b/fluentd/configs.d/input-ocp-audit.conf
@@ -1,0 +1,44 @@
+<source>
+  @type tail
+  path /var/log/audit/audit-ocp.log
+  pos_file /var/log/audit/audit-ocp.pos
+  # From 3.9, the advanced audits logs comes in json format by default.
+  format json
+  tag audit-ocp.log
+</source>
+
+<match audit-ocp.log>
+  # @type stdout
+   @type copy
+  <store>
+    @type elasticsearch_dynamic
+    log_level debug
+    host "#{ENV['OPS_HOST']}"
+    port "#{ENV['OPS_PORT']}"
+    scheme https
+    index_name operations.ocp.auditlog.
+    
+    user fluentd
+    password changeme
+
+    client_key "#{ENV['OPS_CLIENT_KEY']}"
+    client_cert "#{ENV['OPS_CLIENT_CERT']}"
+    ca_file "#{ENV['OPS_CA']}"
+
+    type_name com.redhat.ocp.auditlog
+
+    # there is currently a bug in the es plugin + excon - cannot
+    # recreate/reload connections
+    reload_connections false
+    reload_on_failure false
+    flush_interval 5s
+    max_retry_wait 300
+    disable_retry_limit true
+    buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+    buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+    # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+    # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+    # buffer to the remote - default is 'exception' because in_tail handles that case
+    buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
+  </store>
+</match>


### PR DESCRIPTION
This conf file have the configuration capture the OpenShift Audit logs and send them to ElasticSearch.
It creates an index also.