### PR TITLE
bug 1679864. Allow cluster admins to retrieve indice list

### DIFF
--- a/elasticsearch/sgconfig/sg_action_groups.yml
+++ b/elasticsearch/sgconfig/sg_action_groups.yml
@@ -84,10 +84,11 @@ INDEX_OPERATIONS:
   - INDEX_ANY_ADMIN
 INDEX_ANY_OPERATIONS:
   - INDEX_ANY_ADMIN
+  - INDICES_MONITOR
 INDEX_PROJECT:
   - INDEX_ANY_ADMIN
   - INDEX_ALL
-  
+
 METRICS:
   - cluster:monitor/prometheus/metrics
   - cluster:monitor/nodes/stats


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1679864