### PR TITLE
add support for new fluentd viaq filter undefined fields

### DIFF
--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -11,6 +11,9 @@ Following are the environment variables that can be modified to adjust the confi
 | `LOGGING_FILE_PATH` | The log file absolute path where Fluentd is writting its logs. If you want Fluentd to output its logs as Fluentd does by default (`STDOUT`) set this variable to `console` value. Default value is `/var/log/fluentd/fluentd.log`. | `LOGGING_FILE_PATH=console` |
 | `LOGGING_FILE_AGE` | Number of log files that Fluentd keeps before deleting the oldest file. Default value is `10`. | `LOGGING_FILE_AGE=30` |
 | `LOGGING_FILE_SIZE` | Maximum size of a Fluentd log file in bytes. If the size of the log file is bigger, the log file gets rotated. Default is 1MB | `LOGGING_FILE_PATH=1024000`
+| `CDM_UNDEFINED_TO_STRING` | When `MERGE_JSON_LOG=true` - see below (Default: false) | `CDM_UNDEFINED_TO_STRING=true` |
+| `CDM_UNDEFINED_DOT_REPLACE_CHAR` | When `MERGE_JSON_LOG=true` - see below (Default: UNUSED) | `CDM_UNDEFINED_DOT_REPLACE_CHAR=_` |
+| `CDM_UNDEFINED_MAX_NUM_FIELDS` | When `MERGE_JSON_LOG=true` - see below (Default: -1) | `CDM_UNDEFINED_MAX_NUM_FIELDS=500` |
 
 ## Cri-o Formatted Container Logs
 In order to enable cri-o logs parsing, it is necessary to mount
@@ -29,6 +32,20 @@ whether to setup `in_tail` plugin to parse cri-o formatted logs in
 Fluentd by default writes its logs into a file given by `LOGGING_FILE_PATH` environment variable. You can change the maximum size of a single log file or number of log files to keep(age), by setting `LOGGING_FILE_SIZE` and `LOGGING_FILE_AGE` environment variables accordingly.
 
 If you want Fluentd to output its logs as Fluentd does by default (`STDOUT`) set the `LOGGING_FILE_PATH` variable to `console` value.
