### PR TITLE
LOG-226. Use nonresourceurl for prometheus metrics

### DIFF
--- a/elasticsearch/sgconfig/sg_config.yml
+++ b/elasticsearch/sgconfig/sg_config.yml
@@ -18,10 +18,8 @@ searchguard:
           config:
              subjectAccessReviews:
                prometheus:
-                 namespace: openshift-logging
-                 verb: view
-                 resource: prometheus
-                 resourceAPIGroup: metrics.openshift.io
+                 verb: get
+                 resource: /metrics
       authentication_domain_basic_internal:
         enabled: true
         order: 1


### PR DESCRIPTION
This PR fixex https://jira.coreos.com/browse/LOG-226
* By consuming the dependency that supports the SAR change
* Modifying the SAR that we expect to be deployed by cluster-monitoring-operator

blocked by https://github.com/fabric8io/openshift-elasticsearch-plugin/pull/161

cc @ewolinetz @richm 