### PR TITLE
Bug 1632648 - Record is missing kubernetes field when Docker log driver is journald

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -43,7 +43,7 @@ docker_uses_journal() {
         if grep -q '^[^#].*"log-driver":.*journald' /etc/docker/daemon.json 2> /dev/null ; then
             return 0
         fi
-    elif grep -q "^OPTIONS='[^']*--log-driver=journald" /etc/sysconfig/docker 2> /dev/null ; then
+    elif grep -q "^OPTIONS='[^']*--log-driver[   =][     ]*journald" /etc/sysconfig/docker 2> /dev/null ; then
         return 0
     fi
     return 1


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1632648
In /etc/sysconfig/docker, the log-driver may be specified
as --log-driver=journald or --log-driver journald delimited
by one or more whitespace