### PR TITLE
LOG-192. Impl bearer token for  openshift-elasticsearch-plugin

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -13,7 +13,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     INSTANCE_RAM=512G \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.10.3-redhat-1 \
+    OSE_ES_VER=5.6.10.4-redhat-1 \
     PROMETHEUS_EXPORTER_VER=5.6.10.0-redhat-2 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -22,7 +22,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     RELEASE_STREAM=prod \
     container=oci
 
-ARG OSE_ES_VER=5.6.10.3-redhat-1
+ARG OSE_ES_VER=5.6.10.4-redhat-1
 ARG OSE_ES_URL
 ARG PROMETHEUS_EXPORTER_VER=5.6.10.0-redhat-2
 ARG PROMETHEUS_EXPORTER_URL

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -14,7 +14,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_VER=1.8.0 \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.10.3 \
+    OSE_ES_VER=5.6.10.4 \
     PROMETHEUS_EXPORTER_VER=5.6.10.0 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -22,7 +22,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     RECOVER_AFTER_TIME=5m \
     RELEASE_STREAM=origin
 
-ARG OSE_ES_VER=5.6.10.3
+ARG OSE_ES_VER=5.6.10.4
 ARG SG_VER=5.6.10-19.2
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \

--- a/elasticsearch/run.sh
+++ b/elasticsearch/run.sh
@@ -77,12 +77,6 @@ else
     exit 1
 fi
 
-cat <<CONF >> ${HOME}/sgconfig/sg_roles_mapping.yml
-sg_role_prometheus:
-  users:
-    - "${PROMETHEUS_USER:-system:serviceaccount:prometheus:prometheus}"
-CONF
-
 build_jks_truststores
 ./init.sh &
 

--- a/elasticsearch/sgconfig/sg_action_groups.yml
+++ b/elasticsearch/sgconfig/sg_action_groups.yml
@@ -95,8 +95,6 @@ METRICS:
 USER_ALL_INDEX_OPS:
   - "indices:data/read/field_caps*"
 USER_CLUSTER_OPERATIONS:
-  - "indices:data/read/field_caps*"
-  - "indices:data/read/scroll*"
   - CLUSTER_COMPOSITE_OPS_RO
   - MONITOR
   - CLUSTER_COMPOSITE_OPS
@@ -119,10 +117,12 @@ CLUSTER_OPERATIONS:
   - CLUSTER_ALL
 
 CLUSTER_COMPOSITE_OPS_RO:
+  - "indices:data/read/coordinate-msearch*"
+  - "indices:data/read/field_caps*"
   - "indices:data/read/mget"
   - "indices:data/read/msearch"
   - "indices:data/read/mtv"
-  - "indices:data/read/coordinate-msearch*"
+  - "indices:data/read/scroll*"
   - "indices:admin/aliases/exists*"
   - "indices:admin/aliases/get*"
 

--- a/elasticsearch/sgconfig/sg_config.yml
+++ b/elasticsearch/sgconfig/sg_config.yml
@@ -7,16 +7,21 @@ searchguard:
         trustedProxies: '.*'
         internalProxies: '.*'
     authc:
-      authentication_domain_proxy:
+      openshift_domain:
         enabled: true
         order: 0
         http_authenticator:
           challenge: false
-          type: proxy
-          config:
-            user_header: 'x-proxy-remote-user'
+          type: io.fabric8.elasticsearch.plugin.auth.OpenShiftTokenAuthentication
         authentication_backend:
-          type: noop
+          type: io.fabric8.elasticsearch.plugin.auth.OpenShiftTokenAuthentication
+          config:
+             subjectAccessReviews:
+               prometheus:
+                 namespace: openshift-logging
+                 verb: view
+                 resource: prometheus
+                 resourceAPIGroup: metrics.openshift.io
       authentication_domain_basic_internal:
         enabled: true
         order: 1
@@ -25,15 +30,3 @@ searchguard:
           challenge: false
         authentication_backend:
           type: noop
