### PR TITLE
[3.10] Bug 1641166 - Eventrouter creates duplicated events every 30 min with…

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -53,6 +53,7 @@ ADD filter_k8s_meta_for_mux_client.rb /etc/fluent/plugin/
 ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb /etc/fluent/plugin/
 ADD parser_viaq_docker_audit.rb viaq_docker_audit.rb /etc/fluent/plugin/
 ADD run.sh generate_throttle_configs.rb generate_syslog_config.rb ${HOME}/
+ADD filter_elasticsearch_genid_ext.rb /etc/fluent/plugin/
 
 RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
     chmod 777 /etc/fluent/configs.d/dynamic && \

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -61,6 +61,7 @@ ADD filter_k8s_meta_for_mux_client.rb /etc/fluent/plugin/
 ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb /etc/fluent/plugin/
 ADD parser_viaq_docker_audit.rb viaq_docker_audit.rb /etc/fluent/plugin/
 ADD run.sh generate_throttle_configs.rb generate_syslog_config.rb ${HOME}/
+ADD filter_elasticsearch_genid_ext.rb /etc/fluent/plugin/
 ADD patch/logger/log.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 ADD patch/logger/supervisor.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 COPY utils/** /usr/local/bin/

--- a/fluentd/configs.d/openshift/filter-post-genid.conf
+++ b/fluentd/configs.d/openshift/filter-post-genid.conf
@@ -1,6 +1,8 @@
 # generate ids at source mitigate creating duplicate records
 # requires fluent-plugin-elasticsearch
 <filter **>
-  @type elasticsearch_genid
+  @type elasticsearch_genid_ext
   hash_id_key viaq_msg_id
+  alt_key kubernetes.event.metadata.uid
+  alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'}"
 </filter>

--- a/fluentd/configs.d/openshift/filter-retag-journal.conf
+++ b/fluentd/configs.d/openshift/filter-retag-journal.conf
@@ -59,16 +59,18 @@
   # k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2
   # we filter these logs through the kibana_transform.conf filter
   rewriterule1 CONTAINER_NAME ^k8s_kibana\. kubernetes.journal.container.kibana
+  # mark eventrouter events
+  rewriterule2 CONTAINER_NAME ^k8s_[^_]+_logging-eventrouter-[^_]+_ kubernetes.journal.container._default_.kubernetes-event
   # mark logs from default namespace for processing as k8s logs but stored as system logs
-  rewriterule2 CONTAINER_NAME ^k8s_[^_]+_[^_]+_default_ kubernetes.journal.container._default_
+  rewriterule3 CONTAINER_NAME ^k8s_[^_]+_[^_]+_default_ kubernetes.journal.container._default_
   # mark logs from openshift-* namespaces for processing as k8s logs but stored as system logs
-  rewriterule3 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift-(.+)_ kubernetes.journal.container._openshift-$1_
+  rewriterule4 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift-(.+)_ kubernetes.journal.container._openshift-$1_
   # mark logs from openshift namespace for processing as k8s logs but stored as system logs
-  rewriterule4 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift_ kubernetes.journal.container._openshift_
+  rewriterule5 CONTAINER_NAME ^k8s_[^_]+_[^_]+_openshift_ kubernetes.journal.container._openshift_
   # mark fluentd container logs
-  rewriterule5 CONTAINER_NAME ^k8s_.*fluentd kubernetes.journal.container.fluentd
+  rewriterule6 CONTAINER_NAME ^k8s_.*fluentd kubernetes.journal.container.fluentd
   # this is a kubernetes container
-  rewriterule6 CONTAINER_NAME ^k8s_ kubernetes.journal.container
+  rewriterule7 CONTAINER_NAME ^k8s_ kubernetes.journal.container
   # not kubernetes - assume a system log or system container log
-  rewriterule7 _TRANSPORT .+ journal.system
+  rewriterule8 _TRANSPORT .+ journal.system
 </match>

--- a/fluentd/filter_elasticsearch_genid_ext.rb
+++ b/fluentd/filter_elasticsearch_genid_ext.rb
@@ -1,0 +1,78 @@
+require 'securerandom'
+require 'base64'
+require 'fluent/filter'
+
+begin
+  GenidMatchClass = Fluent::Match
+rescue
+  # Fluent::Match not provided with 0.14
+  class GenidMatchClass
+    def initialize(pattern_str, unused)
+      patterns = pattern_str.split(/\s+/).map {|str|
+        Fluent::MatchPattern.create(str)
+      }
+      if patterns.length == 1
+        @pattern = patterns[0]
+      else
+        @pattern = Fluent::OrMatchPattern.new(patterns)
+      end
+    end
+    def match(tag)
+      @pattern.match(tag)
+    end
+    def to_s
+      "#{@pattern}"
+    end
+  end
+end
+
+module Fluent
+  class ElasticsearchGenidExtFilter < Filter
+    Fluent::Plugin.register_filter('elasticsearch_genid_ext', self)
+
+    desc 'key to store generated unique id or the value of alt_key if specified'
+    config_param :hash_id_key, :string, :default => '_hash'
+    desc 'key for the hash "record" (optional)'
+    config_param :alt_key, :string, default: ""
+    desc 'process alt_key in records with this tag pattern'
+    config_param :alt_tags, :string, default: ""
+
+    def configure(conf)
+      super
+      @alt_keys = @alt_key.split('.')
+      @alt_tag_matcher = GenidMatchClass.new(@alt_tags, nil)
+    end
+
+    def filter(tag, time, record)
+      record[@hash_id_key] = ""
+      if @alt_tag_matcher.match(tag)
+        myid = nil
+        unless @alt_key.to_s.strip.empty? || record.empty?
+          myid = record
+          @alt_keys.each do |p|
+            unless myid.key?(p)
+              unless p.eql? @alt_key
+                log.on_debug do
+                  log.debug "filter:elasticsearch_genid_ext: #{p} in alt_key #{@alt_key} is not a key of record."
+                end
+                myid = nil
+              end
+              break
+            end
+            myid = myid[p]
+          end
+        end
+        record[@hash_id_key] = if myid.is_a? String
+                                 myid
+                               else
+                                 Base64.strict_encode64(SecureRandom.uuid)
+                               end
+      end
+      if record[@hash_id_key].to_s.strip.empty?
+          record[@hash_id_key] = Base64.strict_encode64(SecureRandom.uuid)
+      end
+      record
+    end
+
+  end
+end

--- a/test/eventrouter.sh
+++ b/test/eventrouter.sh
@@ -6,7 +6,30 @@ source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 os::test::junit::declare_suite_start "test/eventrouter"
 
-FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 5 * minute ))}
+
+muxmode=$( oc set env ds/logging-fluentd --list | grep \^MUX_CLIENT_MODE ) || :
+if [ -z "${muxmode:-}" ] ; then
+    muxmode=MUX_CLIENT_MODE-
+fi
+
+cleanup() {
+    local return_code="$?"
+    set +e
+    fpod=$( get_running_pod fluentd )
+    oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
+    os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+    if [ -n "${fpod:-}" ] ; then
+        os::cmd::try_until_failure "oc get pod $fpod > /dev/null 2>&1" $FLUENTD_WAIT_TIME
+    fi
+    oc set env ds/logging-fluentd $muxmode
+    oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
+    os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running " $FLUENTD_WAIT_TIME
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
 
 function warn_nonformatted() {
     local es_svc=$1
@@ -22,8 +45,10 @@ function get_eventrouter_pod() {
 }
 
 function logs_count_is_gt() {
-    local expected=$1
-    local actual=$( curl_es $esopssvc /.operations.*/_count?q=kubernetes.event.verb:* | get_count_from_json )
+    local expected="$1"
+    local myqs="$2"
+    local actual=$( curl_es $esopssvc /.operations.*/_count -X POST -d "$myqs" | get_count_from_json )
+    echo "logs_count_is_gt: $myqs $actual gt $expected ?" | artifact_out
     test $actual -gt $expected
 }
 
