### PR TITLE
testing - fix marketplace api group and version

### DIFF
--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -35,8 +35,8 @@ fi
 export LOGGING_NS
 
 # if using operators, turn off the managed state
-if oc get clusterlogging example > /dev/null 2>&1 ; then
-    oc patch -n ${LOGGING_NS} clusterlogging example --type=json --patch '[
+if oc get clusterlogging instance > /dev/null 2>&1 ; then
+    oc patch -n ${LOGGING_NS} clusterlogging instance --type=json --patch '[
           {"op":"replace","path":"/spec/managementState","value":"Unmanaged"}]'
 fi
 
@@ -44,7 +44,7 @@ fluentd_ds=$( get_fluentd_ds_name )
 oc get -n ${LOGGING_NS} $fluentd_ds -o yaml > "${ARTIFACT_DIR}/logging-fluentd-orig.yaml"
 
 # patch fluentd and the node to make it easier to test in new environment
-if oc get clusterlogging example > /dev/null 2>&1 ; then
+if oc get clusterlogging instance > /dev/null 2>&1 ; then
     tolerations="$( oc get -n ${LOGGING_NS} $fluentd_ds -o jsonpath='{.spec.template.spec.tolerations}' )"
     if [ -n "$tolerations" ] ; then
         oc patch -n ${LOGGING_NS} $fluentd_ds --type=json --patch '[
@@ -54,7 +54,7 @@ if oc get clusterlogging example > /dev/null 2>&1 ; then
     if [ -z "$nodesel" ] ; then
         oc patch -n ${LOGGING_NS} $fluentd_ds --type=json --patch '[
             {"op":"add","path":"/spec/template/spec/nodeSelector","value":{"logging-infra-fluentd":"true"}}]'
-        oc patch -n ${LOGGING_NS} clusterlogging example --type=json --patch '[
+        oc patch -n ${LOGGING_NS} clusterlogging instance --type=json --patch '[
             {"op":"add","path":"/spec/collection/logs/fluentd/nodeSelector","value":{"logging-infra-fluentd":"true"}},
             {"op":"add","path":"/spec/collection/logs/rsyslog/nodeSelector","value":{"logging-infra-rsyslog":"true"}}]'
     fi

--- a/openshift/ci-operator/build-image/cluster-logging-catalogsourceconfig.yaml
+++ b/openshift/ci-operator/build-image/cluster-logging-catalogsourceconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: "marketplace.redhat.com/v1alpha1"
+apiVersion: "operators.coreos.com/v1"
 kind: "CatalogSourceConfig"
 metadata:
   name: "cluster-logging"

--- a/openshift/ci-operator/build-image/cr.yaml
+++ b/openshift/ci-operator/build-image/cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: "logging.openshift.io/v1alpha1"
 kind: "ClusterLogging"
 metadata:
-  name: "example"
+  name: "instance"
 spec:
   managementState: "Managed"
   logStore:

--- a/openshift/ci-operator/build-image/elasticsearch-catalogsourceconfig.yaml
+++ b/openshift/ci-operator/build-image/elasticsearch-catalogsourceconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: "marketplace.redhat.com/v1alpha1"
+apiVersion: "operators.coreos.com/v1"
 kind: "CatalogSourceConfig"
 metadata:
   name: "elasticsearch"

--- a/test/zzz-rsyslog.sh
+++ b/test/zzz-rsyslog.sh
@@ -55,13 +55,13 @@ cleanup() {
     else
         rpod=$( get_running_pod rsyslog )
         oc logs $rpod > $ARTIFACT_DIR/rsyslog-rsyslog.log 2>&1
-        oc patch clusterlogging example --type=json \
+        oc patch clusterlogging instance --type=json \
             --patch '[{"op":"replace","path":"/spec/collection/logs/type","value":"fluentd"},
                       {"op":"replace","path":"/spec/managementState","value":"Managed"}]' 2>&1 | artifact_out
         oc label node --all logging-infra-rsyslog-
         os::cmd::try_until_failure "oc get pods $rpod > /dev/null 2>&1"
         start_fluentd true 2>&1 | artifact_out
-        oc patch clusterlogging example --type=json \
+        oc patch clusterlogging instance --type=json \
             --patch '[{"op":"replace","path":"/spec/managementState","value":"Unmanaged"}]' 2>&1 | artifact_out
         sleep 10
     fi
@@ -125,12 +125,12 @@ EOF
 deploy_using_operators() {
     # edit the operator - change logcollector type to rsyslog
     oc label node -l logging-ci-test=true --overwrite logging-infra-rsyslog=true 2>&1 | artifact_out
-    oc patch clusterlogging example --type=json \
+    oc patch clusterlogging instance --type=json \
         --patch '[{"op":"replace","path":"/spec/collection/logs/type","value":"rsyslog"},
                   {"op":"replace","path":"/spec/managementState","value":"Managed"}]' 2>&1 | artifact_out
     os::cmd::try_until_success "oc get pods 2> /dev/null | grep -q 'rsyslog.*Running'"
     rpod=$( get_running_pod rsyslog )
-    oc patch clusterlogging example --type=json \
+    oc patch clusterlogging instance --type=json \
         --patch '[{"op":"replace","path":"/spec/managementState","value":"Unmanaged"}]' 2>&1 | artifact_out
     sleep 10
     os::cmd::try_until_success "oc get cm rsyslog 2> /dev/null"


### PR DESCRIPTION
testing - fix marketplace api group and version
fix recent CI failures due to change of Marketplace APIs
(OperatorSource and CatalogSourceConfig) to
operators.coreos.com/v1 from marketplace.redhat.com/v1alpha1
error messages look like this:
```
error: unable to recognize "openshift/ci-operator/build-image/elasticsearch-catalogsourceconfig.yaml": no matches for kind "CatalogSourceConfig" in version "marketplace.redhat.com/v1alpha1"
```