### PR TITLE
[3.11] Bug 1613722 - Eventrouter creates duplicated events every 30 min with…

### DIFF
--- a/fluentd/configs.d/openshift/filter-post-genid.conf
+++ b/fluentd/configs.d/openshift/filter-post-genid.conf
@@ -4,5 +4,5 @@
   @type elasticsearch_genid_ext
   hash_id_key viaq_msg_id
   alt_key kubernetes.event.metadata.uid
-  alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.kube-eventrouter-*.** kubernetes.journal.container.kubernetes-event'}"
+  alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'}"
 </filter>

--- a/fluentd/configs.d/openshift/filter-retag-journal.conf
+++ b/fluentd/configs.d/openshift/filter-retag-journal.conf
@@ -60,7 +60,7 @@
   # we filter these logs through the kibana_transform.conf filter
   rewriterule1 CONTAINER_NAME ^k8s_kibana\. kubernetes.journal.container.kibana
   # mark eventrouter events
-  rewriterule2 CONTAINER_NAME ^k8s_[^_]+_logging-eventrouter-[^_]+_ kubernetes.journal.container._default_.kubernetes.event
+  rewriterule2 CONTAINER_NAME ^k8s_[^_]+_logging-eventrouter-[^_]+_ kubernetes.journal.container._default_.kubernetes-event
   # mark logs from default namespace for processing as k8s logs but stored as system logs
   rewriterule3 CONTAINER_NAME ^k8s_[^_]+_[^_]+_default_ kubernetes.journal.container._default_
   # mark logs from kube-* namespaces for processing as k8s logs but stored as system logs

--- a/fluentd/lib/filter_elasticsearch_genid_ext/test/filter_elasticsearch_genid_ext_test.rb
+++ b/fluentd/lib/filter_elasticsearch_genid_ext/test/filter_elasticsearch_genid_ext_test.rb
@@ -2,7 +2,7 @@ require 'fluent/test'
 require 'test/unit/rr'
 require 'json'
 
-require File.join(File.dirname(__FILE__), '..', 'lib/filter_elasticsearch_genid_ext') 
+require File.join(File.dirname(__FILE__), '..', 'lib/filter_elasticsearch_genid_ext')
 
 class ElasticsearchGenidExtFilterTest < Test::Unit::TestCase
   include Fluent
@@ -28,14 +28,14 @@ class ElasticsearchGenidExtFilterTest < Test::Unit::TestCase
     d.run {
       d.emit_with_tag(tag, record, @time)
     }.filtered.instance_variable_get(:@record_array)[0]
-  end  
+  end
 
   sub_test_case 'configure' do
     test 'check setting all params to non-default values' do
       d = create_driver('
         hash_id_key viaq_msg_id
         alt_key kubernetes.event.metadata.uid
-        alt_tags "kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container.kubernetes-event"
+        alt_tags "kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event"
       ')
       assert_equal('viaq_msg_id', d.instance.hash_id_key)
       assert_equal('kubernetes.event.metadata.uid', d.instance.alt_key)
@@ -63,7 +63,7 @@ class ElasticsearchGenidExtFilterTest < Test::Unit::TestCase
       rec = emit_with_tag('kubernetes.var.log.containers.logging-eventrouter-9876543210', record, '
         hash_id_key viaq_msg_id
         alt_key key.subkey
-        alt_tags "kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container.kubernetes-event"
+        alt_tags "kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event"
       ')
       assert_not_equal('0123456789', rec["viaq_msg_id"])
     end
@@ -80,7 +80,7 @@ class ElasticsearchGenidExtFilterTest < Test::Unit::TestCase
       rec = emit_with_tag('kubernetes.var.log.containers.logging-eventrouter-9876543210', record, '
         hash_id_key viaq_msg_id
         alt_key key.subkey
-        alt_tags "kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container.kubernetes-event"
+        alt_tags "kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event"
       ')
       assert_equal('0123456789', rec["viaq_msg_id"])
     end


### PR DESCRIPTION
… verb UPDATE

Replacing the eventrouter journald tag
  kubernetes.journal.container._default_.kubernetes.event
with
  kubernetes.journal.container._default_.kubernetes-event

Plus bug fixes.

(cherry picked from commit 51b68c15eed1c6637d4ec998cf566411775212fc)

https://bugzilla.redhat.com/show_bug.cgi?id=1613722

Manually cherrypicked: https://github.com/openshift/origin-aggregated-logging/pull/1434