### PR TITLE
[release-3.11] Including fluent-plugin-concat to support cri-o multiline logs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,14 @@ matrix:
         cd fluentd/lib/filter_parse_json_field
       script:
         rake test
+    - name: fluentd - filter_concat test
+      env:
+        - FLUENTD_VERSION=0.12.0
+      language: ruby
+      rvm:
+      - 2.0
+      gemfile: fluentd/lib/filter_concat/Gemfile
+      before_script:
+        cd fluentd/lib/filter_concat
+      script:
+        rake test

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -55,6 +55,7 @@ ADD parser_viaq_docker_audit.rb viaq_docker_audit.rb /etc/fluent/plugin/
 ADD run.sh generate_syslog_config.rb ${HOME}/
 ADD lib/generate_throttle_configs/lib/*.rb ${HOME}/
 ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
+ADD lib/filter_concat/lib/filter_concat.rb /etc/fluent/plugin/
 ADD patch/in_prometheus.rb ${GEM_HOME}/gems/fluent-plugin-prometheus-0.4.0/lib/fluent/plugin/
 
 RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -48,8 +48,8 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
       fluentd:${FLUENTD_VERSION} \
      'fluent-plugin-elasticsearch:<2.0.0' \
      'fluent-plugin-kubernetes_metadata_filter:<2' \
-      'fluent-plugin-record-modifier:<1.0.0' \
-      'fluent-plugin-rewrite-tag-filter:<1.6.0' \
+     'fluent-plugin-record-modifier:<1.0.0' \
+     'fluent-plugin-rewrite-tag-filter:<1.6.0' \
       fluent-plugin-secure-forward \
      'fluent-plugin-systemd:<0.1.0' \
       fluent-plugin-viaq_data_model \
@@ -65,6 +65,7 @@ ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
 ADD patch/logger/log.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 ADD patch/logger/supervisor.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 COPY utils/** ${HOME}/utils/
+ADD lib/filter_concat/lib/filter_concat.rb /etc/fluent/plugin/
 ADD patch/in_prometheus.rb ${GEM_HOME}/gems/fluent-plugin-prometheus-0.4.0/lib/fluent/plugin/
 
 RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \

--- a/fluentd/lib/filter_concat/Gemfile
+++ b/fluentd/lib/filter_concat/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'codeclimate-test-reporter', :group => :test, :require => nil
+
+gemspec

--- a/fluentd/lib/filter_concat/Rakefile
+++ b/fluentd/lib/filter_concat/Rakefile
@@ -1,0 +1,11 @@
+#require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+    t.test_files = FileList['test/**/*_test.rb']
+    t.warning = false
+    #t.verbose = true
+end
+desc "Run tests"
+
+task default: :test

--- a/fluentd/lib/filter_concat/filter_concat.gemspec
+++ b/fluentd/lib/filter_concat/filter_concat.gemspec
@@ -1,0 +1,24 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+# can override for testing
+FLUENTD_VERSION = ENV['FLUENTD_VERSION'] || "0.12.0"
+
+Gem::Specification.new do |gem|
+  gem.name          = "filter_concat"
+  gem.version       = "0.0.1"
+  gem.authors       = ["Noriko Hosoi"]
+  gem.summary       = %q{Filter plugin to concatinate multiline logs}
+
+  gem.required_ruby_version = '>= 2.0.0'
+
+  gem.add_runtime_dependency "fluentd", "~> #{FLUENTD_VERSION}"
+
+  gem.add_development_dependency "bundler"
+  gem.add_development_dependency("fluentd", "~> #{FLUENTD_VERSION}")
+  gem.add_development_dependency("rake", ["~> 11.0"])
+  gem.add_development_dependency("rr", ["~> 1.0"])
+  gem.add_development_dependency("test-unit", ["~> 3.2"])
+  gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
+end

