### PR TITLE
Bug 1686941 - Newly introduced log-rotation in fluentd not working

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -63,6 +63,7 @@ RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
     chmod 777 /etc/fluent/configs.d/dynamic && \
     ln -s /etc/fluent/configs.d/user/fluent.conf /etc/fluent/fluent.conf
 
+ADD patch/logger/log.rb patch/logger/supervisor.rb ${HOME}/
 # for some reason, this isn't able to be loaded from the gem
 RUN if [ ! -d /etc/fluent/plugin ] ; then \
       mkdir -p /etc/fluent/plugin ; \
@@ -72,10 +73,12 @@ RUN if [ ! -d /etc/fluent/plugin ] ; then \
         echo Error: sniffer not found - possibly not using rubygem-fluent-plugin-elasticsearch 1.17.2 or later ; \
     else \
         cp $sniffer /etc/fluent/plugin/ ; \
-    fi
+    fi ; \
+    logrbpath=$( gem contents fluentd | grep lib/fluent/log.rb\$ ) ; \
+    suprbpath=$( gem contents fluentd | grep lib/fluent/supervisor.rb\$ ) ; \
+    cp ${HOME}/log.rb $logrbpath ; \
+    cp ${HOME}/supervisor.rb $suprbpath
 
-ADD patch/logger/log.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
-ADD patch/logger/supervisor.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
 COPY utils/** /usr/local/bin/
 
 WORKDIR ${HOME}

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -63,8 +63,7 @@ ADD run.sh generate_syslog_config.rb ${HOME}/
 ADD lib/generate_throttle_configs/lib/*.rb ${HOME}/
 ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
 ADD lib/filter_elasticsearch_genid_ext/lib/filter_elasticsearch_genid_ext.rb /etc/fluent/plugin/
-ADD patch/logger/log.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
-ADD patch/logger/supervisor.rb ${GEM_HOME}/gems/fluentd-0.12.43/lib/fluent/
+ADD patch/logger/log.rb patch/logger/supervisor.rb ${HOME}/
 ADD lib/filter_concat/lib/filter_concat.rb /etc/fluent/plugin/
 COPY utils/** /usr/local/bin/
 ADD patch/in_prometheus.rb ${GEM_HOME}/gems/fluent-plugin-prometheus-0.4.0/lib/fluent/plugin/
@@ -77,7 +76,11 @@ RUN if [ ! -d /etc/fluent/plugin ] ; then \
       mkdir -p /etc/fluent/plugin ; \
     fi ; \
     sniffer=$( gem contents fluent-plugin-elasticsearch|grep elasticsearch_simple_sniffer.rb ) ; \
-    cp $sniffer /etc/fluent/plugin/
+    cp $sniffer /etc/fluent/plugin/ ; \
+    logrbpath=$( gem contents fluentd | grep lib/fluent/log.rb\$ ) ; \
+    suprbpath=$( gem contents fluentd | grep lib/fluent/supervisor.rb\$ ) ; \
+    cp ${HOME}/log.rb $logrbpath ; \
+    cp ${HOME}/supervisor.rb $suprbpath
 
 WORKDIR ${HOME}
 USER 0


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1686941
Cause: The files that implement the new log rotation
functionality were not being copied to the correct
fluentd directory.

Consequence: Fluentd was not using log rotation and its log
files were not being rotated.

Fix: Change the container build to inspect the fluentd
gem to find out where to install the files.

Result: The files that implement log rotation are
copied to the correct directory for fluentd to use.

cherrypick of https://github.com/openshift/origin-aggregated-logging/pull/1529
(cherry picked from commit 99d29508213fbb6f6642c75898caacc29edec5e4)
(cherry picked from commit 8e7b2e1eb2eb490e165552a1fc2b13319b49ab84)