### PR TITLE
Fixes for Mac OS users.

### DIFF
--- a/hack/logging-dump.sh
+++ b/hack/logging-dump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
@@ -15,6 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+if (( ${BASH_VERSION%%.*} < 4 ));
+then
+  echo "You need bash version higher than 4 to run this script."
+  exit 1
+fi
+
 set -euo pipefail
 if [ -n "${DEBUG:-}" ] ; then
     set -x


### PR DESCRIPTION
As a mac user, you get a bash version 3.* and [line 158](https://stackoverflow.com/questions/39726784/syntax-error-near-unexpected-token-when-using-redirection-operator) is failing.
Then you need to install it with `brew`.
And bash installed with `brew` leaves in `/usr/local/bin/bash`