--- a/fluentd/lib/filter_concat/lib/filter_concat.rb
+++ b/fluentd/lib/filter_concat/lib/filter_concat.rb
@@ -1,0 +1,257 @@
+module Fluent
+  class ConcatFilter < Filter
+    Plugin.register_filter("concat", self)
+
+    desc "The key for part of multiline log"
+    config_param :key, :string, required: true
+    desc "The separator of lines"
+    config_param :separator, :string, default: "\n"
+    desc "The number of lines"
+    config_param :n_lines, :integer, default: nil
+    desc "The regexp to match beginning of multiline"
+    config_param :multiline_start_regexp, :string, default: nil
+    desc "The regexp to match ending of multiline"
+    config_param :multiline_end_regexp, :string, default: nil
+    desc "The key to determine which stream an event belongs to"
+    config_param :stream_identity_key, :string, default: nil
+    desc "The interval between data flushes, 0 means disable timeout"
+    config_param :flush_interval, :time, default: 60
+    desc "The label name to handle timeout"
+    config_param :timeout_label, :string, default: nil
+    desc "Use timestamp of first record when buffer is flushed"
+    config_param :use_first_timestamp, :bool, default: false
+    desc "The field name that is the reference to concatenate records"
+    config_param :partial_key, :string, default: nil
+    desc "The value stored in the field specified by partial_key that represent partial log"
+    config_param :partial_value, :string, default: nil
+    desc "If true, keep partial_key in concatenated records"
+    config_param :keep_partial_key, :bool, default: false
+
+    class TimeoutError < StandardError
+    end
+
+    def initialize
+      super
+
+      @buffer = Hash.new {|h, k| h[k] = [] }
+      @timeout_map = Hash.new {|h, k| h[k] = Fluent::Engine.now }
+    end
+
+    def configure(conf)
+      super
+
+      if @n_lines && @multiline_start_regexp
+        raise ConfigError, "n_lines and multiline_start_regexp are exclusive"
+      end
+      if @n_lines.nil? && @multiline_start_regexp.nil? && @partial_key.nil?
+        raise ConfigError, "Either partial_key or n_lines or multiline_start_regexp is required"
+      end
+      if @partial_key && @n_lines
+        raise Fluent::ConfigError, "partial_key and n_lines are exclusive"
+      end
+      if @partial_key && @partial_value.nil?
+        raise Fluent::ConfigError, "partial_value is required when partial_key is specified"
+      end
+
+      @mode = nil
+      case
+      when @n_lines
+        @mode = :line
+      when @partial_key
+        @mode = :partial
+      when @multiline_start_regexp
+        @mode = :regexp
+        @multiline_start_regexp = Regexp.compile(@multiline_start_regexp[1..-2])
+        if @multiline_end_regexp
+          @multiline_end_regexp = Regexp.compile(@multiline_end_regexp[1..-2])
+        end
+      end
+    end
+
+    def start
+      super
+      @loop = Coolio::Loop.new
+      timer = TimeoutTimer.new(1, method(:on_timer))
+      @loop.attach(timer)
+      @thread = Thread.new(@loop, &:run)
+    end
+
+    def shutdown
+      super
+      @loop.watchers.each {|w| w.detach if w.attached? }
+      @loop.stop
+      @thread.join
+      @finished = true
+    rescue => e
+      log.error "unexpected error", error: e, error_class: e.class
+      log.error_backtrace
+    end
+
+    def filter_stream(tag, es)
+      new_es = MultiEventStream.new
+      es.each do |time, record|
+        begin
+          flushed_es = process(tag, time, record)
+          unless flushed_es.empty?
+            flushed_es.each do |_time, new_record|
+              time = _time if @use_first_timestamp
+              merged_record = record.merge(new_record)
+              merged_record.delete(@partial_key) unless @keep_partial_key
+              new_es.add(time, merged_record)
+            end
+          end
+        rescue => e
+          router.emit_error_event(tag, time, record, e)
+        end
+      end
+      new_es
+    end
+
+    private
+
+    def on_timer
+      return if @flush_interval <= 0
+      return if @finished
+      flush_timeout_buffer
+    end
+
+    def process(tag, time, record)
+      new_es = MultiEventStream.new
+      if @stream_identity_key
+        stream_identity = "#{tag}:#{record[@stream_identity_key]}"
+      else
+        stream_identity = "#{tag}:default"
+      end
+      @timeout_map[stream_identity] = Fluent::Engine.now
+      case @mode
+      when :line
+        @buffer[stream_identity] << [tag, time, record]
+        if @buffer[stream_identity].size >= @n_lines
+          new_time, new_record = flush_buffer(stream_identity)
+          time = new_time if @use_first_timestamp
+          new_es.add(time, new_record)
+          return new_es
+        end
+      when :partial
+        @buffer[stream_identity] << [tag, time, record]
+        unless @partial_value == record[@partial_key]
+          new_time, new_record = flush_buffer(stream_identity)
+          time = new_time if @use_first_timestamp
+          new_record.delete(@partial_key)
+          new_es.add(time, new_record)
+          return new_es
+        end
+      when :regexp
+        case
+        when firstline?(record[@key])
+          if @buffer[stream_identity].empty?
+            @buffer[stream_identity] << [tag, time, record]
+            if lastline?(record[@key])
+              new_time, new_record = flush_buffer(stream_identity)
+              time = new_time if @use_first_timestamp
+              new_es.add(time, new_record)
+            end
+          else
+            new_time, new_record = flush_buffer(stream_identity, [tag, time, record])
+            time = new_time if @use_first_timestamp
+            new_es.add(time, new_record)
+            if lastline?(record[@key])
+              new_time, new_record = flush_buffer(stream_identity)
+              time = new_time if @use_first_timestamp
+              new_es.add(time, new_record)
+            end
+            return new_es
+          end
+        when lastline?(record[@key])
+          @buffer[stream_identity] << [tag, time, record]
+          new_time, new_record = flush_buffer(stream_identity)
+          time = new_time if @use_first_timestamp
+          new_es.add(time, new_record)
+          return new_es
+        else
+          if @buffer[stream_identity].empty?
+            new_es.add(time, record)
+            return new_es
+          else
+            # Continuation of the previous line
+            @buffer[stream_identity] << [tag, time, record]
+          end
+        end
+      end
+      new_es
+    end
+
+    def firstline?(text)
+      @multiline_start_regexp && !!@multiline_start_regexp.match(text)
+    end
+
+    def lastline?(text)
+      @multiline_end_regexp && !!@multiline_end_regexp.match(text)
+    end
+
+    def flush_buffer(stream_identity, new_element = nil)
+      lines = @buffer[stream_identity].map {|_tag, _time, record| record[@key] }
+      _tag, time, first_record = @buffer[stream_identity].first
+      new_record = {
+        @key => lines.join
+      }
+      @buffer[stream_identity] = []
+      @buffer[stream_identity] << new_element if new_element
+      [time, first_record.merge(new_record)]
+    end
+
+    def flush_timeout_buffer
+      now = Fluent::Engine.now
+      timeout_stream_identities = []
+      @timeout_map.each do |stream_identity, previous_timestamp|
+        next if @flush_interval > (now - previous_timestamp)
+        next if @buffer[stream_identity].empty?
+        time, flushed_record = flush_buffer(stream_identity)
+        timeout_stream_identities << stream_identity
+        tag = stream_identity.split(":").first
+        message = "Timeout flush: #{stream_identity}"
+        handle_timeout_error(tag, @use_first_timestamp ? time : now, flushed_record, message)
+        log.info(message)
+      end
+      @timeout_map.reject! do |stream_identity, _|
+        timeout_stream_identities.include?(stream_identity)
+      end
+    end
+
+    def flush_remaining_buffer
+      @buffer.each do |stream_identity, elements|
+        next if elements.empty?
+
+        lines = elements.map {|_tag, _time, record| record[@key] }
+        new_record = {
+          @key => lines.join
+        }
+        tag, time, record = elements.first
+        message = "Flush remaining buffer: #{stream_identity}"
+        handle_timeout_error(tag, time, record.merge(new_record), message)
+        log.info(message)
+      end
+      @buffer.clear
+    end
+
+    def handle_timeout_error(tag, time, record, message)
+      if @timeout_label
+        label = Engine.root_agent.find_label(@timeout_label)
+        label.event_router.emit(tag, time, record)
+      else
+        router.emit_error_event(tag, time, record, TimeoutError.new(message))
+      end
+    end
+
+    class TimeoutTimer < Coolio::TimerWatcher
+      def initialize(interval, callback)
+        super(interval, true)
+        @callback = callback
+      end
+
+      def on_timer
+        @callback.call
+      end
+    end
+  end
+end

