### PR TITLE
must now use apiVersion: template.openshift.io/v1 for Templates

### DIFF
--- a/hack/kopf/logging-es-kopf-template.yaml
+++ b/hack/kopf/logging-es-kopf-template.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   name: logging-es-kopf
   annotations:

--- a/hack/templates/dev-builds.yaml
+++ b/hack/templates/dev-builds.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: "Template"
 metadata:
   name: logging-dev-build-template

--- a/hack/templates/pv-hostmount.yaml
+++ b/hack/templates/pv-hostmount.yaml
@@ -1,4 +1,4 @@
-apiVersion: "v1"
+apiVersion: template.openshift.io/v1
 kind: "Template"
 metadata:
   name: logging-pv-template

--- a/hack/templates/pv-nfs.yaml
+++ b/hack/templates/pv-nfs.yaml
@@ -1,4 +1,4 @@
-apiVersion: "v1"
+apiVersion: template.openshift.io/v1
 kind: "Template"
 metadata:
   name: logging-pv-template

--- a/hack/testing/templates/fluentd_dc.yaml
+++ b/hack/testing/templates/fluentd_dc.yaml
@@ -1,4 +1,4 @@
-apiVersion: "v1"
+apiVersion: template.openshift.io/v1
 kind: "Template"
 metadata:
   name: logging-fluentd-template-maker

--- a/hack/testing/templates/logging-ci-test-runner-template.yaml
+++ b/hack/testing/templates/logging-ci-test-runner-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: logging-ci-test-runner-template

--- a/hack/testing/templates/test-template.yaml
+++ b/hack/testing/templates/test-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: test-template


### PR DESCRIPTION
must now use apiVersion: template.openshift.io/v1 for Templates
when was support for apiVersion: v1 dropped?
it was deprecated in 3.4
it was dropped with the k8s 1.12 rebase