### PR TITLE
bug 1694884. Kibana default pattern

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -13,7 +13,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     INSTANCE_RAM=512G \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.13.3-redhat-1 \
+    OSE_ES_VER=5.6.13.4-redhat-1 \
     PROMETHEUS_EXPORTER_VER=5.6.13.1-redhat-1 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     container=oci
 
-ARG OSE_ES_VER=5.6.13.3-redhat-1
+ARG OSE_ES_VER=5.6.13.4-redhat-1
 ARG OSE_ES_URL
 ARG PROMETHEUS_EXPORTER_VER=5.6.13.1-redhat-1
 ARG PROMETHEUS_EXPORTER_URL

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -14,7 +14,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_VER=1.8.0 \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.13.3 \
+    OSE_ES_VER=5.6.13.4 \
     PROMETHEUS_EXPORTER_VER=5.6.13.1 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     RELEASE_STREAM=origin
 
-ARG OSE_ES_VER=5.6.13.3
+ARG OSE_ES_VER=5.6.13.4
 ARG SG_VER=5.6.13-19.2
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \


### PR DESCRIPTION
This PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=1694884 by pulling in the latest openshift-elasticsearch-plugin to default the kibana index-pattern

blocked by https://github.com/fabric8io/openshift-elasticsearch-plugin/pull/170