### PR TITLE
Secure ES metrics endpoint with auth proxy

### DIFF
--- a/elasticsearch/sgconfig/sg_roles_mapping.yml
+++ b/elasticsearch/sgconfig/sg_roles_mapping.yml
@@ -17,6 +17,7 @@ sg_role_curator:
 sg_role_admin:
   users:
     - 'CN=system.admin,OU=OpenShift,O=Logging'
+
 sg_role_prometheus:
   backendroles:
     - 'prometheus'


### PR DESCRIPTION
ES uses self-signed CA, which isn't trusted by external components,
namely Prometheus. To tackle this, we're adding a side-car proxy
in front of ES, that speak TLS to the outside and its certs are
signed by the openshift signing service. Communication between
the proxy and ES happens within the same network namespace.