### PR TITLE
[3.11] Bug 1613722 - Eventrouter creates duplicated events every 30 min with…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,14 @@ matrix:
         cd fluentd/lib/filter_concat
       script:
         rake test
+    - name: fluentd - filter_elasticsearch_genid_ext test
+      env:
+        - FLUENTD_VERSION=0.12.0
+      language: ruby
+      rvm:
+      - 2.0
+      gemfile: fluentd/lib/filter_elasticsearch_genid_ext/Gemfile
+      before_script:
+        cd fluentd/lib/filter_elasticsearch_genid_ext
+      script:
+        rake test

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -56,6 +56,7 @@ ADD run.sh generate_syslog_config.rb ${HOME}/
 ADD lib/generate_throttle_configs/lib/*.rb ${HOME}/
 ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
 ADD lib/filter_concat/lib/filter_concat.rb /etc/fluent/plugin/
+ADD lib/filter_elasticsearch_genid_ext/lib/filter_elasticsearch_genid_ext.rb /etc/fluent/plugin/
 ADD patch/in_prometheus.rb ${GEM_HOME}/gems/fluent-plugin-prometheus-0.4.0/lib/fluent/plugin/
 
 RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -62,6 +62,7 @@ ADD parser_viaq_docker_audit.rb viaq_docker_audit.rb /etc/fluent/plugin/
 ADD run.sh generate_syslog_config.rb ${HOME}/
 ADD lib/generate_throttle_configs/lib/*.rb ${HOME}/
 ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
+ADD lib/filter_elasticsearch_genid_ext/lib/filter_elasticsearch_genid_ext.rb /etc/fluent/plugin/
 ADD patch/logger/log.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 ADD patch/logger/supervisor.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 ADD lib/filter_concat/lib/filter_concat.rb /etc/fluent/plugin/

--- a/fluentd/configs.d/openshift/filter-post-genid.conf
+++ b/fluentd/configs.d/openshift/filter-post-genid.conf
@@ -1,6 +1,8 @@
 # generate ids at source mitigate creating duplicate records
 # requires fluent-plugin-elasticsearch
 <filter **>
-  @type elasticsearch_genid
+  @type elasticsearch_genid_ext
   hash_id_key viaq_msg_id
+  alt_key kubernetes.event.metadata.uid
+  alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.kube-eventrouter-*.** kubernetes.journal.container.kubernetes-event'}"
 </filter>

--- a/fluentd/configs.d/openshift/filter-retag-journal.conf
+++ b/fluentd/configs.d/openshift/filter-retag-journal.conf
@@ -59,18 +59,20 @@
   # k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2
   # we filter these logs through the kibana_transform.conf filter
   rewriterule1 CONTAINER_NAME ^k8s_kibana\. kubernetes.journal.container.kibana
+  # mark eventrouter events
+  rewriterule2 CONTAINER_NAME ^k8s_[^_]+_logging-eventrouter-[^_]+_ kubernetes.journal.container._default_.kubernetes.event
   # mark logs from default namespace for processing as k8s logs but stored as system logs
-  rewriterule2 CONTAINER_NAME ^k8s_[^_]+_[^_]+_default_ kubernetes.journal.container._default_
+  rewriterule3 CONTAINER_NAME ^k8s_[^_]+_[^_]+_default_ kubernetes.journal.container._default_
   # mark logs from kube-* namespaces for processing as k8s logs but stored as system logs
-  rewriterule3 CONTAINER_NAME ^k8s_[^_]+_[^_]+_kube-(.+)_ kubernetes.journal.container._kube-$1_
+  rewriterule4 CONTAINER_NAME ^k8s_[^_]+_[^_]+_kube-(.+)_ kubernetes.journal.container._kube-$1_
   # mark logs from openshift-* namespaces for processing as k8s logs but stored as system logs
-  rewriterule4 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift-(.+)_ kubernetes.journal.container._openshift-$1_
+  rewriterule5 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift-(.+)_ kubernetes.journal.container._openshift-$1_
   # mark logs from openshift namespace for processing as k8s logs but stored as system logs
-  rewriterule5 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift_ kubernetes.journal.container._openshift_
+  rewriterule6 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift_ kubernetes.journal.container._openshift_
   # mark fluentd container logs
-  rewriterule6 CONTAINER_NAME ^k8s_.*fluentd kubernetes.journal.container.fluentd
+  rewriterule7 CONTAINER_NAME ^k8s_.*fluentd kubernetes.journal.container.fluentd
   # this is a kubernetes container
-  rewriterule7 CONTAINER_NAME ^k8s_ kubernetes.journal.container
+  rewriterule8 CONTAINER_NAME ^k8s_ kubernetes.journal.container
   # not kubernetes - assume a system log or system container log
-  rewriterule8 _TRANSPORT .+ journal.system
+  rewriterule9 _TRANSPORT .+ journal.system
 </match>

--- a/fluentd/lib/filter_elasticsearch_genid_ext/Gemfile
+++ b/fluentd/lib/filter_elasticsearch_genid_ext/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'codeclimate-test-reporter', :group => :test, :require => nil
+
+gemspec

--- a/fluentd/lib/filter_elasticsearch_genid_ext/Rakefile
+++ b/fluentd/lib/filter_elasticsearch_genid_ext/Rakefile
@@ -1,0 +1,11 @@
+#require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+    t.test_files = FileList['test/**/*_test.rb']
+    t.warning = false
+    #t.verbose = true
+end
+desc "Run tests"
+
+task default: :test

