### PR TITLE
use default of 2 for flush_thread_count

### DIFF
--- a/fluentd/configs.d/filter-pre-mux-client.conf
+++ b/fluentd/configs.d/filter-pre-mux-client.conf
@@ -16,7 +16,7 @@
     @type file
     path '/var/lib/fluentd/buffer-mux-client'
     flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
-    flush_thread_count "#{ENV['FORWARD_FLUSH_THREAD_COUNT'] || 1}"
+    flush_thread_count "#{ENV['FORWARD_FLUSH_THREAD_COUNT'] || 2}"
     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"

--- a/fluentd/configs.d/openshift/output-es-config.conf
+++ b/fluentd/configs.d/openshift/output-es-config.conf
@@ -31,7 +31,7 @@
         @type file
         path '/var/lib/fluentd/buffer-output-es-config'
         flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
-        flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 1}"
+        flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
         retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
         retry_forever true

--- a/fluentd/configs.d/openshift/output-es-ops-config.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-config.conf
@@ -31,7 +31,7 @@
         @type file
         path '/var/lib/fluentd/buffer-output-es-ops-config'
         flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '1s'}"
-        flush_thread_count "#{ENV['OPS_FLUSH_THREAD_COUNT'] || ENV['ES_FLUSH_THREAD_COUNT'] || 1}"
+        flush_thread_count "#{ENV['OPS_FLUSH_THREAD_COUNT'] || ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
         retry_max_interval "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
         retry_forever true

--- a/fluentd/configs.d/openshift/output-es-ops-retry.conf
+++ b/fluentd/configs.d/openshift/output-es-ops-retry.conf
@@ -29,7 +29,7 @@
         @type file
         path '/var/lib/fluentd/es-ops-retry'
         flush_interval "#{ENV['OPS_FLUSH_INTERVAL'] || ENV['ES_FLUSH_INTERVAL'] || '1s'}"
-        flush_thread_count "#{ENV['OPS_FLUSH_THREAD_COUNT'] || ENV['ES_FLUSH_THREAD_COUNT'] || 1}"
+        flush_thread_count "#{ENV['OPS_FLUSH_THREAD_COUNT'] || ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
         retry_max_interval "#{ENV['OPS_RETRY_WAIT'] || ENV['ES_RETRY_WAIT'] || '300'}"
         retry_forever true

--- a/fluentd/configs.d/openshift/output-es-retry.conf
+++ b/fluentd/configs.d/openshift/output-es-retry.conf
@@ -29,7 +29,7 @@
         @type file
         path '/var/lib/fluentd/es-retry'
         flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
-        flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 1}"
+        flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
         retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
         retry_forever true

--- a/fluentd/configs.d/user/secure-forward.conf
+++ b/fluentd/configs.d/user/secure-forward.conf
@@ -16,6 +16,7 @@
 #     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 #     flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 #     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
+#     flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
 #     retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
 #     retry_forever true
 #     # the systemd journald 0.0.8 input plugin will just throw away records if the buffer


### PR DESCRIPTION
This will get rid of the message
```
2019-03-21 20:27:25 +0000 [warn]: To prevent events traffic jam, you should specify 2 or more 'flush_thread_count'.
```