### PR TITLE
[3.11] fix recent eventrouter and fluentd-forward test flakes

### DIFF
--- a/test/eventrouter.sh
+++ b/test/eventrouter.sh
@@ -6,13 +6,36 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::test::junit::declare_suite_start "test/eventrouter"
 
-FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 3 * minute ))}
+
+muxmode=$( oc set env ds/logging-fluentd --list | grep \^MUX_CLIENT_MODE ) || :
+if [ -z "${muxmode:-}" ] ; then
+    muxmode=MUX_CLIENT_MODE-
+fi
+
+cleanup() {
+    local return_code="$?"
+    set +e
+    fpod=$( get_running_pod fluentd )
+    oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+    if [ -n "${fpod:-}" ] ; then
+        os::cmd::try_until_failure "oc get pod $fpod > /dev/null 2>&1" $FLUENTD_WAIT_TIME
+    fi
+    oc set env ds/logging-fluentd $muxmode
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running " $FLUENTD_WAIT_TIME
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
 
 function warn_nonformatted() {
     local es_svc=$1
     local index=$2
     # check if eventrouter and fluentd with correct ViaQ plugin are deployed
-    local non_formatted_event_count=$( curl_es $es_svc /$index/_count?q=verb:* | get_count_from_json )
+    local non_formatted_event_count=$( curl_es $es_svc $index/_count?q=verb:* | get_count_from_json )
     if [ "$non_formatted_event_count" != 0 ]; then
         os::log::warning "$non_formatted_event_count events from eventrouter in index $index were not processed by ViaQ fluentd plugin"
     fi
@@ -44,29 +67,29 @@ else
     os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
 
     warn_nonformatted $essvc '/project.*'
-    warn_nonformatted $esopssvc '/.operations.*/'
+    warn_nonformatted $esopssvc '/.operations.*'
 
-    os::cmd::expect_success_and_not_text "curl_es $esopssvc /.operations.*/_count?q=kubernetes.event.verb:* | get_count_from_json" "^0\$"
+    os::cmd::try_until_not_text "curl_es $esopssvc /.operations.*/_count?q=kubernetes.event.verb:* | get_count_from_json" "^0\$" $FLUENTD_WAIT_TIME
     prev_event_count=$( curl_es $esopssvc /.operations.*/_count?q=kubernetes.event.verb:* | get_count_from_json )
 
     # utilize mux if mux pod exists
     if oc get dc/logging-mux > /dev/null 2>&1 ; then
-        # MUX_CLIENT_MODE: maximal; oc set env restarts logging-fluentd
+        # MUX_CLIENT_MODE: maximal
         oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
         os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
         oc set env ds/logging-fluentd MUX_CLIENT_MODE=maximal 2>&1 | artifact_out
         oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
-        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-        os::cmd::try_until_success "logs_count_is_gt $prev_event_count"
+        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running " $FLUENTD_WAIT_TIME
+        os::cmd::try_until_success "logs_count_is_gt $prev_event_count" $FLUENTD_WAIT_TIME
         prev_event_count=$( curl_es $esopssvc /.operations.*/_count?q=kubernetes.event.verb:* | get_count_from_json )
 
-        # MUX_CLIENT_MODE: minimal; oc set env restarts logging-fluentd
+        # MUX_CLIENT_MODE: minimal
         oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
         os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
         oc set env ds/logging-fluentd MUX_CLIENT_MODE=minimal 2>&1 | artifact_out
         oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
-        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-        os::cmd::try_until_success "logs_count_is_gt $prev_event_count"
+        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running " $FLUENTD_WAIT_TIME
+        os::cmd::try_until_success "logs_count_is_gt $prev_event_count" $FLUENTD_WAIT_TIME
     fi
 
 fi

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -24,8 +24,8 @@ update_current_fluentd() {
     FLUENTD_FORWARD=()
     id=0
     while [ $id -lt $cnt ]; do
-      POD=$( oc get pods -l component=forward-fluentd${id} -o name )
-      FLUENTD_FORWARD[$id]=$( oc get $POD --template='{{.status.podIP}}' )
+      POD=$( get_running_pod forward-fluentd${id} )
+      FLUENTD_FORWARD[$id]=$( oc get pod $POD --template='{{.status.podIP}}' )
       artifact_log update_current_fluentd .status.podIP ${FLUENTD_FORWARD[$id]}
       id=$( expr $id + 1 ) || :
     done
@@ -145,8 +145,8 @@ create_forwarding_fluentd() {
        --from-file=fluent.conf=$OS_O_A_L_DIR/hack/templates/forward-fluent.conf 2>&1 | artifact_out
 
     # create a directory for file buffering so as not to conflict with fluentd
-    if [ ! -d /var/lib/fluentd/forward${id} ] ; then
-        sudo mkdir -p /var/lib/fluentd/forward${id}
+    if ! sudo test -d /var/lib/fluentd-forward${id} ; then
+        sudo mkdir -p /var/lib/fluentd-forward${id}
     fi
 
     # create forwarding daemonset
@@ -173,17 +173,17 @@ create_forwarding_fluentd() {
     # make it use a different hostpath than fluentd
     oc set volumes daemonset/logging-forward-fluentd${id} --add --overwrite \
        --name=filebufferstorage --type=hostPath \
-       --path=/var/lib/fluentd/forward${id} --mount-path=/var/lib/fluentd 2>&1 | artifact_out
+       --path=/var/lib/fluentd-forward${id} --mount-path=/var/lib/fluentd 2>&1 | artifact_out
     # make it use a different log file than fluentd
-    oc set env daemonset/logging-forward-fluentd${id} LOGGING_FILE_PATH=/var/log/fluentd/fluentd.$id.log
+    oc set env daemonset/logging-forward-fluentd${id} LOGGING_FILE_PATH=/var/log/fluentd/forward.$id.log
     os::cmd::expect_success flush_fluentd_pos_files
     oc label node --all logging-infra-forward-fluentd${id}=true  2>&1 | artifact_out
 
     # wait for forward-fluentd to start
     os::cmd::try_until_text "oc get pods -l component=forward-fluentd${id}" "^logging-forward-fluentd${id}-.* Running "
-    POD=$( oc get pods -l component=forward-fluentd${id} -o name )
+    POD=$( get_running_pod forward-fluentd${id} )
     artifact_log create_forwarding_fluentd $cnt
-    get_fluentd_pod_log $POD /var/log/fluentd/fluentd.$id.log > $ARTIFACT_DIR/fluentd-forward.$id.log
+    get_fluentd_pod_log $POD /var/log/fluentd/forward.$id.log > $ARTIFACT_DIR/fluentd-forward.$id.log
     id=$( expr $id + 1 )
   done
 }
@@ -212,7 +212,7 @@ cleanup() {
   oc get pods 2>&1 | artifact_out
   id=0
   while [ $id -lt $cnt ]; do
-    POD=$( oc get pods -l component=forward-fluentd${id} -o name ) || :
+    POD=$( get_running_pod forward-fluentd${id} ) || :
     artifact_log cleanup $cnt
     get_fluentd_pod_log $POD /var/log/fluentd/fluentd.$id.log > $ARTIFACT_DIR/$fpod.$id.cleanup.log
     id=$( expr $id + 1 )
@@ -237,7 +237,12 @@ cleanup() {
   done
   flush_fluentd_pos_files 2>&1 | artifact_out
   sudo rm -f /var/log/fluentd/fluentd.log
+  # remove buffers to solve this error in the fluentd log:
+  # 2018-10-17 15:26:44 +0000 [error]: Exception emitting record: No such file or directory - (/var/lib/fluentd/buffer-mux-client.journal.b5786e0f775c92183.log, /var/lib/fluentd/buffer-mux-client.journal.q5786e0f775c92183.log)
+  sudo rm -rf /var/lib/fluentd/*
+  sudo rm -rf /var/lib/fluentd-forward*
   oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
+  os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
   if [ $cnt -gt 1 ]; then
     cat $extra_artifacts
     # this will call declare_test_end, suite_end, etc.


### PR DESCRIPTION
I think that the eventrouter and fluentd-forward tests are leaving
fluentd in some strange state that causes test failures in
subsequent tests
Also improve diagnosing test failures
This replaces https://github.com/openshift/origin-aggregated-logging/pull/1430
manual cherrypick of https://github.com/openshift/origin-aggregated-logging/pull/1425 and https://github.com/openshift/origin-aggregated-logging/pull/1431

(cherry picked from commit 94ae3f49d4a7baef243d40729f5b96c6229fbb12)
(cherry picked from commit 5f465c73fb54326c854a95b60d078b4ffc79d894)
(cherry picked from commit 8fb1c167778c11a2d57e799c73ee10b8518c5f99)