### PR TITLE
[3.10] Fluentd doesn't output it's logs to STDOUT when LOGGING_FILE_PATH=con…

### DIFF
--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -10,7 +10,7 @@ Following are the environment variables that can be modified to adjust the confi
 | `OCP_OPERATIONS_PROJECTS`| The list of project or patterns for which messages will be sent to the operations indices|`OCP_OPERATIONS_PROJECTS="default openshift openshift-"`|
 | `LOGGING_FILE_PATH` | The log file absolute path where Fluentd is writting its logs. If you want Fluentd to output its logs as Fluentd does by default (`STDOUT`) set this variable to `console` value. Default value is `/var/log/fluentd/fluentd.log`. | `LOGGING_FILE_PATH=console` |
 | `LOGGING_FILE_AGE` | Number of log files that Fluentd keeps before deleting the oldest file. Default value is `10`. | `LOGGING_FILE_AGE=30` |
-| `LOGGING_FILE_SIZE` | Maximum size of a Fluentd log file in bytes. If the size of the log file is bigger, the log file gets rotated. Default is 1MB | `LOGGING_FILE_PATH=1024000`
+| `LOGGING_FILE_SIZE` | Maximum size of a Fluentd log file in bytes. If the size of the log file is bigger, the log file gets rotated. Default is 1MB | `LOGGING_FILE_SIZE=1024000`
 | `CDM_UNDEFINED_TO_STRING` | When `MERGE_JSON_LOG=true` - see below (Default: false) | `CDM_UNDEFINED_TO_STRING=true` |
 | `CDM_UNDEFINED_DOT_REPLACE_CHAR` | When `MERGE_JSON_LOG=true` - see below (Default: UNUSED) | `CDM_UNDEFINED_DOT_REPLACE_CHAR=_` |
 | `CDM_UNDEFINED_MAX_NUM_FIELDS` | When `MERGE_JSON_LOG=true` - see below (Default: -1) | `CDM_UNDEFINED_MAX_NUM_FIELDS=500` |

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -3,6 +3,7 @@
 export MERGE_JSON_LOG=${MERGE_JSON_LOG:-true}
 CFG_DIR=/etc/fluent/configs.d
 OCP_OPERATIONS_PROJECTS=${OCP_OPERATIONS_PROJECTS:-"default openshift openshift-"}
+LOGGING_FILE_PATH=${LOGGING_FILE_PATH:-"/var/log/fluentd/fluentd.log"}
 OCP_FLUENTD_TAGS=""
 for p in ${OCP_OPERATIONS_PROJECTS}; do
     if [[ "${p}" == *- ]] ; then
@@ -15,16 +16,19 @@ for file in ${ocp_fluentd_files} ; do
     sed -i -e "s/%OCP_FLUENTD_TAGS%/${OCP_FLUENTD_TAGS}/" $file
 done
 
-echo "============================="
-echo "Fluentd logs have been redirected to: $LOGGING_FILE_PATH"
-echo "If you want to print out the logs, use command:"
-echo "oc exec <pod_name> -- logs"
-echo "============================="
+if [ ${LOGGING_FILE_PATH} != "console" ] ; then
+    echo "============================="
+    echo "Fluentd logs have been redirected to: $LOGGING_FILE_PATH"
+    echo "If you want to print out the logs, use command:"
+    echo "oc exec <pod_name> -- logs"
+    echo "============================="
 
-if [ ! -d `dirname $LOGGING_FILE_PATH` ]; then
-  mkdir -p `dirname $LOGGING_FILE_PATH`
+    dirname=$( dirname $LOGGING_FILE_PATH )
+    if [ ! -d $dirname ] ; then
+        mkdir -p $dirname
+    fi
+    touch $LOGGING_FILE_PATH; exec >> $LOGGING_FILE_PATH 2>&1
 fi
-touch $LOGGING_FILE_PATH; exec >> $LOGGING_FILE_PATH 2>&1
 
 fluentdargs="--no-supervisor"
 if [[ $VERBOSE ]]; then


### PR DESCRIPTION
…sole

Release 3.10 - https://bugzilla.redhat.com/show_bug.cgi?id=1693043

Putting the code for "Fluentd logs have been redirected to: $LOGGING_FILE_PATH"
into the 'if [ ${LOGGING_FILE_PATH} != "console" ]' clause.

(cherry picked from commit 3085651c49b01f3108071c640bf164a67a17c4db)