### PR TITLE
move fluent utils to /usr/local/bin

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -76,7 +76,7 @@ RUN if [ ! -d /etc/fluent/plugin ] ; then \
 
 ADD patch/logger/log.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 ADD patch/logger/supervisor.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
-COPY utils/** ${HOME}/utils/
+COPY utils/** /usr/local/bin/
 
 WORKDIR ${HOME}
 

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -65,7 +65,7 @@ ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
 ADD lib/filter_concat/lib/filter_concat.rb /etc/fluent/plugin/
 ADD patch/logger/log.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 ADD patch/logger/supervisor.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
-COPY utils/** ${HOME}/utils/
+COPY utils/** /usr/local/bin/
 ADD lib/parser_json_or_crio/lib/*.rb /etc/fluent/plugin/
 ADD patch/in_prometheus.rb ${GEM_HOME}/gems/fluent-plugin-prometheus-0.4.0/lib/fluent/plugin/
 


### PR DESCRIPTION
This PR moves the fluent utils to /usr/local/bin so they can be executed from `oc exec` without full path