### PR TITLE
Do not change jaeger CN in SearchGuard config

### DIFF
--- a/elasticsearch/init/0001-jaeger
+++ b/elasticsearch/init/0001-jaeger
@@ -22,7 +22,6 @@ info "Starting init script: ${script}"
 
 if [ -n "${NAMESPACE:-}" ] ; then
  sed -i -e 's/namespace:.*/namespace: '"$NAMESPACE"'/' ${HOME}/sgconfig/sg_config.yml
- sed -i -e 's/user.jaeger/user.'"$NAMESPACE"'.jaeger/' ${HOME}/sgconfig/sg_roles_mapping.yml
 else
   error "NAMESPACE variable is not set. Failed to substitute it in Jaeger SearchGuard config"
 fi


### PR DESCRIPTION
We don't have to change jaeger CN based on namespace because every
jaeger instance will have different CA/key certs.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>