### PR TITLE
Added info message about redirection of fluentd logs

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -16,6 +16,12 @@ for file in ${ocp_fluentd_files} ; do
     sed -i -e "s/%OCP_FLUENTD_TAGS%/${OCP_FLUENTD_TAGS}/" $file
 done
 
+echo "============================="
+echo "Fluentd logs have been redirected to: $LOGGING_FILE_PATH"
+echo "If you want to print out the logs, use command:"
+echo "oc exec <pod_name> $HOME/utils/logs"
+echo "============================="
+
 fluentdargs="--no-supervisor"
 if [[ $VERBOSE ]]; then
   set -ex

--- a/hack/logging-dump.sh
+++ b/hack/logging-dump.sh
@@ -143,6 +143,10 @@ get_pod_logs() {
   do
     oc logs $pod -c $container | nice xz > $logs_folder/$pod-$container.log.xz || oc logs $pod | nice xz > $logs_folder/$pod.log.xz || echo ---- Unable to get logs from pod $pod and container $container
   done
+  if [ "$fluentd_folder" == "$2" ]
+  then
+    oc exec $1 logs | nice xz >> $logs_folder/$pod.log.xz
+  fi  
 }
 
 check_fluentd_connectivity() {


### PR DESCRIPTION
Added a message that will be printed out when `oc logs <fluentd_pod>` is used. Informing user that logs are written to log files and what to do if they want to see them.

I am unsure whether to put the message at the end of the `run.sh` script or somewhere at the start.
Also `logs` file is not in the PATH so you need to type `./utils/logs` or the absolute path variant to use it. Is it a problem?