### PR TITLE
[release-3.7] look for /var/log/fluentd/fluentd.log for pod logs

### DIFF
--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -300,3 +300,20 @@ artifact_out() {
         internal_artifact_log "${ts}" "$line"
     done
 }
+
+# fluentd may have pod logs and logs in the file
+get_fluentd_pod_log() {
+    local pod=${1:-$( get_running_pod fluentd )}
+    local logfile=${2:-/var/log/fluentd/fluentd.log}
+    oc logs $pod 2>&1
+    if sudo test -f $logfile ; then
+        sudo cat $logfile
+    fi
+}
+
+get_mux_pod_log() {
+    local pod=${1:-$( get_running_pod mux )}
+    local logfile=${2:-/var/log/fluentd/fluentd.log}
+    oc logs $pod 2>&1
+    oc exec $pod -- cat $logfile 2> /dev/null || :
+}

--- a/test/docker_audit.sh
+++ b/test/docker_audit.sh
@@ -82,6 +82,7 @@ os::log::info "ops diff before:  $ops_logs_before"
 os::log::info "proj diff before: $logs_before"
 
 os::cmd::expect_success flush_fluentd_pos_files
+sudo rm -f /var/log/fluentd/fluentd.log
 os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
@@ -92,7 +93,7 @@ docker run --rm centos:7 echo "running test container"
 
 if ! os::cmd::try_until_success "logs_count_is_ge $esopspod '/.operations.*/' 4 $timestamp" $((second * 60)) ; then
     sudo grep VIRT_CONTROL /var/log/audit/audit.log | tail -40 > $ARTIFACT_DIR/docker_audit_audit.log
