### PR TITLE
LOG-400 - rsyslog - support log rotation for rsyslog log files

### DIFF
--- a/rsyslog/Dockerfile
+++ b/rsyslog/Dockerfile
@@ -24,12 +24,14 @@ FROM registry.svc.ci.openshift.org/ocp/4.0:base
 
 COPY --from=builder /RPMS/ /RPMS/
 
-RUN yum -y install /RPMS/*.rpm && \
+RUN yum -y install /RPMS/*.rpm cronie && \
     rm -rf /RPMS && \
     yum clean all
 
 ADD install.sh /bin/install.sh
 ADD rsyslog.sh /bin/rsyslog.sh
 ADD uninstall.sh /bin/uninstall.sh
+COPY utils/** /usr/local/bin/
+RUN sed -i -e 's,\(session[ 	]*required[ 	]*pam_loginuid.so\),\#\1,' /etc/pam.d/crond
 
 CMD [ "/bin/rsyslog.sh" ]

--- a/rsyslog/Dockerfile.fedora
+++ b/rsyslog/Dockerfile.fedora
@@ -5,6 +5,7 @@ MAINTAINER https://github.com/ViaQ/rsyslog-container
 RUN dnf -y install rsyslog rsyslog-elasticsearch \
     rsyslog-mmkubernetes rsyslog-mmjsonparse rsyslog-kafka \
     rsyslog-mmnormalize rsyslog-relp rsyslog-gssapi \
+    cronie \
     && dnf clean all
 
 LABEL install="docker run --rm --privileged -v /:/host \
@@ -33,5 +34,6 @@ LABEL run="docker run -d --privileged --name NAME \
 ADD install.sh /bin/install.sh
 ADD rsyslog.sh /bin/rsyslog.sh
 ADD uninstall.sh /bin/uninstall.sh
+COPY utils/** /usr/local/bin/
 
 CMD [ "/bin/rsyslog.sh" ]

--- a/rsyslog/README.md
+++ b/rsyslog/README.md
@@ -1,2 +1,25 @@
 # rsyslog-container
-container for rsyslog, based on fedora
+[Rsyslog](https://www.rsyslog.com/) is the log collector that resides on each Openshift node to gather application and node logs
+
+## Configuration
+Following are the environment variables that can be modified to adjust the configuration:
+
+| Environment Variable | Description |Example|
+|----------------------|-------------|---|
+| `MERGE_JSON_LOG`     | **DEPRECATED** Parse JSON log messages and merge them into the JSON payload to be indexed to Elasticsearch. **Default:** false | `MERGE_JSON_LOG=true`|
+| `LOGGING_FILE_PATH` | The log file absolute path where Rsyslog is writting its logs. If you want rsyslog to output its logs as Rsyslog does by default (`STDOUT`) set this variable to `console` value. Default value is `/var/log/rsyslog/rsyslog.log`. | `LOGGING_FILE_PATH=console` |
+| `LOGGING_FILE_AGE` | Number of log files that Rsyslog keeps before deleting the oldest file. Default value is `10`. | `LOGGING_FILE_AGE=30` |
+| `LOGGING_FILE_SIZE` | Maximum size of a rsyslog log file in bytes. If the size of the log file is bigger, the log file gets rotated. Default is 1MB | `LOGGING_FILE_SIZE=1024000`
+
+## Rsyslog logging to file
+Rsyslog by default writes its logs into a file given by `LOGGING_FILE_PATH` environment variable. You can change the maximum size of a single log file or number of log files to keep(age), by setting `LOGGING_FILE_SIZE` and `LOGGING_FILE_AGE` environment variables accordingly.
+
+If you want Rsyslog to output its logs as Rsyslog does by default (`STDOUT`) set the `LOGGING_FILE_PATH` variable to `console` value.
+
+## Utilities
+### logs
+Print out the contents of Rsyslog log files.
+
+Contents of files stored in the directory where `LOGGING_FILE_PATH` is, are printed out. Starting with the oldest log. Using `-f` option you can follow what is being written into the logs.
+The default path where the logs are is `/var/log/rsyslog/`, default name of the log file is `rsyslog.log`.
+

--- a/rsyslog/utils/logs
+++ b/rsyslog/utils/logs
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+set -euo pipefail
+
+log_dir=`dirname ${LOGGING_FILE_PATH:-/var/log/rsyslog/rsyslog.log}`
+cmd=cat
+
+helpMsg() {
+cat <<MSG
+ Usage: $0 [options]
+ Retrieve Rsyslog logs from the log directory using "LOGGING_FILE_PATH" environment variable.
+   Options:
+     -f                   Follow the log file in the rsyslog log directory.
+                          Default log file is "rsyslog.log".
+     -h --help               Prints out help.
+MSG
+}
+
+
+while (($#))
+do
+case $1 in
+    -f)
+      cmd="tail"
+      tail_args="-f"
+      break
+      ;;
+    --help|-h)
+      helpMsg
+      exit 0
+      ;;
+    *)
+      ;;
+  esac
+  shift
+done
+
+if [ $cmd = "cat" ] ; then
+    for log_file in $( ls $log_dir | sort -Vr ); do
+        cat $log_dir/$log_file
+    done
+else
+    exec tail "$tail_args" $log_dir/rsyslog.log
+fi


### PR DESCRIPTION
Adding utils/logs to rsyslog
Including cronie for logrotate
To run crond in the foreground mode, /etc/pam.d/crond must not enable pam_loginuid.so module.