### PR TITLE
Fix typo of random_string

### DIFF
--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -123,7 +123,7 @@ module Fluent
             break
           }
         end
-        if @packet.tag.eql? random_string
+        if @packet.tag.eql? @random_string
           @packet.tag = tag[0..31] # tag is trimmed to 32 chars for syslog_protocol gem compatibility
         end
         packet = @packet.dup


### PR DESCRIPTION
To fix this error:
```
[warn]: emit transaction failed: error_class=NameError error="undefined local variable or method `random_string' for #<Fluent::SyslogOutput:0x007f553ed585c8>" location="/etc/fluent/plugin/out_syslog.rb:126:in `block in emit'"
```