### PR TITLE
bug 1652224. Fix defaultIndex for Kibana uprade

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -13,7 +13,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     INSTANCE_RAM=512G \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.13.1-redhat-1 \
+    OSE_ES_VER=5.6.13.2-redhat-1 \
     PROMETHEUS_EXPORTER_VER=5.6.13.1-redhat-1 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -22,7 +22,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     RELEASE_STREAM=prod \
     container=oci
 
-ARG OSE_ES_VER=5.6.13.1-redhat-1
+ARG OSE_ES_VER=5.6.13.2-redhat-1
 ARG OSE_ES_URL
 ARG PROMETHEUS_EXPORTER_VER=5.6.13.1-redhat-1
 ARG PROMETHEUS_EXPORTER_URL

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -14,7 +14,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_VER=1.8.0 \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.13.1 \
+    OSE_ES_VER=5.6.13.2 \
     PROMETHEUS_EXPORTER_VER=5.6.13.1 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -22,7 +22,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     RECOVER_AFTER_TIME=5m \
     RELEASE_STREAM=origin
 
-ARG OSE_ES_VER=5.6.13.1
+ARG OSE_ES_VER=5.6.13.2
 ARG SG_VER=5.6.13-19.2
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \


### PR DESCRIPTION
This bug fixes https://bugzilla.redhat.com/show_bug.cgi?id=1652224 by making sure their exists a current kibana config object for a user's kibana index.

Started here since master  CI is not functional.  Will need to be cherrypicked foward  into master

blocked by https://github.com/fabric8io/openshift-elasticsearch-plugin/pull/166