### PR TITLE
Add cluster manage role to curator

### DIFF
--- a/elasticsearch/sgconfig/sg_roles.yml
+++ b/elasticsearch/sgconfig/sg_roles.yml
@@ -35,6 +35,7 @@ sg_role_rsyslog:
 sg_role_curator:
   cluster:
     - CLUSTER_MONITOR
+    - MANAGE
   indices:
     '*':
       '*':


### PR DESCRIPTION
Jaeger uses curator to delete indices, create templates and aliases.

The aliases and templates are cluster roles https://www.elastic.co/guide/en/shield/2.2/privileges-list.html

With the original curator configuration, I get 403:
```
// crate template
{"error":{"root_cause":[{"type":"security_exception","reason":"no permissions for [indices:admin/template/put] and User [name=CN=system.logging.curator,OU=OpenShift,O=Logging, roles=[]]"}],"type":"security_exception","reason":"no permissions for [indices:admin/template/put] and User [name=CN=system.logging.curator,OU=OpenShift,O=Logging, roles=[]]"},"status":403}

// crete alias
curator.exceptions.FailedExecution: Exception encountered.  Rerun with loglevel DEBUG and/or check Elasticsearch logs for more information. Exception: AuthorizationException(403, 'security_exception', 'no permissions for [indices:admin/aliases] and User [name=CN=system.logging.curator,OU=OpenShift,O=Logging, roles=[]]')
```




Signed-off-by: Pavol Loffay <ploffay@redhat.com>