### PR TITLE
[3.10] eventrouter v0.2 + get-machine-run-tests.sh fixes

### DIFF
--- a/hack/get-machine-run-tests.sh
+++ b/hack/get-machine-run-tests.sh
@@ -212,6 +212,8 @@ update_etc_hosts $ip $fqdn $kibana_host $kibana_ops_host
 oct sync local origin-aggregated-logging --branch $GIT_BRANCH --merge-into ${GIT_BASE_BRANCH:-master} --src $GIT_REPO_BASE_DIR/origin-aggregated-logging
 # seems to be a bug currently - doesn't checkout branch other than master - so force it to make sure
 ssh -n openshiftdevel "cd $OS_O_A_L_DIR; git checkout ${GIT_BASE_BRANCH:-master}"
+# also doesn't handle submodules very well
+ssh -n openshiftdevel "cd $OS_O_A_L_DIR; git submodule sync; git submodule update --init --recursive --remote"
 #oct sync remote openshift-ansible --branch master
 oct sync local openshift-ansible --branch $ANSIBLE_BRANCH --merge-into ${ANSIBLE_BASE_BRANCH:-master} --src $GIT_REPO_BASE_DIR/openshift-ansible
 # seems to be a bug currently - doesn't checkout branch other than master - so force it to make sure
@@ -542,7 +544,15 @@ ANSIBLE_LOG_PATH=/tmp/ansible-origin.log ansible-playbook -vvv --become         
   -e oreg_url='openshift/origin-\${component}:'"${OPENSHIFT_IMAGE_TAG:-\$( cat ./ORIGIN_IMAGE_TAG )}" \
   -e openshift_node_port_range=30000-32000 \
   -e 'osm_controller_args={"enable-hostpath-provisioner":["true"]}' -e @sjb/inventory/base.cfg \
-  -e skip_sanity_checks=true -e 'openshift_disable_check=*' -e openshift_install_examples=false \
+  -e openshift_install_examples=false \
+  -e openshift_master_public_api_url="https://$fqdn:8443" \
+  -e openshift_master_public_console_url="https://$fqdn:8443/console" \
+  -e openshift_logging_master_public_url="https://$fqdn:8443" \
+  -e openshift_master_logging_public_url="https://$kibana_host" \
+  -e openshift_master_cluster_public_hostname=$fqdn \
+  -e openshift_console_install=False \
+  -e openshift_cli_image="openshift/origin-node:${OPENSHIFT_IMAGE_TAG:-\$( cat ./ORIGIN_IMAGE_TAG )}" \
+  \${EXTRA_ANSIBLE_OPENSHIFT:-} \
   \${playbook}
 EOF
 scp $runfile openshiftdevel:/tmp


### PR DESCRIPTION
manual cherrypick of https://github.com/openshift/origin-aggregated-logging/pull/1472