--- a/fluentd/lib/filter_elasticsearch_genid_ext/filter_elasticsearch_genid_ext.gemspec
+++ b/fluentd/lib/filter_elasticsearch_genid_ext/filter_elasticsearch_genid_ext.gemspec
@@ -1,0 +1,24 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+# can override for testing
+FLUENTD_VERSION = ENV['FLUENTD_VERSION'] || "0.12.0"
+
+Gem::Specification.new do |gem|
+  gem.name          = "filter_elasticsearch_genid_ext"
+  gem.version       = "0.0.1"
+  gem.authors       = ["Noriko Hosoi"]
+  gem.summary       = %q{Filter plugin to generate id; if alt_key is given the value of record of the key is used for the id.}
+
+  gem.required_ruby_version = '>= 2.0.0'
+
+  gem.add_runtime_dependency "fluentd", "~> #{FLUENTD_VERSION}"
+
+  gem.add_development_dependency "bundler"
+  gem.add_development_dependency("fluentd", "~> #{FLUENTD_VERSION}")
+  gem.add_development_dependency("rake", ["~> 11.0"])
+  gem.add_development_dependency("rr", ["~> 1.0"])
+  gem.add_development_dependency("test-unit", ["~> 3.2"])
+  gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
+end

--- a/fluentd/lib/filter_elasticsearch_genid_ext/lib/filter_elasticsearch_genid_ext.rb
+++ b/fluentd/lib/filter_elasticsearch_genid_ext/lib/filter_elasticsearch_genid_ext.rb
@@ -1,0 +1,78 @@
+require 'securerandom'
+require 'base64'
+require 'fluent/filter'
+
+begin
+  GenidMatchClass = Fluent::Match
+rescue
+  # Fluent::Match not provided with 0.14
+  class GenidMatchClass
+    def initialize(pattern_str, unused)
+      patterns = pattern_str.split(/\s+/).map {|str|
+        Fluent::MatchPattern.create(str)
+      }
+      if patterns.length == 1
+        @pattern = patterns[0]
+      else
+        @pattern = Fluent::OrMatchPattern.new(patterns)
+      end
+    end
+    def match(tag)
+      @pattern.match(tag)
+    end
+    def to_s
+      "#{@pattern}"
+    end
+  end
+end
+
+module Fluent
+  class ElasticsearchGenidExtFilter < Filter
+    Fluent::Plugin.register_filter('elasticsearch_genid_ext', self)
+
+    desc 'key to store generated unique id or the value of alt_key if specified'
+    config_param :hash_id_key, :string, :default => '_hash'
+    desc 'key for the hash "record" (optional)'
+    config_param :alt_key, :string, default: ""
+    desc 'process alt_key in records with this tag pattern'
+    config_param :alt_tags, :string, default: ""
+
+    def configure(conf)
+      super
+      @alt_keys = @alt_key.split('.')
+      @alt_tag_matcher = GenidMatchClass.new(@alt_tags, nil)
+    end
+
+    def filter(tag, time, record)
+      record[@hash_id_key] = ""
+      if @alt_tag_matcher.match(tag)
+        myid = nil
+        unless @alt_key.to_s.strip.empty? || record.empty?
+          myid = record
+          @alt_keys.each do |p|
+            unless myid.key?(p)
+              unless p.eql? @alt_key
+                log.on_debug do
+                  log.debug "filter:elasticsearch_genid_ext: #{p} in alt_key #{@alt_key} is not a key of record."
+                end
+                myid = nil
+              end
+              break
+            end
+            myid = myid[p]
+          end
+        end
+        record[@hash_id_key] = if myid.is_a? String
+                                 myid
+                               else
+                                 Base64.strict_encode64(SecureRandom.uuid)
+                               end
+      end
+      if record[@hash_id_key].to_s.strip.empty?
+          record[@hash_id_key] = Base64.strict_encode64(SecureRandom.uuid)
+      end
+      record
+    end
+
+  end
+end

