### PR TITLE
Updating to create secret_dir if it doesnt exist for es cert generation

### DIFF
--- a/elasticsearch/utils/logging
+++ b/elasticsearch/utils/logging
@@ -185,6 +185,11 @@ copy_keys_to_secretdir() {
 
   if [ -d $provided_secret_dir ] ; then
     info "Copying certs from ${provided_secret_dir} to ${secret_dir}"
+
+    if [ ! -d $secret_dir ] ; then
+      mkdir $secret_dir
+    fi
+
     cp $provided_secret_dir/* $secret_dir/
   fi
 }


### PR DESCRIPTION
To resolve currently seeing the following with cluster-logging-operator generated secret:
```
[2018-10-03 20:29:01,311][INFO ][container.run            ] Copying certs from /etc/openshift/elasticsearch/secret to /etc/elasticsearch/secret
cp: target '/etc/elasticsearch/secret/' is not a directory
```