### PR TITLE
make rsyslog build OS agnostic

### DIFF
--- a/rsyslog/Dockerfile
+++ b/rsyslog/Dockerfile
@@ -1,26 +1,17 @@
 FROM registry.svc.ci.openshift.org/ocp/4.0:base as builder
 
 # get pkg list from rpmspec -q --buildrequires vendored_src/*/*.spec | sort -u
-RUN yum install -y --setopt=tsflags=nodocs \
-      make redhat-rpm-config rpm-build \
-      autoconf automake bison chrpath cyrus-sasl-devel \
-      flex gcc gcc-c++ gnutls-devel krb5-devel libcurl-devel \
-      libgcrypt-devel libtool libuuid-devel lz4-devel \
-      mariadb-devel mariadb-connector-c-devel net-snmp-devel \
-      pcre-devel pkgconfig postgresql-devel python-sphinx \
-      python3 python3-docutils python3-sphinx \
-      systemd-devel zlib-devel && \
-    yum clean all
-
+ADD install-builder-packages.sh /tmp
+RUN cd /tmp && ./install-builder-packages.sh
 ADD vendored_src/ /vendored_src/
 ADD install-from-src.sh /vendored_src/
 RUN cd /vendored_src && ./install-from-src.sh
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 
-COPY --from=builder /vendored_src/RPMS/ /RPMS/
+COPY --from=builder /RPMS/ /RPMS/
 
-RUN yum -y install /RPMS/*/*.rpm && \
+RUN yum -y install /RPMS/*.rpm && \
     rm -rf /RPMS && \
     yum clean all
 

--- a/rsyslog/install-builder-packages.sh
+++ b/rsyslog/install-builder-packages.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+rhelver=""
+if [ -f /etc/redhat-release ] ; then
+    rhelver=$( sed 's/^Red Hat Enterprise Linux Server release \([1-9][0-9]*\)[.].*$/\1/' /etc/redhat-release )
+fi
+# get pkg list from rpmspec -q --buildrequires vendored_src/*/*.spec | sort -u
+PKGLIST="make redhat-rpm-config rpm-build \
+      autoconf automake bison chrpath cyrus-sasl-devel \
+      flex gcc gcc-c++ gnutls-devel krb5-devel libcurl-devel \
+      libgcrypt-devel libtool libuuid-devel lz4-devel \
+      net-snmp-devel pcre-devel pkgconfig postgresql-devel \
+      systemd-devel zlib-devel"
+if [ "$rhelver" = 7 ] ; then
+    PKGLIST="$PKGLIST mariadb-devel python-sphinx"
+else
+    PKGLIST="$PKGLIST mariadb-connector-c-devel python3 python3-docutils python3-sphinx"
+fi
+yum -y install $PKGLIST
+rpm -V $PKGLIST
+yum clean all


### PR DESCRIPTION
rsyslog build needs a different set of packages for RHEL7 and
RHEL8.  Add a script install-builder-packages.sh to determine
which OS is being used and install the packages for that OS.
Also cleans up the builder script so that only packages that
aren't already installed are installed.