### PR TITLE
Fixing prometheus plugin certs to use env vars like output plugin

### DIFF
--- a/fluentd/configs.d/openshift/input-pre-prometheus-metrics.conf
+++ b/fluentd/configs.d/openshift/input-pre-prometheus-metrics.conf
@@ -2,9 +2,9 @@
   @type prometheus
   <ssl>
     enable true
-    certificate_path "/etc/fluent/keys/cert"
-    private_key_path "/etc/fluent/keys/key"
-    ca_path "/etc/fluent/keys/ca"
+    certificate_path "#{ENV['ES_CLIENT_CERT']}"
+    private_key_path "#{ENV['ES_CLIENT_KEY']}"
+    ca_path "#{ENV['ES_CA']}"
   </ssl>
 </source>
 


### PR DESCRIPTION
Resolves why fluentd keeps terminating on https://github.com/openshift/cluster-logging-operator/pull/23

```
2018-10-19 20:20:58 +0000 [info]: reading config file path="/etc/fluent/fluent.conf"
2018-10-19 20:20:58 +0000 [warn]: 'block' action stops input process until the buffer full is resolved. Check your pipeline this action is fit or not
2018-10-19 20:20:58 +0000 [warn]: 'block' action stops input process until the buffer full is resolved. Check your pipeline this action is fit or not
2018-10-19 20:20:58 +0000 [error]: unexpected error error_class=Errno::ENOENT error=#<Errno::ENOENT: No such file or directory - /etc/fluent/keys/cert>
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluent-plugin-prometheus-0.5.0/lib/fluent/plugin/in_prometheus.rb:60:in `read'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluent-plugin-prometheus-0.5.0/lib/fluent/plugin/in_prometheus.rb:60:in `start'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:115:in `block in start'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:114:in `each'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:114:in `start'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/engine.rb:237:in `start'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/engine.rb:187:in `run'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:579:in `run_engine'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:185:in `block in start'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:375:in `call'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:375:in `main_process'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:179:in `start'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/command/fluentd.rb:173:in `<top (required)>'
  2018-10-19 20:20:58 +0000 [error]: /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
  2018-10-19 20:20:58 +0000 [error]: /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/gems/fluentd-0.12.43/bin/fluentd:8:in `<top (required)>'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/bin/fluentd:23:in `load'
  2018-10-19 20:20:58 +0000 [error]: /opt/app-root/src/bin/fluentd:23:in `<main>'
```