### PR TITLE
Bug 1684048 - Newly introduced log-rotation in fluentd not working

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -58,6 +58,7 @@ RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
     chmod 777 /etc/fluent/configs.d/dynamic && \
     ln -s /etc/fluent/configs.d/user/fluent.conf /etc/fluent/fluent.conf
 
+ADD patch/logger/log.rb patch/logger/supervisor.rb ${HOME}/
 # for some reason, this isn't able to be loaded from the gem
 RUN if [ ! -d /etc/fluent/plugin ] ; then \
       mkdir -p /etc/fluent/plugin ; \
@@ -67,10 +68,12 @@ RUN if [ ! -d /etc/fluent/plugin ] ; then \
         echo Error: sniffer not found - possibly not using rubygem-fluent-plugin-elasticsearch 1.17.2 or later ; \
     else \
         cp $sniffer /etc/fluent/plugin/ ; \
-    fi
+    fi ; \
+    logrbpath=$( gem contents fluentd | grep lib/fluent/log.rb\$ ) ; \
+    suprbpath=$( gem contents fluentd | grep lib/fluent/supervisor.rb\$ ) ; \
+    cp ${HOME}/log.rb $logrbpath ; \
+    cp ${HOME}/supervisor.rb $suprbpath
 
-ADD patch/logger/log.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
-ADD patch/logger/supervisor.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 COPY utils/** /usr/local/bin/
 
 WORKDIR ${HOME}

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -61,8 +61,7 @@ ADD filter_k8s_meta_for_mux_client.rb /etc/fluent/plugin/
 ADD out_syslog_buffered.rb out_syslog.rb /etc/fluent/plugin/
 ADD parser_viaq_docker_audit.rb viaq_docker_audit.rb /etc/fluent/plugin/
 ADD run.sh generate_throttle_configs.rb generate_syslog_config.rb ${HOME}/
-ADD patch/logger/log.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
-ADD patch/logger/supervisor.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
+ADD patch/logger/log.rb patch/logger/supervisor.rb ${HOME}/
 COPY utils/** /usr/local/bin/
 
 RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
@@ -73,7 +72,11 @@ RUN if [ ! -d /etc/fluent/plugin ] ; then \
       mkdir -p /etc/fluent/plugin ; \
     fi ; \
     sniffer=$( gem contents fluent-plugin-elasticsearch|grep elasticsearch_simple_sniffer.rb ) ; \
-    cp $sniffer /etc/fluent/plugin/
+    cp $sniffer /etc/fluent/plugin/ ; \
+    logrbpath=$( gem contents fluentd | grep lib/fluent/log.rb\$ ) ; \
+    suprbpath=$( gem contents fluentd | grep lib/fluent/supervisor.rb\$ ) ; \
+    cp ${HOME}/log.rb $logrbpath ; \
+    cp ${HOME}/supervisor.rb $suprbpath
 
 WORKDIR ${HOME}
 USER 0


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1684048

Cause: The files that implement the new log rotation
functionality were not being copied to the correct
fluentd directory.
    
Consequence: Fluentd was not using log rotation and its log
files were not being rotated.

Fix: Change the container build to inspect the fluentd
gem to find out where to install the files.
    
Result: The files that implement log rotation are
copied to the correct directory for fluentd to use.