### PR TITLE
support running tests against local libvirt machine

### DIFF
--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -25,6 +25,9 @@
 source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 
+# clear cert cache
+rm -rf ${OS_O_A_L_DIR}/temp/es_certs
+
 LOGGING_NS=openshift-logging
 if oc get project logging -o name > /dev/null && [ $(oc get dc -n logging -o name | wc -l) -gt 0 ]  ; then
     LOGGING_NS=logging

--- a/test/zzz-rsyslog.sh
+++ b/test/zzz-rsyslog.sh
@@ -97,9 +97,7 @@ mv $tmpvars $ARTIFACT_DIR/vars_file
 
 popd > /dev/null
 
-pushd /etc
-sudo tar cf - rsyslog.conf rsyslog.d | (cd $ARTIFACT_DIR; tar xf -)
-popd > /dev/null
+sudo tar -C /etc -cf $ARTIFACT_DIR/rsyslog-after-ansible.tar rsyslog.conf rsyslog.d
 
 get_logmessage() {
     logmessage="$1"


### PR DESCRIPTION
Now that api.ci is regularly publishing the latest rpm packages
and images, we no longer require an aws devenv.  This commit
allows devs to stand up and run tests against a local "devenv"
style libvirt machine.

Requirements: a CentOS7 VM with at least 12GB RAM, 40GB disk,
and 4 CPUs.  Can probably be made to work on a smaller vm.
The VM should be set up with the following:

- the machine has an fqdn, not just a local 192.168.122.x IP address e.g.
  you have added an /etc/hosts entry for the machine - this is useful
  when you don't want to or cannot use an external resolver like xip.io
- can ssh as root into the machine with no password, which usually
  means the machine /root/.ssh/authorized_keys has your ssh pub key
- your host has NFS exported your $HOME (or source root) directory, and
  has mapped root to your local uid/gid (default 1000) e.g.

```
  /etc/exports.d/home.exports:
  /home/myusername	192.168.0.0/255.255.0.0(rw,all_squash,anonuid=1000,anongid=1000)
```

- your machine has NFS mounted this export as `/share` inside the VM:

```
  /etc/fstab:
  192.168.122.1:/home/myusername    /share          nfs     nfsvers=3       0 0
```