### PR TITLE
[release-3.10] look for /var/log/fluentd/fluentd.log for pod logs

### DIFF
--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -442,3 +442,20 @@ get_bulk_thread_pool_url() {
     done
     echo $url
 }
+
+# fluentd may have pod logs and logs in the file
+get_fluentd_pod_log() {
+    local pod=${1:-$( get_running_pod fluentd )}
+    local logfile=${2:-/var/log/fluentd/fluentd.log}
+    oc logs $pod 2>&1
+    if sudo test -f $logfile ; then
+        sudo cat $logfile
+    fi
+}
+
+get_mux_pod_log() {
+    local pod=${1:-$( get_running_pod mux )}
+    local logfile=${2:-/var/log/fluentd/fluentd.log}
+    oc logs $pod 2>&1
+    oc exec $pod -- cat $logfile 2> /dev/null || :
+}

--- a/test/docker_audit.sh
+++ b/test/docker_audit.sh
@@ -82,6 +82,7 @@ os::log::info "ops diff before:  $ops_logs_before"
 os::log::info "proj diff before: $logs_before"
 
 os::cmd::expect_success flush_fluentd_pos_files
+sudo rm -f /var/log/fluentd/fluentd.log
 os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
@@ -92,7 +93,7 @@ docker run --rm centos:7 echo "running test container"
 
 if ! os::cmd::try_until_success "logs_count_is_ge $esopssvc '/.operations.*/' 4 $timestamp" $((second * 60)) ; then
     sudo grep VIRT_CONTROL /var/log/audit/audit.log | tail -40 > $ARTIFACT_DIR/docker_audit_audit.log
-    oc logs $fpod > $ARTIFACT_DIR/docker_audit_fluentd.log 2>&1
+    get_fluentd_pod_log $fpod > $ARTIFACT_DIR/docker_audit_fluentd.log
     ops_logs_after=$( get_logs_count $esopssvc '/.operations.*/' )
     logs_after=$( get_logs_count $essvc '/project.*/' )
     get_logs_source $esopssvc '/.operations.*/' > $ARTIFACT_DIR/docker_audit_ops.json 2>&1