@@ -46,8 +71,12 @@ else
     warn_nonformatted $essvc '/project.*'
     warn_nonformatted $esopssvc '/.operations.*/'
 
-    os::cmd::expect_success_and_not_text "curl_es $esopssvc /.operations.*/_count?q=kubernetes.event.verb:* | get_count_from_json" "^0\$"
-    prev_event_count=$( curl_es $esopssvc /.operations.*/_count?q=kubernetes.event.verb:* | get_count_from_json )
+    qs='{"query":{"wildcard":{"kubernetes.event.verb":"*"}}}'
+    escapedqs='{\"query\":{\"wildcard\":{\"kubernetes.event.verb\":\"*\"}}}'
+    os::cmd::try_until_success "logs_count_is_gt 0 $escapedqs" $FLUENTD_WAIT_TIME
+    prev_event_count=$( curl_es $esopssvc /.operations.*/_count -X POST -d "$qs" | get_count_from_json )
+    echo "prev_event_count: $prev_event_count $qs $prev_event_count" | artifact_out
+    fpod=$( get_running_pod fluentd )
 
     # utilize mux if mux pod exists
     if oc get dc/logging-mux > /dev/null 2>&1 ; then
@@ -56,17 +85,34 @@ else
         os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
         oc set env ds/logging-fluentd MUX_CLIENT_MODE=maximal 2>&1 | artifact_out
         oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
