### PR TITLE
revert curator to 5.2.0 because of missing downstream dependencies

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -13,7 +13,7 @@ ENV HOME=/opt/app-root/src \
     CURATOR_ACTIONS_FILE=/etc/curator/settings/actions.yaml \
     CURATOR_LOG_LEVEL=ERROR \
     CURATOR_SCRIPT_LOG_LEVEL=INFO \
-    CURATOR_VER=5.5.4 \
+    CURATOR_VER=5.2.0 \
     CURATOR_TIMEOUT=300 \
     container=oci
 

--- a/curator/Dockerfile.centos7
+++ b/curator/Dockerfile.centos7
@@ -13,7 +13,7 @@ ENV HOME=/opt/app-root/src \
     CURATOR_ACTIONS_FILE=/etc/curator/settings/actions.yaml \
     CURATOR_LOG_LEVEL=ERROR \
     CURATOR_SCRIPT_LOG_LEVEL=INFO \
-    CURATOR_VER=5.5.4 \
+    CURATOR_VER=5.2 \
     CURATOR_TIMEOUT=300
 
 LABEL io.k8s.description="Curator elasticsearch container for elasticsearch deletion/archival" \


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/ART-257  To fix downstream build that is missing dependencies

cc @adammhaile 