### PR TITLE
bug 1667801. Fix kibana index replicas

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -13,7 +13,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     INSTANCE_RAM=512G \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.13.4-redhat-1 \
+    OSE_ES_VER=5.6.13.5-redhat-1 \
     PROMETHEUS_EXPORTER_VER=5.6.13.1-redhat-1 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     container=oci
 
-ARG OSE_ES_VER=5.6.13.4-redhat-1
+ARG OSE_ES_VER=5.6.13.5-redhat-1
 ARG OSE_ES_URL
 ARG PROMETHEUS_EXPORTER_VER=5.6.13.1-redhat-1
 ARG PROMETHEUS_EXPORTER_URL

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -14,7 +14,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_VER=1.8.0 \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.13.4 \
+    OSE_ES_VER=5.6.13.5 \
     PROMETHEUS_EXPORTER_VER=5.6.13.1 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     RELEASE_STREAM=origin
 
-ARG OSE_ES_VER=5.6.13.4
+ARG OSE_ES_VER=5.6.13.5
 ARG SG_VER=5.6.13-19.2
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \

--- a/elasticsearch/init/0530-bz1667801-fix-kibana-replica-shards
+++ b/elasticsearch/init/0530-bz1667801-fix-kibana-replica-shards
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright 2019 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# init script to cleanup kibana indicies to have
+# N replicas as defined by REPLICA_SHARD to resolve:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1667801
+set -eu
+
+if [ -n "${DEBUG:-}" ] ; then
+  set -x
+fi
+
+source "logging"
+
+script=$(basename $0)
+
+info "Starting init script: ${script}"
+replicas=${REPLICA_SHARDS:-0}
+
+tot_indices=$(es_util --query=".kibana*/_settings/index.number_of_replicas?pretty" | grep number_of_replicas | grep -v "\"number_of_replicas\" : \"$replicas\"" | wc -l)
+info "Found ${tot_indices} Kibana indices with replica count not equal to $replicas"
+
+if [ $tot_indices -ne 0 ] ; then
+  info "Updating all Kibana indices settings to have replica count: $replicas"
+  response=$(es_util --query='.kibana*/_settings?pretty' -XPUT -d "{\"index\":{\"number_of_replicas\":$replicas}}")
+  if [ $? -ne 0 ] ; then
+    error "Error updating the Kibana indices replica count: $response"
+  fi
+fi
+
+info "Completed init script: ${script}"

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -46,7 +46,7 @@ fluentd_ds=$( get_fluentd_ds_name )
 oc get -n ${LOGGING_NS} $fluentd_ds -o yaml > "${ARTIFACT_DIR}/logging-fluentd-orig.yaml"
 
 # patch fluentd and the node to make it easier to test in new environment
-if oc get clusterlogging instance > /dev/null 2>&1 ; then
+if oc -n ${LOGGING_NS} get clusterlogging instance > /dev/null 2>&1 ; then
     tolerations="$( oc get -n ${LOGGING_NS} $fluentd_ds -o jsonpath='{.spec.template.spec.tolerations}' )"
     if [ -n "$tolerations" ] ; then
         oc patch -n ${LOGGING_NS} $fluentd_ds --type=json --patch '[

--- a/hack/testing/test-0530-bz1667801-fix-kibana-replica-shards
+++ b/hack/testing/test-0530-bz1667801-fix-kibana-replica-shards
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec ${OS_O_A_L_DIR}/test/0530-bz1667801-fix-kibana-replica-shards

--- a/test/0530-bz1667801-fix-kibana-replica-shards
+++ b/test/0530-bz1667801-fix-kibana-replica-shards
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# test init script tests cleanup of old SG indices
+# https://bugzilla.redhat.com/show_bug.cgi?id=1658632
+LOGGING_NS=${LOGGING_NS:-openshift-logging}
+
+if [ -n "${DEBUG:-}" ] ; then
+    set -x
+fi
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+source "${OS_O_A_L_DIR}/elasticsearch/init/common"
+
+os::util::environment::use_sudo
+
+test_name=$(basename $0)
+init_script="0530-bz1667801-fix-kibana-replica-shards"
+os::test::junit::declare_suite_start ${test_name}
+
+cleanup() {
+    local return_code="$?"
+    set +e
+    if [ $return_code = 0 ] ; then
+        mycmd=os::log::info
+    else
+        mycmd=os::log::error
+    fi
+    $mycmd ${test_name} test finished at $( date )
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
+
+seed_data(){
+  os::log::info Seeding data for the test
+  local pod=$1
+  names=(abc123 xyz123 zzz123)
+  for n in "${names[@]}"
+  do
+    index=".kibana.$n"
+    os::log::info Creating index $index
+    result=$(oc -n ${LOGGING_NS} exec -c elasticsearch $pod -- es_util --query=$index -XPUT -d '{"settings": {"index":{"number_of_replicas":"2"}}}')
+    if echo $result | grep -q error ; then
+      os::log::error Error seeding indices: $result
+      exit 1
+    fi
+  done
+}
+
+os::log::info Starting ${test_name} test at $( date )
+
+espod=$( get_es_pod es )
+cmd="oc exec -c elasticsearch -n ${LOGGING_NS} $espod"
+
+# remove existing indices
+os::log::info Remove existing kibana indices
+os::cmd::expect_success "$cmd -- es_util --query=.kibana.* -XDELETE"
+sleep 1
+
+# verify no matches indices is a no-op and script succeeds
+os::log::info 'Verify init script with no matching indices'
+os::cmd::expect_success "$cmd -- /usr/share/elasticsearch/init/$init_script"
+
+# verify indices are removed
+os::log::info "Verify init script with some kibana indices"
+seed_data $espod
+sleep 3
+script='REPLICA_SHARDS=1'
+script="$script /usr/share/elasticsearch/init/$init_script"
+os::cmd::expect_success "$cmd -- bash -c '$script'"
+sleep 3
+
+#verify indices updated
+count=$($cmd -- es_util --query='.kibana.*/_settings/index.number_of_replicas?pretty' | grep '"number_of_replicas" : "1"' | wc -l)
+if [ $count -ne 3 ] ; then
+    os::log::error Kibana indices with number_of_replicas:1 should be 3 but is $count
+    $cmd -- es_util --query='.kibana*/_settings/index.number_of_replicas?pretty' 2>&1 | artifact_out
+    exit 1
+fi


### PR DESCRIPTION
This PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=1667801 by:

* Pulling in new openshift-elasticsearch-plugin
* Rely on template to set kibana index replicas
* Adds test to fix existing kibana indices

blocked by https://github.com/fabric8io/openshift-elasticsearch-plugin/pull/171