### PR TITLE
Define kibana index replication correctly

### DIFF
--- a/elasticsearch/index_templates/common.settings.kibana.template.json
+++ b/elasticsearch/index_templates/common.settings.kibana.template.json
@@ -1,8 +1,8 @@
 {
   "order": 0,
   "settings": {
-    "number_of_replicas": $REPLICA_SHARDS,
-    "number_of_shards": $PRIMARY_SHARDS
+    "index.number_of_replicas": $REPLICA_SHARDS,
+    "index.number_of_shards": $PRIMARY_SHARDS
   },
   "template": ".kibana*"
 }


### PR DESCRIPTION
This PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=1667801 by properly defining the setting for replica shards.

will need cherrypick into master