### PR TITLE
look for /var/log/fluentd/fluentd.log for pod logs

### DIFF
--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -490,3 +490,20 @@ get_bulk_thread_pool_url() {
     done
     echo $url
 }
+
+# fluentd may have pod logs and logs in the file
+get_fluentd_pod_log() {
+    local pod=${1:-$( get_running_pod fluentd )}
+    local logfile=${2:-/var/log/fluentd/fluentd.log}
+    oc logs $pod 2>&1
+    if sudo test -f $logfile ; then
+        sudo cat $logfile
+    fi
+}
+
+get_mux_pod_log() {
+    local pod=${1:-$( get_running_pod mux )}
+    local logfile=${2:-/var/log/fluentd/fluentd.log}
+    oc logs $pod 2>&1
+    oc exec $pod -- cat $logfile 2> /dev/null || :
+}

--- a/test/docker_audit.sh
+++ b/test/docker_audit.sh
@@ -82,6 +82,7 @@ os::log::info "ops diff before:  $ops_logs_before"
 os::log::info "proj diff before: $logs_before"
 
 os::cmd::expect_success flush_fluentd_pos_files
+sudo rm -f /var/log/fluentd/fluentd.log
 os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
@@ -92,7 +93,7 @@ docker run --rm centos:7 echo "running test container"
 
 if ! os::cmd::try_until_success "logs_count_is_ge $esopssvc '/.operations.*/' 4 $timestamp" $((second * 60)) ; then
     sudo grep VIRT_CONTROL /var/log/audit/audit.log | tail -40 > $ARTIFACT_DIR/docker_audit_audit.log
