### PR TITLE
allow setting flush_at_shutdown for migration

### DIFF
--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -9,6 +9,7 @@
   buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
   buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
   max_retry_wait "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
+  flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
   disable_retry_limit true
   buffer_type file
   buffer_path '/var/lib/fluentd/buffer-mux-client'

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -32,6 +32,7 @@
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
       buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
+      flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 
       write_operation 'create'
 

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -32,6 +32,7 @@
       buffer_queue_limit "#{ENV['OPS_BUFFER_QUEUE_LIMIT'] || ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
       buffer_chunk_limit "#{ENV['OPS_BUFFER_SIZE_LIMIT'] || ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
       buffer_queue_full_action "#{ENV['OPS_BUFFER_QUEUE_FULL_ACTION'] || ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
+      flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 
       write_operation 'create'
 

--- a/fluentd/configs.d/openshift/output-es-ops-retry.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-retry.conf
@@ -30,6 +30,7 @@
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
       buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
+      flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 
       write_operation 'create'
 

--- a/fluentd/configs.d/openshift/output-es-retry.conf
+++ b/fluentd/configs.d/openshift/output-es-retry.conf
@@ -30,6 +30,7 @@
       buffer_queue_limit "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
       buffer_chunk_limit "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
       buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
+      flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 
       write_operation 'create'
 

--- a/fluentd/configs.d/user/secure-forward.conf
+++ b/fluentd/configs.d/user/secure-forward.conf
@@ -19,6 +19,7 @@
 #   # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
 #   # buffer to the remote - default is 'exception' because in_tail handles that case
 #   buffer_queue_full_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
+#   flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 
 #   <server>
 #     host server.fqdn.example.com  # or IP


### PR DESCRIPTION
If the env. var. `FLUSH_AT_SHUTDOWN` is set to `"true"`, then when
fluentd is shutting down, it will attempt to flush all of its
file buffer records to Elasticsearch or forward destination.
This is needed in data migration or fluentd upgrade scenarios where
we do not want to or cannot convert the buffers to the newer version.

Steps:
1) oc set env ds/logging-fluentd FLUSH_AT_SHUTDOWN=true
2) oc label node -l logging-infra-fluentd=true --overwrite \
    logging-infra-fluentd=false
3) confirm that /var/lib/fluentd is empty - it may take a few
   minutes
4) oc set env ds/logging-fluentd FLUSH_AT_SHUTDOWN-
5) oc label node -l logging-infra-fluentd=false --overwrite \
    logging-infra-fluentd=true