+
+## MERGE_JSON_LOG and undefined field handling
+
+For background information, see [viaq filter plugin docs](https://github.com/ViaQ/fluent-plugin-viaq_data_model#undefined_to_string)
+Using `MERGE_JSON_LOG=true` is problematic in a number of ways.
+One of the problems with storing data in Elasticsearch is that it really requires you to have strict control over the fields and the number of fields being stored. You typically have to define a strict input pipeline for formatting the data, and define index templates to specify the type of data. If you are dealing with unstructured data, you run into the risk that you have a field named fieldname which in some records has a string value, but in other documents may have an int value or a value of some other data type.  Using `CDM_UNDEFINED_TO_STRING=true` will
+force all undefined fields to have a string value (their JSON string interpretation) so that no conflicts like this may arise.  The default
+value is `false`, so if you have this problem, set the value to `true`.
+
+Another problem with storing data in Elasticsearch is that it will interpret a field name like "foo.bar" to mean a Hash (Object type in Elasticsearch).  This causes problems if the application emits logs with a string valued field "foo", and a hash valued field "foo.bar". The only way to automatically solve this problem is by converting "foo.bar" to be "foo_bar", and using `CDM_UNDEFINED_DOT_REPLACE_CHAR=_` to convert both values to string.  The default value is `UNUSED` which means `foo.bar` is kept, so if you have this problem, set the value to `_` or some
+other "safe" value.
+
+Another problem with storing data in Elasticsearch is that there is an upper limit to the number of fields it can store without causing performance problems. `CDM_UNDEFINED_MAX_NUM_FIELDS` is used to set an upper bound on the number of undefined fields in a single record. If the record contains more than this many undefined fields, no further processing will take place on these fields. Instead, the fields will be converted to a single string JSON value, and will be stored in a top level field named with the value of the `CDM_UNDEFINED_NAME` parameter (default "undefined").  The default value is `-1`, which means all fields are kept, so if you have this problem, set the value to `500`, or
+a smaller number if you know exactly how many fields your application logs will produce.
 
 ## Utilities
 ### sanitize_msg_chunks

--- a/fluentd/configs.d/openshift/filter-viaq-data-model.conf
+++ b/fluentd/configs.d/openshift/filter-viaq-data-model.conf
@@ -1,6 +1,6 @@
 <filter **>
   @type viaq_data_model
-  default_keep_fields CEE,docker,file,geoip,hostname,kubernetes,level,message,offset,pid,pipeline_metadata,rsyslog,service,systemd,tags,time,ovirt,collectd,tlog,aushape,namespace_name,namespace_uuid
+  default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
   extra_keep_fields "#{ENV['CDM_EXTRA_KEEP_FIELDS'] || ''}"
   keep_empty_fields "#{ENV['CDM_KEEP_EMPTY_FIELDS'] || 'message'}"
   use_undefined "#{ENV['CDM_USE_UNDEFINED'] || false}"
@@ -10,6 +10,9 @@
   src_time_name "#{ENV['CDM_SRC_TIME_NAME'] || 'time'}"
   dest_time_name "#{ENV['CDM_DEST_TIME_NAME'] || '@timestamp'}"
   pipeline_type "#{ENV['PIPELINE_TYPE'] || 'collector'}"
+  undefined_to_string "#{ENV['CDM_UNDEFINED_TO_STRING'] || 'false'}"
+  undefined_dot_replace_char "#{ENV['CDM_UNDEFINED_DOT_REPLACE_CHAR'] || 'UNUSED'}"
+  undefined_max_num_fields "#{ENV['CDM_UNDEFINED_MAX_NUM_FIELDS'] || '-1'}"
   <formatter>
     enabled false
     tag "audit.log**"

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -325,7 +325,7 @@ function wait_for_fluentd_to_catch_up() {
         sudo cat /var/log/journal.pos
         # records since start of function
         errqs='{"query":{"range":{"@timestamp":{"gte":"'"$( date --date=@${starttime} -u -Ins )"'"}}}}'
-        curl_es ${es_pod} /${logging_index}/_search -X POST -d "$errqs" | jq . > $ARTIFACT_DIR/apps_err_recs.json 2>&1 || :
+        curl_es ${es_svc} /${logging_index}/_search -X POST -d "$errqs" | jq . > $ARTIFACT_DIR/apps_err_recs.json 2>&1 || :
         rc=1
     fi
 
@@ -338,7 +338,7 @@ function wait_for_fluentd_to_catch_up() {
         fi
     else
         os::log::error $FUNCNAME: not found $expected record .operations for $uuid_es_ops after $timeout seconds
-        curl_es ${es_ops_svc} /.operations.*/_search -X POST -d "$qs" > $ARTIFACT_DIR/apps_search_output.raw 2>&1 || :
+        curl_es ${es_ops_svc} /.operations.*/_search -X POST -d "$qs" > $ARTIFACT_DIR/ops_search_output.raw 2>&1 || :
         os::log::error "Checking journal for $uuid_es_ops..."
         if [ -s $ARTIFACT_DIR/es_ops_out.txt ] ; then
             os::log::error "$( cat $ARTIFACT_DIR/es_ops_out.txt )"
@@ -349,7 +349,7 @@ function wait_for_fluentd_to_catch_up() {
         sudo cat /var/log/journal.pos
         # records since start of function
         errqs='{"query":{"range":{"@timestamp":{"gte":"'"$( date --date=@${starttime} -u -Ins )"'"}}}}'
-        curl_es ${es_ops_pod} /.operations.*/_search -X POST -d "$errqs" | jq . > $ARTIFACT_DIR/ops_err_recs.json 2>&1 || :
+        curl_es ${es_ops_svc} /.operations.*/_search -X POST -d "$errqs" | jq . > $ARTIFACT_DIR/ops_err_recs.json 2>&1 || :
         rc=1
     fi
 

--- a/test/json-parsing.sh
+++ b/test/json-parsing.sh
@@ -14,6 +14,30 @@ if [ -n "${DEBUG:-}" ] ; then
     set -x
 fi
 
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
+
+stop_fluentd() {
+  artifact_log at this point there should be 1 fluentd running in Running state
+  oc get pods 2>&1 | artifact_out
+  local fpod=$( get_running_pod fluentd )
+  oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
+  os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+  artifact_log at this point there should be no fluentd running - number ready is 0
+  oc get pods 2>&1 | artifact_out
+  # for some reason, in this test, after .status.numberReady is 0, the fluentd pod hangs around
+  # in the Terminating state for many seconds, which seems to cause problems with subsequent tests
+  # so, we have to wait for the pod to completely disappear - we cannot rely on .status.numberReady == 0
+  if [ -n "${fpod:-}" ] ; then
+    os::cmd::try_until_failure "oc get pod $fpod > /dev/null 2>&1" $FLUENTD_WAIT_TIME
+  fi
+}
+
+start_fluentd() {
+  sudo rm -f /var/log/fluentd/fluentd.log
+  oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
+  os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running " $FLUENTD_WAIT_TIME
+}
+
 cleanup() {
     local return_code="$?"
     set +e
@@ -27,9 +51,25 @@ cleanup() {
     if [ -n "${fpod:-}" ] ; then
         get_fluentd_pod_log > $ARTIFACT_DIR/json-parsing-fluentd-pod.log
     fi
+
     sudo ls -alrtF /var/lib/fluentd 2>&1 | artifact_out
     sudo docker info | grep -i log 2>&1 | artifact_out
     sudo ls -alrtF /var/log/containers 2>&1 | artifact_out
+
+    stop_fluentd
+    if [ "${orig_MERGE_JSON_LOG:-}" = unset ] ; then
+        orig_MERGE_JSON_LOG="MERGE_JSON_LOG-"
+    fi
+    if [ "${orig_CDM_UNDEFINED_TO_STRING:-}" = unset ] ; then
+        orig_CDM_UNDEFINED_TO_STRING="CDM_UNDEFINED_TO_STRING-"
+    fi
+    if [ -n "${orig_MERGE_JSON_LOG:-}" -o -n "${orig_CDM_UNDEFINED_TO_STRING:-}" ] ; then
+        stop_fluentd
+        oc set env daemonset/logging-fluentd ${orig_MERGE_JSON_LOG:-} ${orig_CDM_UNDEFINED_TO_STRING:-}
+        start_fluentd
+    fi
+
+
     # this will call declare_test_end, suite_end, etc.
     os::test::junit::reconcile_output
     exit $return_code
@@ -37,6 +77,19 @@ cleanup() {
 trap "cleanup" EXIT
 
 os::log::info Starting json-parsing test at $( date )
+
+# enable merge json log
+orig_MERGE_JSON_LOG=$( oc set env daemonset/logging-fluentd --list | grep \^MERGE_JSON_LOG= ) || :
+if [ -z "$orig_MERGE_JSON_LOG" ] ; then
+    orig_MERGE_JSON_LOG=unset
+fi
+orig_CDM_UNDEFINED_TO_STRING=$( oc set env daemonset/logging-fluentd --list | grep \^CDM_UNDEFINED_TO_STRING= ) || :
+if [ -z "$orig_CDM_UNDEFINED_TO_STRING" ] ; then
+    orig_CDM_UNDEFINED_TO_STRING=unset
+fi
+stop_fluentd
+oc set env daemonset/logging-fluentd MERGE_JSON_LOG=true CDM_UNDEFINED_TO_STRING=false
+start_fluentd
 
 # generate a log message in the Kibana logs - Kibana log messages are in JSON format:
 # {"type":"response","@timestamp":"2017-04-07T02:03:37Z","tags":[],"pid":1,"method":"get","statusCode":404,"req":{"url":"/ca30cead-d470-4db8-a2a2-bb71439987e2","method":"get","headers":{"user-agent":"curl/7.29.0","host":"localhost:5601","accept":"*/*"},"remoteAddress":"127.0.0.1","userAgent":"127.0.0.1"},"res":{"statusCode":404,"responseTime":3,"contentLength":9},"message":"GET /ca30cead-d470-4db8-a2a2-bb71439987e2 404 3ms - 9.0B"}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1686947
cherry-pick of https://github.com/openshift/origin-aggregated-logging/pull/1554
add support for new fluentd viaq filter undefined fields
keeps the default values the same as what we have now, namely
- do not automatically convert undefined fields to string
- do not convert `.` to `_` in undefined field names
- no maximum number of fields

We don't want to break users who might be doing just fine
with the defaults, but we want to give users the ability
to turn on these knobs.

Cause: Using MERGE_JSON_LOG=true can create fields in the
record which will cause schema and syntax violations in
Elasticsearch.  It can also create too many fields for
Elasticsearch to handle without severe performance problems.

Consequence: Fluentd reports error 400 sending records to
Elasticsearch.  Elasticsearch performance degrades.

Fix: Allow users who experience these problems to tune their
Fluentd to accomodate their log record fields.

Result: Logs are ingested into Fluentd with no errors.
Elasticsearch performance does not degrade.

(cherry picked from commit f59ebef7e182d479d56cd1ea7c4958e2abeb8dc4)
(cherry picked from commit b8981c2a95ae3629f5fbe6f8f0155c2a7704bf01)