-    oc logs $fpod > $ARTIFACT_DIR/docker_audit_fluentd.log 2>&1
+    get_fluentd_pod_log $fpod > $ARTIFACT_DIR/docker_audit_fluentd.log
     ops_logs_after=$( get_logs_count $esopssvc '/.operations.*/' )
     logs_after=$( get_logs_count $essvc '/project.*/' )
     get_logs_source $esopssvc '/.operations.*/' > $ARTIFACT_DIR/docker_audit_ops.json 2>&1

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -18,7 +18,7 @@ update_current_fluentd() {
     # but instead forwards to the forwarding fluentd
 
     # undeploy fluentd
-    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
 
     FLUENTD_FORWARD=()
@@ -104,21 +104,23 @@ update_current_fluentd() {
     # 256/8
     EXP_BUFFER_QUEUE_LIMIT=$( expr 256 / 8 )
 
-    os::log::debug "$( oc set env daemonset/logging-fluentd FILE_BUFFER_LIMIT=${MY_FILE_BUFFER_LIMIT} BUFFER_SIZE_LIMIT=${MY_BUFFER_SIZE_LIMIT} )"
+    oc set env daemonset/logging-fluentd FILE_BUFFER_LIMIT=${MY_FILE_BUFFER_LIMIT} BUFFER_SIZE_LIMIT=${MY_BUFFER_SIZE_LIMIT} 2>&1 | artifact_out
     # redeploy fluentd
     os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+    sudo rm -f /var/log/fluentd/fluentd.log
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     artifact_log update_current_fluentd $cnt
     fpod=$( get_running_pod fluentd ) || :
-    artifact_log update_current_fluentd $cnt "(oc logs $fpod)"
+    artifact_log update_current_fluentd $cnt
+    oc get pods 2>&1 | artifact_out || :
     if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod 2>&1 | artifact_out
+        get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.1.log
         id=$( expr $cnt - 1 ) || :
         artifact_log update_current_fluentd $cnt "(/etc/fluent/configs.d/user/secure-forward${id}.conf)"
         oc exec $fpod -- cat /etc/fluent/configs.d/user/secure-forward${id}.conf | artifact_out || :
-        artifact_log update_current_fluentd $cnt "(oc get pods)"
-        oc get pods 2>&1 | artifact_out
+        artifact_log update_current_fluentd $cnt
+        oc get pods 2>&1 | artifact_out || :
     fi
 
     # check set BUFFER_QUEUE_LIMIT
@@ -128,7 +130,7 @@ update_current_fluentd() {
     if [ -z "$REAL_BUFFER_QUEUE_LIMIT" ]; then
         os::log::error Environment variable BUFFER_QUEUE_LIMIT is empty.
     elif [ "$REAL_BUFFER_QUEUE_LIMIT" = "$EXP_BUFFER_QUEUE_LIMIT" ]; then
-        os::log::debug "Environment variable BUFFER_QUEUE_LIMIT is correctly set to $EXP_BUFFER_QUEUE_LIMIT."
+        artifact_log "Environment variable BUFFER_QUEUE_LIMIT is correctly set to $EXP_BUFFER_QUEUE_LIMIT."
     else
         os::log::error "Environment variable BUFFER_QUEUE_LIMIT is set to $REAL_BUFFER_QUEUE_LIMIT, which is suppose to be $EXP_BUFFER_QUEUE_LIMIT."
     fi
@@ -140,7 +142,7 @@ create_forwarding_fluentd() {
   while [ $id -lt $cnt ]; do
     # create forwarding configmap named "logging-forward-fluentd"
     oc create configmap logging-forward-fluentd${id} \
-       --from-file=fluent.conf=$OS_O_A_L_DIR/hack/templates/forward-fluent.conf
+       --from-file=fluent.conf=$OS_O_A_L_DIR/hack/templates/forward-fluent.conf 2>&1 | artifact_out
 
     # create a directory for file buffering so as not to conflict with fluentd
     if [ ! -d /var/lib/fluentd/forward${id} ] ; then
@@ -156,7 +158,7 @@ create_forwarding_fluentd() {
             -e '/image:/ a \
         ports: \
           - containerPort: 24284' | \
-        oc create -f -
+        oc create -f - 2>&1 | artifact_out
     else
       oc get daemonset/logging-fluentd -o yaml | \
         sed -e "s/logging-infra-fluentd:/logging-infra-forward-fluentd1:/" \
@@ -165,22 +167,23 @@ create_forwarding_fluentd() {
             -e '/image:/ a \
         ports: \
           - containerPort: 24284' | \
-        oc create -f -
+        oc create -f - 2>&1 | artifact_out
     fi
 
     # make it use a different hostpath than fluentd
     oc set volumes daemonset/logging-forward-fluentd${id} --add --overwrite \
        --name=filebufferstorage --type=hostPath \
-       --path=/var/lib/fluentd/forward${id} --mount-path=/var/lib/fluentd
-
+       --path=/var/lib/fluentd/forward${id} --mount-path=/var/lib/fluentd 2>&1 | artifact_out
+    # make it use a different log file than fluentd
+    oc set env daemonset/logging-forward-fluentd${id} LOGGING_FILE_PATH=/var/log/fluentd/fluentd.$id.log
     os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-forward-fluentd${id}=true )"
+    oc label node --all logging-infra-forward-fluentd${id}=true  2>&1 | artifact_out
 
     # wait for forward-fluentd to start
     os::cmd::try_until_text "oc get pods -l component=forward-fluentd${id}" "^logging-forward-fluentd${id}-.* Running "
     POD=$( oc get pods -l component=forward-fluentd${id} -o name )
-    artifact_log create_forwarding_fluentd $cnt "(oc logs $POD)"
-    oc logs $POD 2>&1 | artifact_out || :
+    artifact_log create_forwarding_fluentd $cnt
+    get_fluentd_pod_log $POD /var/log/fluentd/fluentd.$id.log > $ARTIFACT_DIR/fluentd-forward.$id.log
     id=$( expr $id + 1 )
   done
 }
@@ -204,37 +207,37 @@ cleanup() {
   cnt=${FORWARDCNT:-0}
   # dump the pod before we restart it
   if [ -n "${fpod:-}" ] ; then
-    artifact_log cleanup "(oc logs $fpod)"
-    oc logs $fpod 2>&1 | artifact_out || :
+    get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.cleanup.log
   fi
   oc get pods 2>&1 | artifact_out
   id=0
   while [ $id -lt $cnt ]; do
     POD=$( oc get pods -l component=forward-fluentd${id} -o name ) || :
-    artifact_log cleanup $cnt "(oc logs $POD)"
-    oc logs $POD 2>&1 | artifact_out || :
+    artifact_log cleanup $cnt
+    get_fluentd_pod_log $POD /var/log/fluentd/fluentd.$id.log > $ARTIFACT_DIR/$fpod.$id.cleanup.log
     id=$( expr $id + 1 )
   done
-  os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+  oc label node --all logging-infra-fluentd- 2>&1 | artifact_out || :
   os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
   if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
-    os::log::debug "$( oc replace --force -f $savecm )"
+    oc replace --force -f $savecm 2>&1 | artifact_out
   fi
   if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
-    os::log::debug "$( oc replace --force -f $saveds )"
+    oc replace --force -f $saveds 2>&1 | artifact_out
   fi
   id=0
   while [ $id -lt $cnt ]; do
     $mycmd fluentd-forward${id} test finished at $( date )
 
     # Clean up only if it's still around
-    os::log::debug "$( oc delete daemonset/logging-forward-fluentd${id} 2>&1 || : )"
-    os::log::debug "$( oc delete configmap/logging-forward-fluentd${id} 2>&1 || : )"
-    os::log::debug "$( oc label node --all logging-infra-forward-fluentd${id}- 2>&1 || : )"
+    oc delete daemonset/logging-forward-fluentd${id} 2>&1 | artifact_out
+    oc delete configmap/logging-forward-fluentd${id} 2>&1 | artifact_out
+    oc label node --all logging-infra-forward-fluentd${id}- 2>&1 | artifact_out
     id=$( expr $id + 1 )
   done
-  os::cmd::expect_success flush_fluentd_pos_files
-  os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+  flush_fluentd_pos_files 2>&1 | artifact_out
+  sudo rm -f /var/log/fluentd/fluentd.log
+  oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
   if [ $cnt -gt 1 ]; then
     cat $extra_artifacts
     # this will call declare_test_end, suite_end, etc.

--- a/test/json-parsing.sh
+++ b/test/json-parsing.sh
@@ -23,6 +23,10 @@ cleanup() {
         mycmd=os::log::error
     fi
     $mycmd json-parsing test finished at $( date )
+    fpod=$( get_running_pod fluentd )
+    if [ -n "${fpod:-}" ] ; then
+        get_fluentd_pod_log > $ARTIFACT_DIR/json-parsing-fluentd-pod.log
+    fi
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
     exit $return_code

--- a/test/mux-client-mode.sh
+++ b/test/mux-client-mode.sh
@@ -28,10 +28,10 @@ cleanup() {
     set +e
     # dump the pods before we restart them
     if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod > $ARTIFACT_DIR/mux-client-mode-fluentd-pod.log 2>&1
+        get_fluentd_pod_log $fpod > $ARTIFACT_DIR/mux-client-mode-fluentd-pod.log
     fi
     if [ -n "${muxpod:-}" ] ; then
-        oc logs $muxpod > $ARTIFACT_DIR/mux-client-mode-mux-pod.log 2>&1
+        get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux-client-mode-mux-pod.log 2>&1
     fi
     if [ -n "${saveds:-}" ] ; then
         if [ -f "${saveds:-}" ]; then
@@ -40,6 +40,7 @@ cleanup() {
         fi
     fi
     os::cmd::expect_success flush_fluentd_pos_files
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     # this will call declare_test_end, suite_end, etc.
@@ -66,6 +67,7 @@ os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status
 oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=minimal 2>&1 | artifact_out
 reset_fluentd_daemonset
 os::cmd::expect_success flush_fluentd_pos_files
+sudo rm -f /var/log/fluentd/fluentd.log
 oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
@@ -78,6 +80,7 @@ os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status
 oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=maximal 2>&1 | artifact_out
 reset_fluentd_daemonset
 os::cmd::expect_success flush_fluentd_pos_files
+sudo rm -f /var/log/fluentd/fluentd.log
 oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )

--- a/test/mux.sh
+++ b/test/mux.sh
@@ -156,17 +156,17 @@ update_current_fluentd() {
   reset_fluentd_daemonset
 
   os::cmd::expect_success flush_fluentd_pos_files
-  sudo rm -f /var/lib/fluentd/buffer*.log
-  os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+  sudo rm -f /var/lib/fluentd/buffer*.log /var/log/fluentd/fluentd.log
+  oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
   os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
   fpod=$( get_running_pod fluentd )
 }
 
 print_message() {
-    os::log::debug "$( curl_es $es_svc /project.${myproject}.*/_search?${myfield}:${mymessage} )"
-    os::log::debug "$( curl_es $es_svc /_cat/indices?v )"
+    curl_es $es_svc /project.${myproject}.*/_search?${myfield}:${mymessage} 2>&1 | artifact_out
+    curl_es $es_svc /_cat/indices?v 2>&1 | artifact_out
     if [ "$es_svc" != "$es_ops_svc" ] ; then
-        os::log::debug "$( curl_es $es_ops_svc /_cat/indices?v )"
+        curl_es $es_ops_svc /_cat/indices?v 2>&1 | artifact_out
     fi
 }
 
@@ -304,7 +304,7 @@ cleanup() {
             oc exec $fpod -- ls -alrtF /etc/fluent/configs.d/user 2>&1 | artifact_out
         fi
         if [ -n "${muxpod:-}" ]; then
-            oc logs $muxpod > $ARTIFACT_DIR/mux.mux.pod.log
+            get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux.mux.pod.log
             oc get configmap/logging-mux -o yaml > $ARTIFACT_DIR/mux.mux.configmap.yaml
             oc exec $muxpod -- ls -alrtF /etc/fluent/configs.d/openshift 2>&1 | artifact_out
             oc exec $muxpod -- ls -alrtF /etc/fluent/configs.d/user 2>&1 | artifact_out
@@ -317,15 +317,15 @@ cleanup() {
     curl_es $es_ops_svc /_cat/indices > $ARTIFACT_DIR/es-ops.indices.after 2>&1
     # dump the pod before we restart it
     if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod > $ARTIFACT_DIR/mux.$fpod.log 2>&1
+        get_fluentd_pod_log $fpod > $ARTIFACT_DIR/mux.$fpod.log
     fi
-    os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+    oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
     if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
-        os::log::debug "$( oc replace --force -f $savecm )"
+        oc replace --force -f $savecm 2>&1 | artifact_out
     fi
     if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
-        os::log::debug "$( oc replace --force -f $saveds )"
+        oc replace --force -f $saveds 2>&1 | artifact_out
     fi
     # delete indices created by this test
     for index in testproj default .orphaned openshift- kube-
@@ -333,8 +333,8 @@ cleanup() {
       curl_es $es_svc /project.$index* -XDELETE
     done
     os::cmd::expect_success flush_fluentd_pos_files
-    sudo rm -f /var/lib/fluentd/buffer*.log
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+    sudo rm -f /var/lib/fluentd/buffer*.log /var/log/fluentd/fluentd.log
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     oc delete project testproj 2>&1 | artifact_out
     os::cmd::try_until_failure "oc get project testproj" 2>&1 | artifact_out
@@ -421,16 +421,16 @@ if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" -o "$MUX_FILE_BUFFER_STORAGE_TYPE" 
             fi
         done
     done
-    os::log::debug "$( oc exec $muxpod -- ls -l /var/lib/fluentd )"
-    os::log::debug "$( oc logs $muxpod )"
+    oc exec $muxpod -- ls -l /var/lib/fluentd | artifact_out
+    get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux-before-$muxpod.log 2>&1
 
     # set ES_HOST and OPS_HOST to original
     reset_ES_HOST $ES_HOST_BAK $OPS_HOST_BAK
 
     # wait for the file buffer disappears once
     os::cmd::try_until_text "oc exec $muxpod -- ls -l /var/lib/fluentd" "total 0" $FLUENTD_WAIT_TIME
-    os::log::debug "$( oc exec $muxpod -- ls -l /var/lib/fluentd )"
-    os::log::debug "$( oc logs $muxpod )"
+    oc exec $muxpod -- ls -l /var/lib/fluentd | artifact_out
+    get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux-$muxpod.log 2>&1
 
     # kibana logs with kibana container/pod values
     if [ ${LOGGING_NS} = "logging" ] ; then

--- a/test/out_rawtcp.sh
+++ b/test/out_rawtcp.sh
@@ -12,7 +12,7 @@ os::test::junit::declare_suite_start "test/raw-tcp"
 
 update_current_fluentd() {
     # undeploy fluentd
-    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
 
     # update configmap logging-fluentd
@@ -36,23 +36,25 @@ update_current_fluentd() {
 
     # redeploy fluentd
     os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+    sudo rm -f /var/log/fluentd/fluentd.log
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     fpod=$( get_running_pod logstash )
     if [ -n "${fpod:-}" ] ; then
-      os::cmd::try_until_text "oc logs $fpod 2>&1" ".*kubernetes.*" $FLUENTD_WAIT_TIME
+      os::cmd::try_until_text "get_fluentd_pod_log $fpod 2>&1" ".*kubernetes.*" $FLUENTD_WAIT_TIME
     fi
     fpod=$( get_running_pod fluentd ) || :
-    artifact_log update_current_fluentd "(oc logs $fpod)"
+    artifact_log update_current_fluentd
+    get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.log
 }
 
 create_forwarding_logstash() {
   oc apply -f $OS_O_A_L_DIR/hack/templates/logstash.yml
   # wait for logstash to start
   os::cmd::try_until_text "oc get pods -l component=logstash" "^logstash-.* Running " 360000
-  POD=$( oc get pods -l component=logstash -o name )
-  artifact_log create_forwarding_logstash "(oc logs $POD)"
-  oc logs $POD 2>&1 | artifact_out || :
+  POD=$( get_running_pod logstash )
+  artifact_log create_forwarding_logstash
+  oc logs $POD > $ARTIFACT_DIR/logstash.$POD.log 2>&1
 }
 
 # save current fluentd daemonset
@@ -74,35 +76,39 @@ cleanup() {
 
   # dump the pod before we restart it
   if [ -n "${fpod:-}" ] ; then
-    artifact_log cleanup "(oc logs $fpod)"
-    oc logs $fpod 2>&1 | artifact_out || :
+    artifact_log cleanup
+    get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.cleanup.log 2>&1
   fi
   oc get pods 2>&1 | artifact_out
  
   POD=$( oc get pods -l component=fluentd -o name ) || :
-  artifact_log cleanup "(oc logs $POD)"
-  oc logs $POD 2>&1 | artifact_out || :
+  artifact_log cleanup
+  get_fluentd_pod_log $POD > $ARTIFACT_DIR/$POD.2.cleanup.log 2>&1
 
-  os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+  oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
   os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
   if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
-    os::log::debug "$( oc replace --force -f $savecm )"
+    oc replace --force -f $savecm 2>&1 | artifact_out
   fi
   if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
-    os::log::debug "$( oc replace --force -f $saveds )"
+    oc replace --force -f $saveds 2>&1 | artifact_out
   fi
 
   $mycmd raw-tcp test finished at $( date )
 
   # Clean up only if it's still around
-  os::log::debug "$( oc delete service/logstash 2>&1 || : )"
-  os::log::debug "$( oc delete deploymentconfig/logstash 2>&1 || : )"
+  oc delete service/logstash 2>&1 | artifact_out
+  oc delete deploymentconfig/logstash 2>&1 | artifact_out
 
-  os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+  sudo rm -f /var/log/fluentd/fluentd.log
+  os::cmd::expect_success flush_fluentd_pos_files
+  oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
   os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
   fpod=$( get_running_pod fluentd )
   os::cmd::expect_success wait_for_fluentd_to_catch_up
-  os::cmd::expect_success flush_fluentd_pos_files
+  # this will call declare_test_end, suite_end, etc.
+  os::test::junit::reconcile_output
+  exit $return_code
 }
 trap "cleanup" EXIT
 

--- a/test/zzz-correct-index-names.sh
+++ b/test/zzz-correct-index-names.sh
@@ -40,7 +40,7 @@ cleanup() {
   oc exec -c elasticsearch $es_ops_pod -- indices 2>&1 | artifact_out
 
   fpod=$( get_running_pod fluentd )
-  oc logs $fpod > $ARTIFACT_DIR/$fpod.log 2>&1
+  get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.log 2>&1
 
   oc exec $fpod -- env | sort > $ARTIFACT_DIR/env_vars.log 2>&1
   oc exec $fpod -- sh -c "find  /etc/fluent/configs.d -type f -exec cat {} \;" > $ARTIFACT_DIR/fluent_conf.log 2>&1


### PR DESCRIPTION
add utility functions get_fluentd_pod_log and get_mux_pod_log to
dump the pod logs from wherever they are
also added sudo rm -rf /var/log/fluentd/fluentd.log so that
tests which look for exact strings in the fluentd pod logs
will work correctly and not find older matches
fix incorrect usage of artifact_out