-    oc logs $fpod > $ARTIFACT_DIR/docker_audit_fluentd.log 2>&1
+    get_fluentd_pod_log $fpod > $ARTIFACT_DIR/docker_audit_fluentd.log
     ops_logs_after=$( get_logs_count $esopspod '/.operations.*/' )
     logs_after=$( get_logs_count $espod '/project.*/' )
     get_logs_source $esopspod '/.operations.*/' > $ARTIFACT_DIR/docker_audit_ops.json 2>&1

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -16,7 +16,7 @@ update_current_fluentd() {
     # but instead forwards to the forwarding fluentd
 
     # undeploy fluentd
-    os::log::debug "$( oc label node --all logging-infra-fluentd- )"
+    oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
 
     FLUENTD_FORWARD=()
@@ -102,21 +102,23 @@ update_current_fluentd() {
     # 256/8
     EXP_BUFFER_QUEUE_LIMIT=$( expr 256 / 8 )
 
-    os::log::debug "$( oc set env daemonset/logging-fluentd FILE_BUFFER_LIMIT=${MY_FILE_BUFFER_LIMIT} BUFFER_SIZE_LIMIT=${MY_BUFFER_SIZE_LIMIT} )"
+    oc set env daemonset/logging-fluentd FILE_BUFFER_LIMIT=${MY_FILE_BUFFER_LIMIT} BUFFER_SIZE_LIMIT=${MY_BUFFER_SIZE_LIMIT} 2>&1 | artifact_out
     # redeploy fluentd
     os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+    sudo rm -f /var/log/fluentd/fluentd.log
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     artifact_log update_current_fluentd $cnt
     fpod=$( get_running_pod fluentd ) || :
-    artifact_log update_current_fluentd $cnt "(oc logs $fpod)"
+    artifact_log update_current_fluentd $cnt
+    oc get pods 2>&1 | artifact_out || :
     if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod 2>&1 | artifact_out
+        get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.1.log
         id=$( expr $cnt - 1 ) || :
         artifact_log update_current_fluentd $cnt "(/etc/fluent/configs.d/user/secure-forward${id}.conf)"
         oc exec $fpod -- cat /etc/fluent/configs.d/user/secure-forward${id}.conf | artifact_out || :
-        artifact_log update_current_fluentd $cnt "(oc get pods)"
-        oc get pods 2>&1 | artifact_out
+        artifact_log update_current_fluentd $cnt
+        oc get pods 2>&1 | artifact_out || :
     fi
 
     # check set BUFFER_QUEUE_LIMIT
@@ -126,7 +128,7 @@ update_current_fluentd() {
     if [ -z "$REAL_BUFFER_QUEUE_LIMIT" ]; then
         os::log::error Environment variable BUFFER_QUEUE_LIMIT is empty.
     elif [ "$REAL_BUFFER_QUEUE_LIMIT" = "$EXP_BUFFER_QUEUE_LIMIT" ]; then
-        os::log::debug "Environment variable BUFFER_QUEUE_LIMIT is correctly set to $EXP_BUFFER_QUEUE_LIMIT."
+        artifact_log "Environment variable BUFFER_QUEUE_LIMIT is correctly set to $EXP_BUFFER_QUEUE_LIMIT."
     else
         os::log::error "Environment variable BUFFER_QUEUE_LIMIT is set to $REAL_BUFFER_QUEUE_LIMIT, which is suppose to be $EXP_BUFFER_QUEUE_LIMIT."
     fi
@@ -138,7 +140,7 @@ create_forwarding_fluentd() {
   while [ $id -lt $cnt ]; do
     # create forwarding configmap named "logging-forward-fluentd"
     oc create configmap logging-forward-fluentd${id} \
-       --from-file=fluent.conf=$OS_O_A_L_DIR/hack/templates/forward-fluent.conf
+       --from-file=fluent.conf=$OS_O_A_L_DIR/hack/templates/forward-fluent.conf 2>&1 | artifact_out
 
     # create a directory for file buffering so as not to conflict with fluentd
     if [ ! -d /var/lib/fluentd/forward${id} ] ; then
@@ -154,7 +156,7 @@ create_forwarding_fluentd() {
             -e '/image:/ a \
         ports: \
           - containerPort: 24284' | \
-        oc create -f -
+        oc create -f - 2>&1 | artifact_out
     else
       oc get daemonset/logging-fluentd -o yaml | \
         sed -e "s/logging-infra-fluentd:/logging-infra-forward-fluentd1:/" \
@@ -163,22 +165,23 @@ create_forwarding_fluentd() {
             -e '/image:/ a \
         ports: \
           - containerPort: 24284' | \
-        oc create -f -
+        oc create -f - 2>&1 | artifact_out
     fi
 
     # make it use a different hostpath than fluentd
     oc set volumes daemonset/logging-forward-fluentd${id} --add --overwrite \
        --name=filebufferstorage --type=hostPath \
-       --path=/var/lib/fluentd/forward${id} --mount-path=/var/lib/fluentd
-
+       --path=/var/lib/fluentd/forward${id} --mount-path=/var/lib/fluentd 2>&1 | artifact_out
+    # make it use a different log file than fluentd
+    oc set env daemonset/logging-forward-fluentd${id} LOGGING_FILE_PATH=/var/log/fluentd/fluentd.$id.log
     os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-forward-fluentd${id}=true )"
+    oc label node --all logging-infra-forward-fluentd${id}=true  2>&1 | artifact_out
 
     # wait for forward-fluentd to start
     os::cmd::try_until_text "oc get pods -l component=forward-fluentd${id}" "^logging-forward-fluentd${id}-.* Running "
     POD=$( oc get pods -l component=forward-fluentd${id} -o name )
-    artifact_log create_forwarding_fluentd $cnt "(oc logs $POD)"
-    oc logs $POD 2>&1 | artifact_out || :
+    artifact_log create_forwarding_fluentd $cnt
+    get_fluentd_pod_log $POD /var/log/fluentd/fluentd.$id.log > $ARTIFACT_DIR/fluentd-forward.$id.log
     id=$( expr $id + 1 )
   done
 }
@@ -202,37 +205,37 @@ cleanup() {
   cnt=${FORWARDCNT:-0}
   # dump the pod before we restart it
   if [ -n "${fpod:-}" ] ; then
-    artifact_log cleanup "(oc logs $fpod)"
-    oc logs $fpod 2>&1 | artifact_out || :
+    get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.cleanup.log
   fi
   oc get pods 2>&1 | artifact_out
   id=0
   while [ $id -lt $cnt ]; do
     POD=$( oc get pods -l component=forward-fluentd${id} -o name ) || :
-    artifact_log cleanup $cnt "(oc logs $POD)"
-    oc logs $POD 2>&1 | artifact_out || :
+    artifact_log cleanup $cnt
+    get_fluentd_pod_log $POD /var/log/fluentd/fluentd.$id.log > $ARTIFACT_DIR/$fpod.$id.cleanup.log
     id=$( expr $id + 1 )
   done
-  os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+  oc label node --all logging-infra-fluentd- 2>&1 | artifact_out || :
   os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
   if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
-    os::log::debug "$( oc replace --force -f $savecm )"
+    oc replace --force -f $savecm 2>&1 | artifact_out
   fi
   if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
-    os::log::debug "$( oc replace --force -f $saveds )"
+    oc replace --force -f $saveds 2>&1 | artifact_out
   fi
   id=0
   while [ $id -lt $cnt ]; do
     $mycmd fluentd-forward${id} test finished at $( date )
 
     # Clean up only if it's still around
-    os::log::debug "$( oc delete daemonset/logging-forward-fluentd${id} 2>&1 || : )"
-    os::log::debug "$( oc delete configmap/logging-forward-fluentd${id} 2>&1 || : )"
-    os::log::debug "$( oc label node --all logging-infra-forward-fluentd${id}- 2>&1 || : )"
+    oc delete daemonset/logging-forward-fluentd${id} 2>&1 | artifact_out
+    oc delete configmap/logging-forward-fluentd${id} 2>&1 | artifact_out
+    oc label node --all logging-infra-forward-fluentd${id}- 2>&1 | artifact_out
     id=$( expr $id + 1 )
   done
-  os::cmd::expect_success flush_fluentd_pos_files
-  os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+  flush_fluentd_pos_files 2>&1 | artifact_out
+  sudo rm -f /var/log/fluentd/fluentd.log
+  oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
   if [ $cnt -gt 1 ]; then
     cat $extra_artifacts
     # this will call declare_test_end, suite_end, etc.

--- a/test/json-parsing.sh
+++ b/test/json-parsing.sh
@@ -23,6 +23,10 @@ cleanup() {
         mycmd=os::log::error
     fi
     $mycmd json-parsing test finished at $( date )
+    fpod=$( get_running_pod fluentd )
+    if [ -n "${fpod:-}" ] ; then
+        get_fluentd_pod_log > $ARTIFACT_DIR/json-parsing-fluentd-pod.log
+    fi
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
     exit $return_code

--- a/test/mux.sh
+++ b/test/mux.sh
@@ -188,17 +188,17 @@ update_current_fluentd() {
   reset_fluentd_daemonset
 
   os::cmd::expect_success flush_fluentd_pos_files
-  sudo rm -f /var/lib/fluentd/buffer*.log
-  os::log::debug "$( oc label node --all logging-infra-fluentd=true )"
+  sudo rm -f /var/lib/fluentd/buffer*.log /var/log/fluentd/fluentd.log
+  oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
   os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
   fpod=$( get_running_pod fluentd )
 }
 
 print_message() {
-    os::log::debug "$( curl_es $es_pod /project.${myproject}.*/_search?${myfield}:${mymessage} )"
-    os::log::debug "$( curl_es $es_pod /_cat/indices?v )"
+    curl_es $es_pod /project.${myproject}.*/_search?${myfield}:${mymessage} 2>&1 | artifact_out || :
+    curl_es $es_pod /_cat/indices?v 2>&1 | artifact_out || :
     if [ "$es_pod" != "$es_ops_pod" ] ; then
-        os::log::debug "$( curl_es $es_ops_pod /_cat/indices?v )"
+        curl_es $es_ops_pod /_cat/indices?v 2>&1 | artifact_out || :
     fi
 }
 
@@ -343,7 +343,7 @@ cleanup() {
             oc exec $fpod -- ls -alrtF /etc/fluent/configs.d/user 2>&1 | artifact_out
         fi
         if [ -n "${muxpod:-}" ]; then
-            oc logs $muxpod > $ARTIFACT_DIR/mux.mux.pod.log
+            get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux.mux.pod.log
             oc get configmap/logging-mux -o yaml > $ARTIFACT_DIR/mux.mux.configmap.yaml
             oc exec $muxpod -- ls -alrtF /etc/fluent/configs.d/openshift 2>&1 | artifact_out
             oc exec $muxpod -- ls -alrtF /etc/fluent/configs.d/user 2>&1 | artifact_out
@@ -356,23 +356,23 @@ cleanup() {
     curl_es $es_ops_pod /_cat/indices > $ARTIFACT_DIR/es-ops.indices.after 2>&1
     # dump the pod before we restart it
     if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod > $ARTIFACT_DIR/mux.$fpod.log 2>&1
+        get_fluentd_pod_log $fpod > $ARTIFACT_DIR/mux.$fpod.log
     fi
-    os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+    oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
     if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
-        os::log::debug "$( oc replace --force -f $savecm )"
+        oc replace --force -f $savecm 2>&1 | artifact_out
     fi
     if [ -n "${saveds:-}" -a -f "${saveds:-}" ] ; then
-        os::log::debug "$( oc replace --force -f $saveds )"
+        oc replace --force -f $saveds 2>&1 | artifact_out
     fi
     # delete indices created by this test
     curl_es $es_pod /project.testproj.* -XDELETE
     curl_es $es_pod /project.default.* -XDELETE
     curl_es $es_pod /project.mux-undefined.* -XDELETE
     os::cmd::expect_success flush_fluentd_pos_files
-    sudo rm -f /var/lib/fluentd/buffer*.log
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+    sudo rm -f /var/lib/fluentd/buffer*.log /var/log/fluentd/fluentd.log
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     oc delete project testproj 2>&1 | artifact_out
     os::cmd::try_until_failure "oc get project testproj" 2>&1 | artifact_out
@@ -459,16 +459,16 @@ if [ "$MUX_FILE_BUFFER_STORAGE_TYPE" = "pvc" -o "$MUX_FILE_BUFFER_STORAGE_TYPE" 
             fi
         done
     done
-    os::log::debug "$( oc exec $muxpod -- ls -l /var/lib/fluentd )"
-    os::log::debug "$( oc logs $muxpod )"
+    oc exec $muxpod -- ls -l /var/lib/fluentd | artifact_out
+    get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux-before-$muxpod.log 2>&1
 
     # set ES_HOST and OPS_HOST to original
     reset_ES_HOST $ES_HOST_BAK $OPS_HOST_BAK
 
     # wait for the file buffer disappears once
     os::cmd::try_until_text "oc exec $muxpod -- ls -l /var/lib/fluentd" "total 0" $FLUENTD_WAIT_TIME
-    os::log::debug "$( oc exec $muxpod -- ls -l /var/lib/fluentd )"
-    os::log::debug "$( oc logs $muxpod )"
+    oc exec $muxpod -- ls -l /var/lib/fluentd | artifact_out
+    get_mux_pod_log $muxpod > $ARTIFACT_DIR/mux-$muxpod.log 2>&1
 
     # kibana logs with kibana container/pod values
     myproject=project.logging

--- a/test/remote-syslog.sh
+++ b/test/remote-syslog.sh
@@ -105,14 +105,14 @@ os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* 
 fpod=$( get_running_pod fluentd )
 os::cmd::try_until_success "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
 os::cmd::expect_success "oc exec $fpod grep 'tag_key message' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success_and_not_text "oc logs $fpod" "nil:NilClass"
+os::cmd::expect_success_and_not_text "get_fluentd_pod_log $fpod" "nil:NilClass"
 
 extra_rsyslog_artifacts=$ARTIFACT_DIR/rsyslog-artifacts.txt
 if [ -n "${DEBUG:-}" ] ; then
   echo Test 4, making sure tag_key=message does not cause remote-syslog plugin crash > $extra_rsyslog_artifacts
   echo "$( date --rfc-3339=ns )" "Enabled REMOTE_SYSLOG: USE_REMOTE_SYSLOG=true, REMOTE_SYSLOG_HOST=127.0.0.1, REMOTE_SYSLOG_HOST2=127.0.0.1, REMOTE_SYSLOG_TAG_KEY=message" >> $extra_rsyslog_artifacts
 
-  oc logs $fpod >> $extra_rsyslog_artifacts 2>&1
+  get_fluentd_pod_log $fpod >> $extra_rsyslog_artifacts 2>&1
 
   echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
 
@@ -131,13 +131,13 @@ os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* 
 fpod=$( get_running_pod fluentd )
 os::cmd::try_until_success "oc exec $fpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
 os::cmd::expect_success "oc exec $fpod grep 'tag_key bogus' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
-os::cmd::expect_success_and_not_text "oc logs $fpod" "nil:NilClass"
+os::cmd::expect_success_and_not_text "get_fluentd_pod_log $fpod" "nil:NilClass"
 
 if [ -n "${DEBUG:-}" ] ; then
   echo Test Test 5, making sure tag_key=bogus does not cause remote-syslog plugin crash >> $extra_rsyslog_artifacts
   echo "$( date --rfc-3339=ns )" "Enabled REMOTE_SYSLOG: USE_REMOTE_SYSLOG=true, REMOTE_SYSLOG_HOST=127.0.0.1, REMOTE_SYSLOG_HOST2=127.0.0.1, REMOTE_SYSLOG_TAG_KEY=bogus" >> $extra_rsyslog_artifacts
 
-  oc logs $fpod >> $extra_rsyslog_artifacts 2>&1
+  get_fluentd_pod_log $fpod >> $extra_rsyslog_artifacts 2>&1
 
   echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
 
@@ -168,7 +168,7 @@ if [ "$savemuxdc" != "" ]; then
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
     mpod=$( get_running_pod mux )
     if [ -n "${DEBUG:-}" ] ; then
-      oc logs $mpod >> $extra_rsyslog_artifacts 2>&1
+      get_mux_pod_log $mpod >> $extra_rsyslog_artifacts 2>&1
       echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
       oc exec $mpod -- cat /etc/fluent/configs.d/dynamic/output-remote-syslog.conf >> $extra_rsyslog_artifacts
     fi
@@ -186,7 +186,7 @@ if [ "$savemuxdc" != "" ]; then
   os::cmd::try_until_success "oc exec $mpod find /etc/fluent/configs.d/dynamic/output-remote-syslog.conf"
   os::cmd::expect_success_and_text "oc exec $mpod grep 'remote_syslog' /etc/fluent/configs.d/dynamic/output-remote-syslog.conf" "remote_syslog 127.0.0.1"
   if [ -n "${DEBUG:-}" ] ; then
-    oc logs $mpod >> $extra_rsyslog_artifacts 2>&1
+    get_mux_pod_log $mpod >> $extra_rsyslog_artifacts 2>&1
     echo "output-remote-syslog.conf: " >> $extra_rsyslog_artifacts
     oc exec $mpod -- cat /etc/fluent/configs.d/dynamic/output-remote-syslog.conf >> $extra_rsyslog_artifacts
   fi

--- a/test/viaq-data-model.sh
+++ b/test/viaq-data-model.sh
@@ -27,9 +27,12 @@ cleanup() {
     $mycmd viaq-data-model test finished at $( date )
     # dump the pod before we restart it
     if [ -n "${fpod:-}" ] ; then
-        oc logs $fpod > $ARTIFACT_DIR/$fpod.log 2>&1
+        get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.log 2>&1
     fi
-    os::log::debug "$( oc label node --all logging-infra-fluentd- 2>&1 || : )"
+    if [ -n "${muxpod:-}" ] ; then
+        get_mux_pod_log $muxpod > $ARTIFACT_DIR/$muxpod.log 2>&1
+    fi
+    oc label node --all logging-infra-fluentd- 2>&1 | artifact_out || :
     os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
     if [ -n "${savecm:-}" -a -f "${savecm:-}" ] ; then
         os::log::debug "$( oc replace --force -f $savecm )"
@@ -38,7 +41,8 @@ cleanup() {
         os::log::debug "$( oc replace --force -f $saveds )"
     fi
     os::cmd::expect_success flush_fluentd_pos_files
-    os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
+    sudo rm -f /var/log/fluentd/fluentd.log
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out || :
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
@@ -111,6 +115,7 @@ os::log::debug "$( oc set volumes daemonset/logging-fluentd --add --name=viaq-te
                    --path $cfg 2>&1 )"
 
 os::cmd::expect_success flush_fluentd_pos_files
+sudo rm -f /var/log/fluentd/fluentd.log
 os::log::debug "$( oc label node --all logging-infra-fluentd=true 2>&1 || : )"
 os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 fpod=$( get_running_pod fluentd )
@@ -215,4 +220,5 @@ if [ -n "$is_maximal" ] ; then
     oc set env dc/logging-mux CDM_KEEP_EMPTY_FIELDS-
     os::cmd::try_until_failure "oc get pod $muxpod"
     os::cmd::try_until_text "oc get pods -l component=mux" "^logging-mux-.* Running "
+    muxpod=$( get_running_pod mux )
 fi

--- a/test/zzz-correct-index-names.sh
+++ b/test/zzz-correct-index-names.sh
@@ -26,6 +26,29 @@ es_ops_pod=${es_ops_pod:-$es_pod}
 
 OPS_NAMESPACES="default openshift openshift-infra"
 
+cleanup() {
+  local return_code="$?"
+  set +e
+  es_pod=$( get_es_pod es )
+  es_ops_pod=$( get_es_pod es-ops )
+  es_ops_pod=${es_ops_pod:-$es_pod}
+
+  echo ">>> Indices $es_pod <<<" | artifact_out
+  oc exec -c elasticsearch $es_pod -- indices 2>&1 | artifact_out
+
+  echo ">>> Indices $es_ops_pod <<<" | artifact_out
+  oc exec -c elasticsearch $es_ops_pod -- indices 2>&1 | artifact_out
+
+  fpod=$( get_running_pod fluentd )
+  get_fluentd_pod_log $fpod > $ARTIFACT_DIR/$fpod.log 2>&1
+
+  oc exec $fpod -- env | sort > $ARTIFACT_DIR/env_vars.log 2>&1
+  oc exec $fpod -- sh -c "find  /etc/fluent/configs.d -type f -exec cat {} \;" > $ARTIFACT_DIR/fluent_conf.log 2>&1
+
+  exit $return_code
+}
+trap "cleanup" EXIT
+
 # write some logs from namespace openshift and openshift-infra
 test_template=$OS_O_A_L_DIR/hack/testing/templates/test-template.yaml
 


### PR DESCRIPTION
manual cherrypick of https://github.com/openshift/origin-aggregated-logging/pull/1367
add utility functions get_fluentd_pod_log and get_mux_pod_log to
dump the pod logs from wherever they are
also added sudo rm -rf /var/log/fluentd/fluentd.log so that
tests which look for exact strings in the fluentd pod logs
will work correctly and not find older matches
fix incorrect usage of artifact_out

(cherry picked from commit e3c96c8712c138dc6aef24dafed09b9940390fda)
(cherry picked from commit cbb73be9511383d9f8e350a758b37c59a7e5f604)
(cherry picked from commit 2612ae6e4abf7bd9f4ab33be465336fafc6eed35)