### PR TITLE
Dockerfile FROM 5.6.13

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:5.6.12
+FROM elasticsearch:5.6.13
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 


### PR DESCRIPTION
The base image version needs to match the plugins, right? Getting errors in downstream builds.