--- a/test/json-parsing.sh
+++ b/test/json-parsing.sh
@@ -23,6 +23,10 @@ cleanup() {
         mycmd=os::log::error
     fi
     $mycmd json-parsing test finished at $( date )
+    fpod=$( get_running_pod fluentd )
+    if [ -n "${fpod:-}" ] ; then
+        get_fluentd_pod_log > $ARTIFACT_DIR/json-parsing-fluentd-pod.log
+    fi
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
     exit $return_code

--- a/test/mux-client-mode.sh
+++ b/test/mux-client-mode.sh
@@ -28,10 +28,10 @@ cleanup() {
     set +e
     # dump the pods before we restart them
     if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod > $ARTIFACT_DIR/mux-client-mode-fluentd-pod.log 2>&1
+        get_fluentd_pod_log $fpod > $ARTIFACT_DIR/mux-client-mode-fluentd-pod.log
     fi
     if [ -n "${muxpod:-}" ] ; then
-        oc logs $muxpod > $ARTIFACT_DIR/mux-client-mode-mux-pod.log 2>&1
+        get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux-client-mode-mux-pod.log 2>&1
     fi
     if [ -n "${saveds:-}" ] ; then
         if [ -f "${saveds:-}" ]; then
@@ -40,6 +40,7 @@ cleanup() {
         fi
     fi
     os::cmd::expect_success flush_fluentd_pos_files
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     # this will call declare_test_end, suite_end, etc.
@@ -66,6 +67,7 @@ os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status
 oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=minimal 2>&1 | artifact_out
 reset_fluentd_daemonset
 os::cmd::expect_success flush_fluentd_pos_files
+sudo rm -f /var/log/fluentd/fluentd.log
 oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
@@ -78,6 +80,7 @@ os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status
 oc set env daemonset/logging-fluentd MUX_CLIENT_MODE=maximal 2>&1 | artifact_out
 reset_fluentd_daemonset
 os::cmd::expect_success flush_fluentd_pos_files
+sudo rm -f /var/log/fluentd/fluentd.log
 oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )

--- a/test/mux.sh
+++ b/test/mux.sh
@@ -156,17 +156,17 @@ update_current_fluentd() {
   reset_fluentd_daemonset
 
   os::cmd::expect_success flush_fluentd_pos_files
-  sudo rm -f /var/lib/fluentd/buffer*.log
-  os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+  sudo rm -f /var/lib/fluentd/buffer*.log /var/log/fluentd/fluentd.log
+  oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
   os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
   fpod=$( get_running_pod fluentd )
 }
 
 print_message() {
-    os::log::debug "$( curl_es $es_svc /project.${myproject}.*/_search?${myfield}:${mymessage} )"
-    os::log::debug "$( curl_es $es_svc /_cat/indices?v )"
+    curl_es $es_svc /project.${myproject}.*/_search?${myfield}:${mymessage} 2>&1 | artifact_out
+    curl_es $es_svc /_cat/indices?v 2>&1 | artifact_out
     if [ "$es_svc" != "$es_ops_svc" ] ; then
-        os::log::debug "$( curl_es $es_ops_svc /_cat/indices?v )"
+        curl_es $es_ops_svc /_cat/indices?v 2>&1 | artifact_out
     fi
 }
 
@@ -304,7 +304,7 @@ cleanup() {
             oc exec $fpod -- ls -alrtF /etc/fluent/configs.d/user 2>&1 | artifact_out
         fi
         if [ -n "${muxpod:-}" ]; then
-            oc logs $muxpod > $ARTIFACT_DIR/mux.mux.pod.log
+            get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux.mux.pod.log
             oc get configmap/logging-mux -o yaml > $ARTIFACT_DIR/mux.mux.configmap.yaml
             oc exec $muxpod -- ls -alrtF /etc/fluent/configs.d/openshift 2>&1 | artifact_out
             oc exec $muxpod -- ls -alrtF /etc/fluent/configs.d/user 2>&1 | artifact_out
@@ -317,23 +317,23 @@ cleanup() {
     curl_es $es_ops_svc /_cat/indices > $ARTIFACT_DIR/es-ops.indices.after 2>&1
     # dump the pod before we restart it
     if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod > $ARTIFACT_DIR/mux.$fpod.log 2>&1
+        get_fluentd_pod_log $fpod > $ARTIFACT_DIR/mux.$fpod.log
     fi
-    os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+    oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
     if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
-        os::log::debug "$( oc replace --force -f $savecm )"
+        oc replace --force -f $savecm 2>&1 | artifact_out
     fi
     if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
-        os::log::debug "$( oc replace --force -f $saveds )"
+        oc replace --force -f $saveds 2>&1 | artifact_out
     fi
     # delete indices created by this test
     curl_es $es_svc /project.testproj.* -XDELETE
     curl_es $es_svc /project.default.* -XDELETE
     curl_es $es_svc /project..orphaned.* -XDELETE
     os::cmd::expect_success flush_fluentd_pos_files
-    sudo rm -f /var/lib/fluentd/buffer*.log
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+    sudo rm -f /var/lib/fluentd/buffer*.log /var/log/fluentd/fluentd.log
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     oc delete project testproj 2>&1 | artifact_out
     os::cmd::try_until_failure "oc get project testproj" 2>&1 | artifact_out
@@ -420,16 +420,16 @@ if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" -o "$MUX_FILE_BUFFER_STORAGE_TYPE" 
             fi
         done
     done
-    os::log::debug "$( oc exec $muxpod -- ls -l /var/lib/fluentd )"
-    os::log::debug "$( oc logs $muxpod )"
+    oc exec $muxpod -- ls -l /var/lib/fluentd | artifact_out
+    get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux-before-$muxpod.log 2>&1
 
     # set ES_HOST and OPS_HOST to original
     reset_ES_HOST $ES_HOST_BAK $OPS_HOST_BAK
 
     # wait for the file buffer disappears once
     os::cmd::try_until_text "oc exec $muxpod -- ls -l /var/lib/fluentd" "total 0" $FLUENTD_WAIT_TIME
-    os::log::debug "$( oc exec $muxpod -- ls -l /var/lib/fluentd )"
-    os::log::debug "$( oc logs $muxpod )"
+    oc exec $muxpod -- ls -l /var/lib/fluentd | artifact_out
+    get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux-$muxpod.log 2>&1
 
     # kibana logs with kibana container/pod values
     if [ ${LOGGING_NS} = "logging" ] ; then

--- a/test/out_rawtcp.sh
+++ b/test/out_rawtcp.sh
@@ -12,7 +12,7 @@ os::test::junit::declare_suite_start "test/raw-tcp"
 
 update_current_fluentd() {
     # undeploy fluentd
-    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
 
     # update configmap logging-fluentd
@@ -36,23 +36,25 @@ update_current_fluentd() {
 
     # redeploy fluentd
     os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+    sudo rm -f /var/log/fluentd/fluentd.log
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     fpod=$( get_running_pod logstash )
     if [ -n "${fpod:-}" ] ; then
-      os::cmd::try_until_text "oc logs $fpod 2>&1" ".*kubernetes.*" $FLUENTD_WAIT_TIME
+      os::cmd::try_until_text "get_fluentd_pod_log $fpod 2>&1" ".*kubernetes.*" $FLUENTD_WAIT_TIME
     fi
     fpod=$( get_running_pod fluentd ) || :
-    artifact_log update_current_fluentd "(oc logs $fpod)"
+    artifact_log update_current_fluentd
+    get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.log
 }
 
 create_forwarding_logstash() {
   oc apply -f $OS_O_A_L_DIR/hack/templates/logstash.yml
   # wait for logstash to start
   os::cmd::try_until_text "oc get pods -l component=logstash" "^logstash-.* Running " 360000
-  POD=$( oc get pods -l component=logstash -o name )
-  artifact_log create_forwarding_logstash "(oc logs $POD)"
-  oc logs $POD 2>&1 | artifact_out || :
+  POD=$( get_running_pod logstash )
+  artifact_log create_forwarding_logstash
+  oc logs $POD > $ARTIFACT_DIR/logstash.$POD.log 2>&1
 }
 
 # save current fluentd daemonset
@@ -74,35 +76,39 @@ cleanup() {
 
   # dump the pod before we restart it
   if [ -n "${fpod:-}" ] ; then
-    artifact_log cleanup "(oc logs $fpod)"
-    oc logs $fpod 2>&1 | artifact_out || :
+    artifact_log cleanup
+    get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.cleanup.log 2>&1
   fi
   oc get pods 2>&1 | artifact_out
  
   POD=$( oc get pods -l component=fluentd -o name ) || :
-  artifact_log cleanup "(oc logs $POD)"
-  oc logs $POD 2>&1 | artifact_out || :
+  artifact_log cleanup
+  get_fluentd_pod_log $POD > $ARTIFACT_DIR/$POD.2.cleanup.log 2>&1
 
-  os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+  oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
   os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
   if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
-    os::log::debug "$( oc replace --force -f $savecm )"
+    oc replace --force -f $savecm 2>&1 | artifact_out
   fi
   if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
-    os::log::debug "$( oc replace --force -f $saveds )"
+    oc replace --force -f $saveds 2>&1 | artifact_out
   fi
 
   $mycmd raw-tcp test finished at $( date )
 
   # Clean up only if it's still around
-  os::log::debug "$( oc delete service/logstash 2>&1 || : )"
-  os::log::debug "$( oc delete deploymentconfig/logstash 2>&1 || : )"
+  oc delete service/logstash 2>&1 | artifact_out
+  oc delete deploymentconfig/logstash 2>&1 | artifact_out
 
-  os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+  sudo rm -f /var/log/fluentd/fluentd.log
+  os::cmd::expect_success flush_fluentd_pos_files
+  oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
   os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
   fpod=$( get_running_pod fluentd )
   os::cmd::expect_success wait_for_fluentd_to_catch_up
-  os::cmd::expect_success flush_fluentd_pos_files
+  # this will call declare_test_end, suite_end, etc.
+  os::test::junit::reconcile_output
+  exit $return_code
 }
 trap "cleanup" EXIT
 

--- a/test/remote-syslog.sh
+++ b/test/remote-syslog.sh
@@ -26,6 +26,7 @@ if [ -n "${mpod:-}" ]; then
     oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" '^0$' $FLUENTD_WAIT_TIME
     oc set env ds/logging-fluentd MUX_CLIENT_MODE=maximal 2>&1 | artifact_out
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     fluentdtype="mux"
@@ -48,10 +49,10 @@ cleanup() {
         artifact_log "oc get pods"
         oc get pods 2>&1 | artifact_out
         fpod=$( oc get pods --selector component=fluentd -o name | awk -F'/' '{print $2}' )
-        oc logs $fpod > $ARTIFACT_DIR/remote-syslog-${fpod}.log 2>&1
+        get_fluentd_pod_log $fpod > $ARTIFACT_DIR/remote-syslog-${fpod}.log
         mpod=$( oc get pods --selector component=mux -o name | awk -F'/' '{print $2}' )
         if [ -n "${mpod}" ] ; then
-            oc logs $mpod > $ARTIFACT_DIR/remote-syslog-$mpod.log 2>&1
+            get_mux_pod_log $mpod > $ARTIFACT_DIR/remote-syslog-$mpod.log 2>&1
         fi
         oc get events > $ARTIFACT_DIR/remote-syslog-events.txt 2>&1
         sudo journalctl | grep fluentd | tail -n 30 > $ARTIFACT_DIR/remote-syslog-journal-fluentd.log 2>&1
@@ -71,6 +72,7 @@ cleanup() {
     if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
         oc replace --force -f $saveds 2>&1 | artifact_out
     fi
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 
@@ -115,6 +117,7 @@ if [ -n "$my_remote_syslog_host" ]; then
         oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
         os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" '^0$' $FLUENTD_WAIT_TIME
         oc set env ds/logging-fluentd USE_REMOTE_SYSLOG=true 2>&1 | artifact_out
+        sudo rm -f /var/log/fluentd/fluentd.log
         oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
         os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
         mypod=$( get_running_pod fluentd )
@@ -151,6 +154,7 @@ if [ "$fluentdtype" = "fluentd" ] ; then
 
     # choosing an unrealistic REMOTE_SYSLOG_HOST
     oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=111.222.111.222 2>&1 | artifact_out
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 
@@ -185,6 +189,7 @@ if [ "$fluentdtype" = "fluentd" ] ; then
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" '^0$' $FLUENTD_WAIT_TIME
 
     oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST- 2>&1 | artifact_out
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 
@@ -211,6 +216,7 @@ if [ "$fluentdtype" = "fluentd" ] ; then
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" '^0$' $FLUENTD_WAIT_TIME
 
     oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_HOST2=127.0.0.1 2>&1 | artifact_out
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 
@@ -237,10 +243,12 @@ if [ "$fluentdtype" = "fluentd" ] ; then
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" '^0$' $FLUENTD_WAIT_TIME
 
     oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=message REMOTE_SYSLOG_HOST2- 2>&1 | artifact_out
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 
     mypod=$( get_running_pod fluentd )
+    mycmd=get_fluentd_pod_log
 else
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
     oc scale --replicas=0 dc logging-mux 2>&1 | artifact_out
@@ -250,10 +258,11 @@ else
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
 
     mypod=$( get_running_pod mux )
+    mycmd="oc logs"
 fi
 os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
 os::cmd::expect_success "oc exec $mypod grep 'tag_key message' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success_and_not_text "oc logs $mypod" "nil:NilClass"
+os::cmd::expect_success_and_not_text "$mycmd $mypod" "nil:NilClass"
 
 artifact_log $title $mypod
 
@@ -266,10 +275,12 @@ if [ "$fluentdtype" = "fluentd" ] ; then
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" '^0$' $FLUENTD_WAIT_TIME
 
     oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=127.0.0.1 REMOTE_SYSLOG_TAG_KEY=bogus 2>&1 | artifact_out
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 
     mypod=$( get_running_pod fluentd )
+    mycmd=get_fluentd_pod_log
 else
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
     oc scale --replicas=0 dc logging-mux 2>&1 | artifact_out
@@ -279,10 +290,11 @@ else
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
 
     mypod=$( get_running_pod mux )
+    mycmd="oc logs"
 fi
 os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
 os::cmd::expect_success "oc exec $mypod grep 'tag_key bogus' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success_and_not_text "oc logs $mypod" "nil:NilClass"
+os::cmd::expect_success_and_not_text "$mycmd $mypod" "nil:NilClass"
 artifact_log $title $mypod
 
 
@@ -298,8 +310,8 @@ sudo iptables -L 2>&1 | artifact_out || :
 #   $ModLoad imtcp
 #   $InputTCPServerRun 514 -> 601
 rsyslogconfbakup=$( mktemp )
-cat /etc/rsyslog.conf > $ARTIFACT_DIR/remote-syslog-rsyslog.conf.orig
-cp /etc/rsyslog.conf $rsyslogconfbakup
+sudo cat /etc/rsyslog.conf > $ARTIFACT_DIR/remote-syslog-rsyslog.conf.orig
+sudo cp /etc/rsyslog.conf $rsyslogconfbakup
 sudo sed -i -e 's/^#*\(\$ModLoad imtcp\)/\1/' -e "s/^#*\(\$InputTCPServerRun\) 514/\1 ${ALTPORT}/" \
          -e 's/\(\$ModLoad imuxsock\)/#\1/' -e 's/\(\$ModLoad imjournal\)/#\1/' -e 's/\(\$OmitLocalLogging\)/#\1/' \
          -e 's/\(\$IMJournalStateFile imjournal.state\)/#\1/' -e 's/\(\$ActionFileEnableSync\)/#\1/' \
@@ -308,24 +320,24 @@ sudo sed -i -e 's/^#*\(\$ModLoad imtcp\)/\1/' -e "s/^#*\(\$InputTCPServerRun\) 5
          /etc/rsyslog.conf
 sudo ls -l /etc/rsyslog.d | artifact_out || :
 rsyslogconfbakup2=/tmp/listen.conf
-if [ -f /etc/rsyslog.d/listen.conf ]; then
+if sudo test -f /etc/rsyslog.d/listen.conf ; then
     sudo mv /etc/rsyslog.d/listen.conf $rsyslogconfbakup2
 fi
-cat /etc/rsyslog.conf > $ARTIFACT_DIR/remote-syslog-rsyslog.conf.modified
+sudo cat /etc/rsyslog.conf > $ARTIFACT_DIR/remote-syslog-rsyslog.conf.modified
 
 # date in journalctl -S format
 teststart=$( date "+%Y-%m-%d %H:%M:%S" )
 artifact_log Before restarting rsyslog
-sudo service rsyslog status 2>&1 | artifact_out || :
-os::cmd::expect_success "sudo service rsyslog stop"
+sudo systemctl status rsyslog 2>&1 | artifact_out || :
+os::cmd::expect_success "sudo systemctl stop rsyslog"
 sudo mv /var/log/messages /var/log/messages."$( date +%Y%m%d-%H%M%S )" || :
 sudo touch /var/log/messages || :
 sudo chmod 600 /var/log/messages || :
 sudo semanage fcontext -a -t var_log_t -s system_u /var/log/messages 2>&1 | artifact_out || :
 sudo restorecon -vF /var/log/messages 2>&1 | artifact_out || :
-os::cmd::expect_success "sudo service rsyslog start"
+os::cmd::expect_success "sudo systemctl start rsyslog"
 artifact_log After restarted rsyslog
-sudo service rsyslog status 2>&1 | artifact_out || :
+sudo systemctl status rsyslog 2>&1 | artifact_out || :
 sudo cat /etc/systemd/journald.conf > $ARTIFACT_DIR/remote-syslog-journald.conf
 
 myhost=$( hostname )
@@ -341,10 +353,12 @@ if [ "$fluentdtype" = "fluentd" ] ; then
         REMOTE_SYSLOG_TAG_KEY='ident,systemd.u.SYSLOG_IDENTIFIER,local1.err' 2>&1 | artifact_out
     sudo rm -f /var/log/journal.pos
     sudo rm -rf /var/lib/fluentd/*
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 
     mypod=$( get_running_pod fluentd )
+    mycmd=get_fluentd_pod_log
 else
     # make sure mux is running after previous test
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux.* Running "
@@ -356,6 +370,7 @@ else
     oc scale --replicas=1 dc logging-mux 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
     mypod=$( get_running_pod mux )
+    mycmd="oc logs"
 
     # make sure fluentd is running after previous test
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
@@ -363,13 +378,13 @@ else
     os::cmd::try_until_text "oc get daemonset/logging-fluentd -o jsonpath='{ .status.numberReady }'" '^0$' $FLUENTD_WAIT_TIME
     sudo rm -f /var/log/journal.pos
     sudo rm -rf /var/lib/fluentd/*
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc set env daemonset/logging-fluentd FORWARD_INPUT_LOG_LEVEL=info 2>&1 | artifact_out
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-
 fi
 os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
-oc logs $mypod > $ARTIFACT_DIR/remote-syslog-$mypod.log 2>&1
+$mycmd $mypod > $ARTIFACT_DIR/remote-syslog-$mypod.log 2>&1
 oc exec $mypod -- head -n 60 /etc/fluent/fluent.conf /etc/fluent/configs.d/openshift/output-operations.conf \
     /etc/fluent/configs.d/openshift/output-applications.conf /etc/fluent/configs.d/dynamic/output-remote-syslog.conf | artifact_out || :
 artifact_log ping $myhost from $mypod
@@ -380,7 +395,7 @@ oc exec $mypod -- ping $myhost -c 3 | artifact_out || :
 # sudo egrep \"^[0-6],[0-9]*,\" /var/log/messages | tail -n 5 | artifact_out || :
 
 artifact_log docker info
-docker info | artifact_out || :
+sudo docker info | artifact_out || :
 
 getappsmsg() {
     appsmessage=$1
@@ -420,10 +435,12 @@ if [ "$fluentdtype" = "fluentd" ] ; then
     os::cmd::try_until_text "oc get daemonset/logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
 
     oc set env daemonset/logging-fluentd USE_REMOTE_SYSLOG=true REMOTE_SYSLOG_HOST=$myhost REMOTE_SYSLOG_PORT=${ALTPORT} REMOTE_SYSLOG_USE_RECORD=true REMOTE_SYSLOG_SEVERITY=info REMOTE_SYSLOG_TAG_KEY- 2>&1 | artifact_out
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 
     mypod=$( get_running_pod fluentd )
+    mycmd=get_fluentd_pod_log
 else
     # make sure fluentd is running after previous test
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
@@ -431,6 +448,7 @@ else
     os::cmd::try_until_text "oc get daemonset/logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
 
     oc set env daemonset/logging-fluentd FORWARD_INPUT_LOG_LEVEL=info 2>&1 | artifact_out
+    sudo rm -f /var/log/fluentd/fluentd.log
     oc label node --all logging-infra-fluentd=true --overwrite=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 
@@ -443,6 +461,7 @@ else
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running " $MUX_WAIT_TIME
 
     mypod=$( get_running_pod mux )
+    mycmd="oc logs"
 fi
 os::cmd::try_until_success "oc exec $mypod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" $MUX_WAIT_TIME
 
@@ -465,11 +484,12 @@ fi
 
 hasNoMethodError()
 {
-    oc logs $mypod 2>&1 | artifact_out || :
     no_tag_key_log=$( mktemp )
-    oc logs $mypod > $no_tag_key_log 2>&1 || :
+    $mycmd $mypod > $ARTIFACT_DIR/hasNoMethodError.$mypod.log
+    $mycmd $mypod > $no_tag_key_log
     found=$( grep NoMethodError $no_tag_key_log || : )
-    if [ "$found" == "" ]; then
+    rm -f $no_tag_key_log
+    if [ -z "$found" ]; then
         artifact_log "good - no NoMethodError in the no tag_key case"
         return 0
     else

--- a/test/zzz-correct-index-names.sh
+++ b/test/zzz-correct-index-names.sh
@@ -26,6 +26,29 @@ es_ops_svc=${es_ops_svc:-$es_svc}
 
 OPS_NAMESPACES="default openshift openshift-infra openshift-this-is-a-test"
 
+cleanup() {
+  local return_code="$?"
+  set +e
+  es_pod=$( get_es_pod es )
+  es_ops_pod=$( get_es_pod es-ops )
+  es_ops_pod=${es_ops_pod:-$es_pod}
+
+  echo ">>> Indices $es_pod <<<" | artifact_out
+  oc exec -c elasticsearch $es_pod -- indices 2>&1 | artifact_out
+
+  echo ">>> Indices $es_ops_pod <<<" | artifact_out
+  oc exec -c elasticsearch $es_ops_pod -- indices 2>&1 | artifact_out
+
+  fpod=$( get_running_pod fluentd )
+  get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.log 2>&1
+
+  oc exec $fpod -- env | sort > $ARTIFACT_DIR/env_vars.log 2>&1
+  oc exec $fpod -- sh -c "find  /etc/fluent/configs.d -type f -exec cat {} \;" > $ARTIFACT_DIR/fluent_conf.log 2>&1
+
+  exit $return_code
+}
+trap "cleanup" EXIT
+
 # write some logs from namespace openshift and openshift-infra
 test_template=$OS_O_A_L_DIR/hack/testing/templates/test-template.yaml
 


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/origin-aggregated-logging/pull/1367
add utility functions get_fluentd_pod_log and get_mux_pod_log to
dump the pod logs from wherever they are
also added sudo rm -rf /var/log/fluentd/fluentd.log so that
tests which look for exact strings in the fluentd pod logs
will work correctly and not find older matches
fix incorrect usage of artifact_out

(cherry picked from commit e3c96c8712c138dc6aef24dafed09b9940390fda)