-        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-        os::cmd::try_until_success "logs_count_is_gt $prev_event_count"
-        prev_event_count=$( curl_es $esopssvc /.operations.*/_count?q=kubernetes.event.verb:* | get_count_from_json )
+        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running " $FLUENTD_WAIT_TIME
+        os::cmd::try_until_success "logs_count_is_gt $prev_event_count $escapedqs" $FLUENTD_WAIT_TIME
+        prev_event_count=$( curl_es $esopssvc /.operations.*/_count -X POST -d "$qs" | get_count_from_json )
 
         # MUX_CLIENT_MODE: minimal; oc set env restarts logging-fluentd
         oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
         os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
         oc set env ds/logging-fluentd MUX_CLIENT_MODE=minimal 2>&1 | artifact_out
         oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
-        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running "
-        os::cmd::try_until_success "logs_count_is_gt $prev_event_count"
+        os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running " $FLUENTD_WAIT_TIME
+        os::cmd::try_until_success "logs_count_is_gt $prev_event_count $escapedqs" $FLUENTD_WAIT_TIME
     fi
 
+    # Check if there's no duplicates
+    qs='{"query":{"bool":{"must":[{"match_phrase":{"kubernetes.event.verb":"ADDED"}},{"match":{"message":"'"${fpod}"'"}}]}},"_source":["kubernetes.event.metadata.uid","message"]}'
+    escapedqs='{\"query\":{\"bool\":{\"must\":[{\"match_phrase\":{\"kubernetes.event.verb\":\"ADDED\"}}\,{\"match\":{\"message\":\"'\"${fpod}\"'\"}}]}}\,\"_source\":[\"kubernetes.event.metadata.uid\"\,\"message\"]}'
+    echo "$fpod" | artifact_out
+    echo "$qs" | artifact_out
+    echo "$escapedqs" | artifact_out
+    os::cmd::try_until_success "logs_count_is_gt 0 $escapedqs" $FLUENTD_WAIT_TIME
+    curl_es $esopssvc /.operations.*/_search -X POST -d "$qs" | python -mjson.tool | artifact_out
+    ids=$( curl_es $esopssvc /.operations.*/_search -X POST -d "$qs" | python -mjson.tool | egrep uid | awk '{print $2}' | sed -e "s/\"//g" )
+    for id in $ids; do
+      qs='{"query":{"match_phrase":{"kubernetes.event.metadata.uid":"'"${id}"'"}}}'
+      artifact_log "$id search ----------------------"
+      curl_es $esopssvc /.operations.*/_search -X POST -d "$qs" | python -mjson.tool | artifact_out
+      artifact_log "$id count ----------------------"
+      curl_es $esopssvc /.operations.*/_count -X POST -d "$qs" | get_count_from_json | artifact_out
+      os::cmd::expect_success_and_text "curl_es $esopssvc /.operations.*/_count -X POST -d '$qs' | get_count_from_json" "^1\$"
+    done
 fi


### PR DESCRIPTION
… verb UPDATE

Adding a plugin filter_elasticsearch_genid_ext.rb, which extends filter_
elasticsearch_genid.rb from fluent-plugin-elasticsearch.  The extended plugin
takes config parameter alt_key as shown in filter-post-genid.conf.
  <filter **>
    @type elasticsearch_genid_ext
    hash_id_key viaq_msg_id
    alt_key kubernetes.event.metadata.uid
    alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.kube-eventrouter-*.** kubernetes.journal.container._default_.kubernetes.event'}"
  </filter>
The plugin does -
  1. If the tag matches the alt_tags list or not,
  2. If it does, it checks the alt_key exists in the record hash as the key.
     As the key is kubernetes.event.metadata.uid, it checks
     record[kubernetes][event][metadata][uid] exists or not.
  3. If it exists, viaq_msg_id is set to the value.
  4. Otherwise, the generated hash value is set. This is the default behaviour.

Note: the value of kubernetes.event.metadata.uid is shared among the event logs
originated from the same one event.  By using the value for the elasticsearch
primary key, duplicated logs are not to be indexed in the elasticsearch.

For testing, code to check there is no duplicated value of kubernetes.event.
metadata.uid is added to test/eventrouter.sh.

Additionally, the tag of the event logs via journald used to be
  kubernetes.journal.container._kube-eventrouter_
which is changed to
  kubernetes.journal.container._default_.kubernetes.event

(cherry picked from commit a995992b85ce4fd53e1ea7354ebd95a7dd992174)

https://bugzilla.redhat.com/show_bug.cgi?id=1641166

Cherry-picked: https://github.com/openshift/origin-aggregated-logging/pull/1424