--- a/fluentd/lib/filter_elasticsearch_genid_ext/test/filter_elasticsearch_genid_ext_test.rb
+++ b/fluentd/lib/filter_elasticsearch_genid_ext/test/filter_elasticsearch_genid_ext_test.rb
@@ -1,0 +1,88 @@
+require 'fluent/test'
+require 'test/unit/rr'
+require 'json'
+
+require File.join(File.dirname(__FILE__), '..', 'lib/filter_elasticsearch_genid_ext') 
+
+class ElasticsearchGenidExtFilterTest < Test::Unit::TestCase
+  include Fluent
+
+  setup do
+    Fluent::Test.setup
+    @time = Fluent::Engine.now
+    log = Fluent::Engine.log
+    @timestamp = Time.now
+    @timestamp_str = @timestamp.utc.to_datetime.rfc3339(6)
+    stub(Time).now { @timestamp }
+  end
+
+  def create_driver(conf = '')
+    d = Test::FilterTestDriver.new(ElasticsearchGenidExtFilter, 'this.is.a.tag').configure(conf, true)
+    d.instance.log_level = 'DEBUG'
+    @dlog = d.instance.log
+    d
+  end
+
+  def emit_with_tag(tag, record={}, conf='')
+    d = create_driver(conf)
+    d.run {
+      d.emit_with_tag(tag, record, @time)
+    }.filtered.instance_variable_get(:@record_array)[0]
+  end  
+
+  sub_test_case 'configure' do
+    test 'check setting all params to non-default values' do
+      d = create_driver('
+        hash_id_key viaq_msg_id
+        alt_key kubernetes.event.metadata.uid
+        alt_tags "kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container.kubernetes-event"
+      ')
+      assert_equal('viaq_msg_id', d.instance.hash_id_key)
+      assert_equal('kubernetes.event.metadata.uid', d.instance.alt_key)
+    end
+  end
+
+  sub_test_case 'generate ids' do
+    test 'no alt_key config' do
+      record = JSON.parse('{"log":{"message":"a log record"},"key":{"subkey":"0123456789"},"time":"2018-08-22T17:04:12.385850123Z"}')
+      rec = emit_with_tag('tag', record, '
+        hash_id_key viaq_msg_id
+      ')
+      assert_not_equal('0123456789', rec["viaq_msg_id"])
+    end
+    test 'record has no alt_key; no alt_tags' do
+      record = JSON.parse('{"log":{"message":"a log record"},"key":{"bogus":"0123456789"},"time":"2018-08-22T17:04:12.385850123Z"}')
+      rec = emit_with_tag('tag', record, '
+        hash_id_key viaq_msg_id
+        alt_key key.subkey
+      ')
+      assert_not_equal('0123456789', rec["viaq_msg_id"])
+    end
+    test 'record has no alt_key; has matched alt_tags' do
+      record = JSON.parse('{"log":{"message":"a log record"},"key":{"bogus":"0123456789"},"time":"2018-08-22T17:04:12.385850123Z"}')
+      rec = emit_with_tag('kubernetes.var.log.containers.logging-eventrouter-9876543210', record, '
+        hash_id_key viaq_msg_id
+        alt_key key.subkey
+        alt_tags "kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container.kubernetes-event"
+      ')
+      assert_not_equal('0123456789', rec["viaq_msg_id"])
+    end
+    test 'record has alt_key; no alt_tags' do
+      record = JSON.parse('{"log":{"message":"a log record"},"key":{"subkey":"0123456789"},"time":"2018-08-22T17:04:12.385850123Z"}')
+      rec = emit_with_tag('tag', record, '
+        hash_id_key viaq_msg_id
+        alt_key key.subkey
+      ')
+      assert_not_equal('0123456789', rec["viaq_msg_id"])
+    end
+    test 'record has alt_key; has matched alt_tags' do
+      record = JSON.parse('{"log":{"message":"a log record"},"key":{"subkey":"0123456789"},"time":"2018-08-22T17:04:12.385850123Z"}')
+      rec = emit_with_tag('kubernetes.var.log.containers.logging-eventrouter-9876543210', record, '
+        hash_id_key viaq_msg_id
+        alt_key key.subkey
+        alt_tags "kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container.kubernetes-event"
+      ')
+      assert_equal('0123456789', rec["viaq_msg_id"])
+    end
+  end
+end


### PR DESCRIPTION
… verb UPDATE

Adding a plugin filter_elasticsearch_genid_ext.rb, which extends filter_
elasticsearch_genid.rb from fluent-plugin-elasticsearch.  The extended plugin
takes config parameter alt_key as shown in filter-post-genid.conf.
  <filter **>
    @type elasticsearch_genid_ext
    hash_id_key viaq_msg_id
    alt_key kubernetes.event.metadata.uid
    alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.kube-eventrouter-*.** kubernetes.journal.container._default_.kubernetes.event'}"
  </filter>
The plugin does -
  1. If the tag matches the alt_tags list or not,
  2. If it does, it checks the alt_key exists in the record hash as the key.
     As the key is kubernetes.event.metadata.uid, it checks
     record[kubernetes][event][metadata][uid] exists or not.
  3. If it exists, viaq_msg_id is set to the value.
  4. Otherwise, the generated hash value is set. This is the default behaviour.

Note: the value of kubernetes.event.metadata.uid is shared among the event logs
originated from the same one event.  By using the value for the elasticsearch
primary key, duplicated logs are not to be indexed in the elasticsearch.

For testing, code to check there is no duplicated value of kubernetes.event.
metadata.uid is added to test/eventrouter.sh.

Additionally, the tag of the event logs via journald used to be
  kubernetes.journal.container._kube-eventrouter_
which is changed to
  kubernetes.journal.container._default_.kubernetes.event

(cherry picked from commit a995992b85ce4fd53e1ea7354ebd95a7dd992174)

https://bugzilla.redhat.com/show_bug.cgi?id=1613722