### PR TITLE
Do not install pyyaml 5.1

### DIFF
--- a/curator/Dockerfile.centos7
+++ b/curator/Dockerfile.centos7
@@ -25,7 +25,7 @@ RUN yum install -y epel-release && \
     rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
 RUN yum install -y --setopt=tsflags=nodocs \
         python-pip && \
-    pip install --no-cache-dir 'ruamel.yaml<=0.15' elasticsearch-curator==${CURATOR_VER} && \
+    pip install --no-cache-dir 'ruamel.yaml<=0.15' 'pyyaml<5.1' elasticsearch-curator==${CURATOR_VER}  && \
     yum clean all
 
 COPY run.sh lib/oalconverter/* ${HOME}/


### PR DESCRIPTION
Hi,

I build my images frequently and I get following error, with the new pyyaml 5.1 version.
```
019-04-15 01:30:08,330 INFO	Found curator configuration in [/etc/curator/settings/config.yaml]
2019-04-15 01:30:08,336 INFO	Converting config file.
/usr/lib/python2.7/site-packages/curator/utils.py:53: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  cfg = yaml.load(raw)
No handlers could be found for logger "curator.validators.SchemaCheck"
Traceback (most recent call last):
  File "/usr/bin/curator", line 9, in <module>
    load_entry_point('elasticsearch-curator==5.2.0', 'console_scripts', 'curator')()
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib64/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/curator/cli.py", line 211, in cli
    run(config, action_file, dry_run)
  File "/usr/lib/python2.7/site-packages/curator/cli.py", line 106, in run
    client_args = process_config(config)
  File "/usr/lib/python2.7/site-packages/curator/config_utils.py", line 45, in process_config
    config = test_config(yaml_file)
  File "/usr/lib/python2.7/site-packages/curator/config_utils.py", line 19, in test_config
    'Client Configuration', 'full configuration dictionary').result()
  File "/usr/lib/python2.7/site-packages/curator/validators/schemacheck.py", line 68, in result
    self.test_what, self.location, self.badvalue, self.error)
curator.exceptions.ConfigurationError: Configuration: Client Configuration: Location: full configuration dictionary: Bad Value: "{'certificate': '${ES_CA}', 'client_cert': '${ES_CLIENT_CERT}', 'hosts': ['${ES_HOST}'], 'timeout': '${CURATOR_TIMEOUT}', 'use_ssl': True, 'master_only': False, 'port': '${ES_PORT}', 'ssl_no_validate': False, 'client_key': '${ES_CLIENT_KEY}'}", not a valid value for dictionary value @ data['client']['port']. Check configuration file.
```
It's because of following deprecation https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

For me it's not really clear, why we pin curator to version 5.2. I think at some point curator will fix this. See https://github.com/elastic/curator/issues/1368. It seems curator waits for pyyaml 5.2 https://github.com/elastic/curator/issues/1368#issuecomment-474297539