--- a/fluentd/lib/filter_concat/test/filter_concat_test.rb
+++ b/fluentd/lib/filter_concat/test/filter_concat_test.rb
@@ -1,0 +1,79 @@
+require 'fluent/test'
+require 'test/unit/rr'
+require File.join(File.dirname(__FILE__), '..', 'lib/filter_concat') 
+
+class ConcatFilterTest < Test::Unit::TestCase
+  include Fluent
+
+  setup do
+    Fluent::Test.setup
+    @time = Fluent::Engine.now
+    log = Fluent::Engine.log
+    @timestamp = Time.now
+    @timestamp_str = @timestamp.utc.to_datetime.rfc3339(6)
+    stub(Time).now { @timestamp }
+  end
+
+  def create_driver(conf = '')
+    d = Test::FilterTestDriver.new(ConcatFilter, 'this.is.a.tag').configure(conf, true)
+    d.instance.log_level = 'DEBUG'
+    @dlog = d.instance.log
+    d
+  end
+
+  def emit_with_tag(tag, msg0={}, msg1={}, msg2={}, conf='')
+    d = create_driver(conf)
+    d.run {
+      d.emit_with_tag(tag, msg0, @time)
+      d.emit_with_tag(tag, msg1, @time) unless msg1 == {}
+      d.emit_with_tag(tag, msg2, @time) unless msg2 == {}
+    }.filtered.instance_variable_get(:@record_array)[0]
+  end  
+
+  sub_test_case 'configure' do
+    test 'check setting all params to non-default values' do
+      d = create_driver('
+        key log
+        partial_key logtag
+        partial_value P
+      ')
+      assert_equal(false, d.instance.keep_partial_key)
+      assert_equal('log', d.instance.key)
+      assert_equal('logtag', d.instance.partial_key)
+      assert_equal('P', d.instance.partial_value)
+    end
+  end
+
+  sub_test_case 'merge multilines' do
+    test 'full log message remains intact' do
+      message0 = 'This is a full log message.'
+      rec = emit_with_tag('tag', {'log'=>message0, 'logtag'=>'F'}, {}, {}, '
+        key log
+        partial_key logtag
+        partial_value P
+      ')
+      assert_equal({'log'=>message0}, rec)
+    end
+    test 'partial log + full log message' do
+      message0 = 'First_part'
+      message1 = 'Second_part'
+      rec = emit_with_tag('tag', {'log'=>message0, 'logtag'=>'P'}, {'log'=>message1, 'logtag'=>'F'}, {}, '
+        key log
+        partial_key logtag
+        partial_value P
+      ')
+      assert_equal({'log'=>message0+message1}, rec)
+    end
+    test 'partial log + partial log + full log message' do
+      message0 = 'First_part'
+      message1 = 'Second_part'
+      message2 = 'Thirrd_part'
+      rec = emit_with_tag('tag', {'log'=>message0, 'logtag'=>'P'}, {'log'=>message1, 'logtag'=>'P'}, {'log'=>message2, 'logtag'=>'F'}, '
+        key log
+        partial_key logtag
+        partial_value P
+      ')
+      assert_equal({'log'=>message0+message1+message2}, rec)
+    end
+  end
+end

--- a/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
+++ b/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
@@ -174,7 +174,20 @@ def create_default_docker(input_conf_file, excluded, log, options={})
   keep_time_key true
   read_from_head "#{options[:read_from_head] || 'true'}"
   exclude_path #{excluded}
+  @label @CONCAT
 </source>
+<label @CONCAT>
+  <filter kubernetes.**>
+    @type concat
+    key log
+    partial_key logtag
+    partial_value P
+  </filter>
+  <match kubernetes.**>
+    @type relabel
+    @label @INGRESS
+  </match>
+</label>
     CONF
   }
     log.debug "Created default docker input config file"

--- a/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
+++ b/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
@@ -34,7 +34,20 @@ describe 'generate_throttle_configs' do
   keep_time_key true
   read_from_head "true"
   exclude_path []
+  @label @CONCAT
 </source>
+<label @CONCAT>
+  <filter kubernetes.**>
+    @type concat
+    key log
+    partial_key logtag
+    partial_value P
+  </filter>
+  <match kubernetes.**>
+    @type relabel
+    @label @INGRESS
+  </match>
+</label>
 '
     end
 
@@ -42,7 +55,7 @@ describe 'generate_throttle_configs' do
         it 'should use the specified path and position' do
           options = {
             :cont_logs_path => '/tmp/foo/*.logs',
-            :cont_pos_file => '/tmp/foo/*.logs.pos',
+            :cont_pos_file => '/tmp/foo/test.logs.pos',
             :read_from_head => "false"
           }
 
@@ -53,38 +66,31 @@ describe 'generate_throttle_configs' do
   @id docker-input
   @label @INGRESS
   path "/tmp/foo/*.logs"
-  pos_file "/tmp/foo/*.logs.pos"
+  pos_file "/tmp/foo/test.logs.pos"
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
   format json
   keep_time_key true
   read_from_head "false"
   exclude_path []
+  @label @CONCAT
 </source>
+<label @CONCAT>
+  <filter kubernetes.**>
+    @type concat
+    key log
+    partial_key logtag
+    partial_value P
+  </filter>
+  <match kubernetes.**>
+    @type relabel
+    @label @INGRESS
+  </match>
+</label>
 '
         end
     end
 
-    describe 'and is configured to use CRIO' do
-        it 'should use the CRIO log format' do
-      generate_throttle_configs(@input_conf, @throttle_conf, @log, :use_crio=>'true')
-      act = File.read(@input_conf)
-      act.must_equal'<source>
-  @type tail
-  @id docker-input
-  @label @INGRESS
-  path "/var/log/containers/*.log"
-  pos_file "/var/log/es-containers.log.pos"
-  time_format %Y-%m-%dT%H:%M:%S.%N%:z
-  tag kubernetes.*
-  format /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
-  keep_time_key true
-  read_from_head "true"
-  exclude_path []
-</source>
-'
-        end
-    end
   end
 
   describe 'when throttle config exists and is not empty' do
@@ -135,7 +141,20 @@ secondproject:
   keep_time_key true
   read_from_head \"true\"
   exclude_path [\"#{cont_log_dir}/*_firstproject_*.log\", \"#{cont_log_dir}/*_secondproject_*.log\"]
+  @label @CONCAT
 </source>
+<label @CONCAT>
+  <filter kubernetes.**>
+    @type concat
+    key log
+    partial_key logtag
+    partial_value P
+  </filter>
+  <match kubernetes.**>
+    @type relabel
+    @label @INGRESS
+  </match>
+</label>
 "
       {"firstproject"=>100, "secondproject"=>200}.each do |project,limit|
         throttle_file = "#{ENV['THROTTLE_PREFIX']}#{project}-#{Date.today.strftime('%Y%m%d')}.conf"


### PR DESCRIPTION
Backporting the partial code in fluent-plugin-concat v2.3.0 to v1.0.0.
Note: removing @seperator = '\n' from join.  It adds '\n' at the end of
      the partial message.  The original code has the issue.
  - @key => lines.join(@separator)
  + @key => lines.join

Added missing keep_partial_key code.
Moved filter_concat.rb to lib/filter_concat and added a unit test.
Fixed broken unit test in test/generate_throttle_configs_test.rb.
Enabling filter_concat unit test.
Capturing exception in shutdown.

(cherry picked from commit 30efccb7a7bebbdb09193248934186f54c4294f2)