### PR TITLE
Bug 1650005 - Fluentd pod should log its logs to /var/log/fluentd/flu…

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -19,13 +19,14 @@ done
 echo "============================="
 echo "Fluentd logs have been redirected to: $LOGGING_FILE_PATH"
 echo "If you want to print out the logs, use command:"
-echo "oc exec <pod_name> $HOME/utils/logs"
+echo "oc exec <pod_name> -- logs"
 echo "============================="
 
 dirname=$( dirname $LOGGING_FILE_PATH )
 if [ ! -d $dirname ] ; then
     mkdir -p $dirname
 fi
+touch $LOGGING_FILE_PATH; exec >> $LOGGING_FILE_PATH 2>&1
 fluentdargs="--no-supervisor -o $LOGGING_FILE_PATH --log-rotate-age $LOGGING_FILE_AGE --log-rotate-size $LOGGING_FILE_SIZE"
 # find the sniffer class file
 sniffer=$( gem contents fluent-plugin-elasticsearch|grep elasticsearch_simple_sniffer.rb )


### PR DESCRIPTION
…entd.log by default

Fixing the logs utility path.

Making the output of the run.sh script go to the /var/log/fluentd/fluentd.log file.

(cherry picked from commit 97e9399cb114637660540323a1a3d24f3d3816f8)

https://bugzilla.redhat.com/show_bug.cgi?id=1650005
 Fluentd pod should log its logs to /var/log/fluentd/fluentd.log by default