### PR TITLE
add get_all_logging_pod_logs function

### DIFF
--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -109,6 +109,10 @@ monitor_es_bulk_stats() {
         espod=$( get_es_pod es 2> /dev/null ) || :
     done
     es_ver=$( get_es_major_ver ) || :
+    while [ -z "${es_ver}" ] ; do
+        es_ver=$( get_es_major_ver ) || :
+        sleep 1
+    done
     bulk_url=$( get_bulk_thread_pool_url $es_ver "v" c r a q s qs )
     while true ; do
         local essvc=$( get_es_svc es 2> /dev/null ) || :

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -484,7 +484,10 @@ get_fluentd_pod_log() {
     local pod=${1:-$( get_running_pod fluentd )}
     local logfile=${2:-/var/log/fluentd/fluentd.log}
     oc logs $pod 2>&1
-    if sudo test -f $logfile ; then
+    if oc exec $pod -- logs 2>&1 ; then
+        : # done
+    elif sudo test -f $logfile ; then
+        # can't read from the pod directly - see if we can get the log file
         sudo cat $logfile
     fi
 }
@@ -494,4 +497,26 @@ get_mux_pod_log() {
     local logfile=${2:-/var/log/fluentd/fluentd.log}
     oc logs $pod 2>&1
     oc exec $pod -- cat $logfile 2> /dev/null || :
+}
+
+# writes all pod logs to the given outdir or $ARTIFACT_DIR in the form
+# pod_name.container_name.log
+# it will get both the oc logs output and any log files produced by
+# the pod
+get_all_logging_pod_logs() {
+  local outdir=${1:-$ARTIFACT_DIR}
+  local p
+  local container
+  for p in $(oc get pods -n ${LOGGING_NS} -o jsonpath='{.items[*].metadata.name}') ; do
+    for container in $(oc get po $p -o jsonpath='{.spec.containers[*].name}') ; do
+      case "$p" in
+        logging-fluentd-*) get_fluentd_pod_log $p > $ARTIFACT_DIR/$p.$container.log 2>&1 ;;
+        logging-mux-*) get_mux_pod_log $p > $ARTIFACT_DIR/$p.$container.log 2>&1 ;;
+        logging-es-*) oc logs -n ${LOGGING_NS} -c $container $p > $ARTIFACT_DIR/$p.$container.log 2>&1
+                      oc exec -c elasticsearch -n ${LOGGING_NS} $p -- logs >> $ARTIFACT_DIR/$p.$container.log 2>&1
+                      ;;
+	    *) oc logs -n ${LOGGING_NS} -c $container $p > $ARTIFACT_DIR/$p.$container.log 2>&1 ;;
+      esac
+	done
+  done
 }

--- a/test/cluster/rollout.sh
+++ b/test/cluster/rollout.sh
@@ -23,19 +23,18 @@ cleanup() {
   local return_code="$?"
   set +e
   for r in dc ds cronjob ; do
-    oc describe -n ${LOGGING_NS} $r > $ARTIFACT_DIR/$r.describe 2>&1
+    for it in $( oc get -n ${LOGGING_NS} $r -o name ) ; do
+      oc describe -n ${LOGGING_NS} $it > $ARTIFACT_DIR/$it.describe 2>&1
+    done
   done
 
-  for p in $(oc get pods -n ${LOGGING_NS} -l component=es -o jsonpath={.items[*].metadata.name}) ; do
-    oc logs -c elasticsearch -n ${LOGGING_NS} $p || :  > $ARTIFACT_DIR/$p.rollout.stdout.logs 2>&1
-    oc logs -c proxy -n ${LOGGING_NS} $p > $ARTIFACT_DIR/$p.proxy.stdout.logs 2>&1 || :
-    oc exec -c elasticsearch -n ${LOGGING_NS} $p -- logs || :  > $ARTIFACT_DIR/$p.rollout.file.logs 2>&1
-  done
-  for p in $(oc get pods -n ${LOGGING_NS} -l component!=es -o jsonpath={.items[*].metadata.name}) ; do
-    oc logs -n ${LOGGING_NS} $p || :  > $ARTIFACT_DIR/$p.stdout.logs 2>&1
-  done
+  get_all_logging_pod_logs
   oc get -n ${LOGGING_NS} --all 2>&1 | artifact_out
-  
+  sudo docker images|grep logging 2>&1 | artifact_out
+  sudo docker images|grep oauth 2>&1 | artifact_out
+  sudo docker images|grep eventrouter 2>&1 | artifact_out
+  oc get events > $ARTIFACT_DIR/events.txt 2>&1
+
   os::test::junit::reconcile_output
   exit $return_code
 }


### PR DESCRIPTION
Add a function get_all_logging_pod_logs so tests can dump all
of the logging pod logs. This function takes into account
the various logs commands and log files that different pods
have.