### PR TITLE
Bug 1703118 - Per indice metrics missing in elasticsearch exporter

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -14,7 +14,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
     OSE_ES_VER=5.6.13.5-redhat-1 \
-    PROMETHEUS_EXPORTER_VER=5.6.13.1-redhat-1 \
+    PROMETHEUS_EXPORTER_VER=5.6.13.2-redhat-3 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
     RECOVER_EXPECTED_NODES=1 \
@@ -25,7 +25,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
 
 ARG OSE_ES_VER=5.6.13.5-redhat-1
 ARG OSE_ES_URL
-ARG PROMETHEUS_EXPORTER_VER=5.6.13.1-redhat-1
+ARG PROMETHEUS_EXPORTER_VER=5.6.13.2-redhat-3
 ARG PROMETHEUS_EXPORTER_URL
 ARG MAVEN_REPO_URL=http://download-node-02.eng.bos.redhat.com/brewroot/repos/lpc-rhel-7-maven-build/latest/maven/
 

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -15,7 +15,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
     OSE_ES_VER=5.6.13.5 \
-    PROMETHEUS_EXPORTER_VER=5.6.13.1 \
+    PROMETHEUS_EXPORTER_VER=5.6.13.2 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
     RECOVER_EXPECTED_NODES=1 \
@@ -53,7 +53,7 @@ ADD init.sh run.sh prep-install.${RELEASE_STREAM} install.sh ${HOME}/
 COPY utils/** /usr/local/bin/
 
 ARG OSE_ES_URL
-ARG PROMETHEUS_EXPORTER_URL=https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/${PROMETHEUS_EXPORTER_VER}/elasticsearch-prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
+ARG PROMETHEUS_EXPORTER_URL=https://github.com/lukas-vlcek/elasticsearch-prometheus-exporter/releases/download/${PROMETHEUS_EXPORTER_VER}/prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
 ARG SG_URL
 
 RUN ln -s /usr/local/bin/logging ${HOME}/logging && \

--- a/elasticsearch/prep-install.origin
+++ b/elasticsearch/prep-install.origin
@@ -3,6 +3,6 @@ if [ -z "${OSE_ES_URL:-}" ] ; then
    OSE_ES_URL=https://github.com/fabric8io/openshift-elasticsearch-plugin/releases/download/openshift-elasticsearch-plugin-${OSE_ES_VER}/openshift-elasticsearch-plugin-${OSE_ES_VER}.zip
 fi
 if [ -z "${PROMETHEUS_EXPORTER_URL:-}" ] ; then
-    PROMETHEUS_EXPORTER_URL=https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
+    PROMETHEUS_EXPORTER_URL=https://github.com/lukas-vlcek/elasticsearch-prometheus-exporter/releases/download/${PROMETHEUS_EXPORTER_VER}/prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
 fi
 es_plugins=($OSE_ES_URL $PROMETHEUS_EXPORTER_URL)


### PR DESCRIPTION
There is a new bug-fix release of ES Prometheus plugin.
Notice this release is not part of official upstream but is located in clone.