### PR TITLE
Allow index templates to be reseeded with new replica and primary shard values

### DIFF
--- a/elasticsearch/init/0100-seed-index-templates
+++ b/elasticsearch/init/0100-seed-index-templates
@@ -21,7 +21,12 @@ info Adding index templates
 shopt -s failglob
 for template_file in ${ES_HOME}/index_templates/*.json
 do
-    sed -i "s,\$REPLICA_SHARDS,$REPLICA_SHARDS," $template_file
+    if [ -f ${template_file}.bkup ]; then
+      rm ${template_file}
+      mv ${template_file}.bkup ${template_file}
+    fi
+
+    sed -i.bkup "s,\$REPLICA_SHARDS,$REPLICA_SHARDS," $template_file
     sed -i "s,\$PRIMARY_SHARDS,$PRIMARY_SHARDS," $template_file
     template=`basename $template_file`
     # Check if index template already exists

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -126,7 +126,7 @@ for elasticsearch_pod in $( get_es_pod ${OAL_ELASTICSEARCH_COMPONENT} ); do
 	os::log::info "Checking that Elasticsearch pod ${elasticsearch_pod} contains common data model index templates..."
 	es_home="$( oc exec -c elasticsearch ${elasticsearch_pod} -- env | awk -F= '/^ES_HOME/ {print $2}')"
 	os::cmd::expect_success "oc exec -c elasticsearch ${elasticsearch_pod} -- ls -1 ${es_home}/index_templates"
-	for template in $( oc exec -c elasticsearch "${elasticsearch_pod}" -- ls -1 ${es_home}/index_templates ); do
+	for template in $( oc exec -c elasticsearch "${elasticsearch_pod}" -- ls -1 ${es_home}/index_templates | grep -v .bkup); do
 		os::cmd::expect_success_and_text "curl_es_pod '${elasticsearch_pod}' '/_template/${template}' --request HEAD --head --output /dev/null --write-out '%{response_code}'" '200'
 	done
 


### PR DESCRIPTION
Resolves inability to use workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1697728