-      prometheus_proxy:
-        enabled: true
-        order: 3
-        http_authenticator:
-          challenge: false
-          type: io.fabric8.elasticsearch.plugin.auth.FileAuthenticationBackend
-          config:
-            file_path: /etc/elasticsearch/secret/passwd.yml
-        authentication_backend:
-          type: io.fabric8.elasticsearch.plugin.auth.FileAuthenticationBackend
-          config:
-            file_path: /etc/elasticsearch/secret/passwd.yml

--- a/elasticsearch/sgconfig/sg_roles_mapping.yml
+++ b/elasticsearch/sgconfig/sg_roles_mapping.yml
@@ -13,3 +13,6 @@ sg_role_curator:
 sg_role_admin:
   users:
     - 'CN=system.admin,OU=OpenShift,O=Logging'
+sg_role_prometheus:
+  backendroles:
+    - 'prometheus'

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -73,24 +73,21 @@ function get_test_user_token() {
 # $1 - kibana pod name
 # $2 - es hostname (e.g. logging-es or logging-es-ops)
 # $3 - endpoint (e.g. /projects.*/_search)
-# $4 - username
-# $5 - token
+# $4 - token
 # stdout is the JSON output from Elasticsearch
 # stderr is curl errors
 curl_es_from_kibana() {
     local pod="$1"
     local eshost="$2"
     local endpoint="$3"
-    local test_name="$4"
-    local test_token="$5"
-    shift; shift; shift; shift; shift
+    local test_token="$4"
+    shift; shift; shift; shift
     local args=( "${@:-}" )
 
     local secret_dir="/etc/kibana/keys/"
     oc -n $LOGGING_NS exec "${pod}" -c kibana -- curl --connect-timeout 1 --silent --insecure "${args[@]}" \
        --cert "${secret_dir}cert" \
        --key "${secret_dir}key" \
-       -H "X-Proxy-Remote-User: $test_name" \
        -H "Authorization: Bearer $test_token" \
        -H "X-Forwarded-For: 127.0.0.1" \
        "https://${eshost}:9200${endpoint}"
@@ -151,12 +148,10 @@ function curl_es_input() {
 function curl_es_pod_with_token() {
     local pod="$1"
     local endpoint="$2"
-    local test_name="$3"
-    local test_token="$4"
-    shift; shift; shift; shift
+    local test_token="$3"
+    shift; shift; shift;
     local args=( "${@:-}" )
     oc -n $LOGGING_NS exec -c elasticsearch "${pod}" -- curl --silent --insecure "${args[@]}" \
-                             -H "X-Proxy-Remote-User: $test_name" \
                              -H "Authorization: Bearer $test_token" \
                              -H "X-Forwarded-For: 127.0.0.1" \
                              "https://localhost:9200${endpoint}"
@@ -191,45 +186,38 @@ function curl_es_pod_with_username_password_not_silent() {
 function curl_es_with_token() {
     local svc_name="$1"
     local endpoint="$2"
-    local test_name="$3"
-    local test_token="$4"
-    shift; shift; shift; shift
+    local test_token="$3"
+    shift; shift; shift
     local args=( "${@:-}" )
 
     curl --silent --insecure "${args[@]}" \
-      -H "X-Proxy-Remote-User: $test_name" \
       -H "Authorization: Bearer $test_token" \
-      -H "X-Forwarded-For: 127.0.0.1" \
-      "https://${svc_name}.${LOGGING_NS}:9200${endpoint}"
+      "https://${svc_name}:9200${endpoint}"
 }
 
 function curl_es_pod_with_token_and_input() {
     local pod="$1"
     local endpoint="$2"
-    local test_name="$3"
-    local test_token="$4"
-    shift; shift; shift; shift
+    local test_token="$3"
+    shift; shift; shift
     local args=( "${@:-}" )
 
     oc -n $LOGGING_NS exec -c elasticsearch -i "${pod}" -- curl --silent --insecure "${args[@]}" \
-                             -H "X-Proxy-Remote-User: $test_name" \
                              -H "Authorization: Bearer $test_token" \
-                             -H "X-Forwarded-For: 127.0.0.1" \
+                             -H "Content-type: application/json" \
                              "https://localhost:9200${endpoint}"
 }
 
 function curl_es_with_token_and_input() {
     local svc_name="$1"
     local endpoint="$2"
-    local test_name="$3"
-    local test_token="$4"
-    shift; shift; shift; shift
+    local test_token="$3"
+    shift; shift; shift
     local args=( "${@:-}" )
 
     curl --silent --insecure "${args[@]}" \
-      -H "X-Proxy-Remote-User: $test_name" \
       -H "Authorization: Bearer $test_token" \
-      -H "X-Forwarded-For: 127.0.0.1" \
+      -H "Content-type: application/json" \
       "https://${svc_name}.${LOGGING_NS}:9200${endpoint}"
 }
 

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -50,6 +50,16 @@ test_token="$( oc whoami -t )"
 os::cmd::expect_success "oc login --username=system:admin"
 os::cmd::expect_success "oc project ${LOGGING_NS}"
 
+result=$(oc get sa prometheus-scraper -n ${LOGGING_NS} ||:)
+if [ "$result" == "" ] ; then
+  oc create sa prometheus-scraper -n ${LOGGING_NS}
+fi
+result=$(oc get rolebinding prometheus-scraper -n ${LOGGING_NS} prometheus-scraper ||:)
+if [ "$result" == "" ] ; then
+  oc create rolebinding prometheus-scraper --serviceaccount=${LOGGING_NS}:prometheus-scraper --role=prometheus-metrics-viewer
+fi
+SATOKEN=$(oc -n ${LOGGING_NS} serviceaccounts get-token prometheus-scraper)
+
 # We can reach the Elasticsearch service at serviceName:apiPort
 elasticsearch_api="$( oc get svc "${OAL_ELASTICSEARCH_SERVICE}" -o jsonpath='{ .metadata.name }:{ .spec.ports[?(@.targetPort=="restapi")].port }' )"
 
@@ -132,17 +142,14 @@ for elasticsearch_pod in $( oc get pods --selector component="${OAL_ELASTICSEARC
 		os::log::info "Elasticsearch pod ${elasticsearch_pod} contains expected plugin(s)"
 	fi
 
-#	WIP, uncommented unless we figure out how to get user name
 	os::log::info "Checking that Elasticsearch pod ${elasticsearch_pod} exports Prometheus metrics"
-	passwd_contents="$(oc extract secret/logging-elasticsearch --keys=passwd.yml --to=-)"
-	user_name="$(echo ${passwd_contents} | cut -d'"' -f2)"
-	user_passwd="$(echo ${passwd_contents} | cut -d'"' -f4 | base64 -d)"
+    es_pod_ip=$(oc get pod ${elasticsearch_pod} -o jsonpath={.status.podIP})
 
-	if os::cmd::expect_success_and_text "curl_es_pod_with_username_password '${elasticsearch_pod}' '/_prometheus/metrics' '$user_name' '$user_passwd' --output /dev/null --write-out '%{response_code}'" '200'; then
+	if os::cmd::expect_success_and_text "curl_es_with_token '${es_pod_ip}' '/_prometheus/metrics' '${SATOKEN}' --output /dev/null --write-out '%{response_code}' -v" '200'; then
 		os::log::info "Received data from metrics endpoint"
 	else
 		artifact_log unable to connect to prometheus end point:
-		artifact_log $( curl_es_pod_with_username_password_not_silent "${elasticsearch_pod}" '/_prometheus/metrics' "$user_name" "$user_passwd" )
+		artifact_log $( curl_es_with_token "${es_pod_ip}" '/_prometheus/metrics' "$SATOKEN" )
 		artifact_log $(oc exec -n $LOGGING_NS -c elasticsearch ${elasticsearch_pod} -- es_acl get --doc=actiongroups)
 		os::log::fatal "Failed while curling _prometheus/metrics endpoint"
 	fi

--- a/test/kibana_dashboards.sh
+++ b/test/kibana_dashboards.sh
@@ -55,7 +55,7 @@ done
 # make sure admin kibana index exists - log in to ES as admin user
 get_test_user_token $LOG_ADMIN_USER $LOG_ADMIN_PW
 for pod in $espod $esopspod ; do
-    curl_es_pod_with_token $pod "/" "$test_name" "$test_token" | curl_output
+    curl_es_pod_with_token $pod "/" "$test_token" | curl_output
     # add the ui objects
     os::cmd::expect_success_and_text "oc exec -c elasticsearch $pod -- es_load_kibana_ui_objects $LOG_ADMIN_USER" "Success"
 done

--- a/test/multi_tenancy.sh
+++ b/test/multi_tenancy.sh
@@ -91,11 +91,11 @@ function test_user_has_proper_access() {
     for proj in "$@" ; do
         os::log::info See if user $user can read /project.$proj.*
         get_test_user_token $user $pw
-        nrecs=$( curl_es_pod_with_token $espod "/project.$proj.*/_count" $test_name $test_token | \
+        nrecs=$( curl_es_pod_with_token $espod "/project.$proj.*/_count" $test_token | \
                      get_count_from_json )
         if ! os::cmd::expect_success "test $nrecs = 1" ; then
             os::log::error $user cannot access project.$proj.* indices
-            curl_es_pod_with_token $espod "/project.$proj.*/_count" $test_name $test_token | python -mjson.tool
+            curl_es_pod_with_token $espod "/project.$proj.*/_count" $test_token | python -mjson.tool
             os::log::info "acl documents"
             oc exec -c elasticsearch $espod -- es_acl get --doc=roles
             oc exec -c elasticsearch $espod -- es_acl get --doc=rolesmapping
@@ -110,14 +110,14 @@ function test_user_has_proper_access() {
     os::log::info See if user $user can _msearch "$indices"
     get_test_user_token $user $pw
     nrecs=$( { echo '{"index":'"${indices}"'}'; echo '{"size":0,"query":{"match_all":{}}}'; } | \
-                     curl_es_pod_with_token_and_input $espod "/_msearch" $test_name $test_token -XPOST --data-binary @- | \
+                     curl_es_pod_with_token_and_input $espod "/_msearch" $test_token -XPOST --data-binary @- | \
                      get_count_from_json_from_search )
     if ! os::cmd::expect_success "test $nrecs = 2" ; then
         os::log::error $user cannot access "$indices" indices with _msearch
         {
             echo '{"index":'"${indices}"'}'
             echo '{"query" : {"match_all" : {}}}'
-        } | curl_es_pod_with_token_and_input $espod "/_msearch" $test_name $test_token -XPOST --data-binary @- | \
+        } | curl_es_pod_with_token_and_input $espod "/_msearch" $test_token -XPOST --data-binary @- | \
             python -mjson.tool
         exit 1
     fi
@@ -125,22 +125,22 @@ function test_user_has_proper_access() {
     # verify normal user has no access to default indices
     os::log::info See if user $user is denied /project.default.*
     get_test_user_token $user $pw
-    nrecs=$( curl_es_pod_with_token $espod "/project.default.*/_count" $test_name $test_token | \
+    nrecs=$( curl_es_pod_with_token $espod "/project.default.*/_count" $test_token | \
                  get_count_from_json )
     if ! os::cmd::expect_success "test $nrecs = 0" ; then
         os::log::error $LOG_NORMAL_USER has improper access to project.default.* indices
-        curl_es_pod_with_token $espod "/project.default.*/_count" $test_name $test_token | python -mjson.tool
+        curl_es_pod_with_token $espod "/project.default.*/_count" $test_token | python -mjson.tool
         exit 1
     fi
 
     # verify normal user has no access to .operations
     os::log::info See if user $user is denied /.operations.*
     get_test_user_token $user $pw
-    nrecs=$( curl_es_pod_with_token $esopspod "/.operations.*/_count" $test_name $test_token | \
+    nrecs=$( curl_es_pod_with_token $esopspod "/.operations.*/_count" $test_token | \
                  get_count_from_json )
     if ! os::cmd::expect_success "test $nrecs = 0" ; then
         os::log::error $LOG_NORMAL_USER has improper access to .operations.* indices
-        curl_es_pod_with_token $esopspod "/.operations.*/_count" $test_name $test_token | python -mjson.tool
+        curl_es_pod_with_token $esopspod "/.operations.*/_count" $test_token | python -mjson.tool
         exit 1
     fi
 }


### PR DESCRIPTION
This PR imples https://jira.coreos.com/browse/LOG-192

which adds a native bearer token authentication and should allow us to remove the proxy for metrics

Blocked by https://github.com/fabric8io/openshift-elasticsearch-plugin/pull/158