### PR TITLE
use openshift-operators-redhat for elasticsearch-operator

### DIFF
--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -713,6 +713,8 @@ get_all_logging_pod_logs() {
   local p
   local container
   for p in $(oc get pods -n ${LOGGING_NS} -o jsonpath='{.items[*].metadata.name}') ; do
+    oc -n ${LOGGING_NS} describe pod $p > $ARTIFACT_DIR/$p.describe 2>&1 || :
+    oc -n ${LOGGING_NS} get pod $p -o yaml > $ARTIFACT_DIR/$p.yaml 2>&1 || :
     for container in $(oc get po $p -o jsonpath='{.spec.containers[*].name}') ; do
       case "$p" in
         logging-fluentd-*|fluentd-*) get_fluentd_pod_log $p > $ARTIFACT_DIR/$p.$container.log 2>&1 ;;

--- a/openshift/ci-operator/build-image/elasticsearch-catalogsourceconfig.yaml
+++ b/openshift/ci-operator/build-image/elasticsearch-catalogsourceconfig.yaml
@@ -4,5 +4,5 @@ metadata:
   name: "elasticsearch"
   namespace: "openshift-marketplace"
 spec:
-  targetNamespace: "openshift-operators"
+  targetNamespace: "openshift-operators-redhat"
   packages: "elasticsearch-operator"

--- a/openshift/ci-operator/build-image/elasticsearch-subscription.yaml
+++ b/openshift/ci-operator/build-image/elasticsearch-subscription.yaml
@@ -2,9 +2,9 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   generateName: elasticsearch-
-  namespace: openshift-operators
+  namespace: openshift-operators-redhat
 spec:
   source: elasticsearch
-  sourceNamespace: openshift-operators
+  sourceNamespace: openshift-operators-redhat
   name: elasticsearch-operator
   channel: preview

--- a/openshift/ci-operator/build-image/openshift-operators-redhat-namespace.yaml
+++ b/openshift/ci-operator/build-image/openshift-operators-redhat-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-logging: "true"
+    openshift.io/cluster-monitoring: "true"

--- a/openshift/ci-operator/build-image/openshift-operators-redhat-operatorgroup.yaml
+++ b/openshift/ci-operator/build-image/openshift-operators-redhat-operatorgroup.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-operators-redhat
+  namespace: openshift-operators-redhat
+spec: {}


### PR DESCRIPTION
Change CI to create namespace openshift-operators-redhat and
operatorgroup.

FYI: The elasticsearch-operator needs to watch all namespaces
for elasticsearch objects.
https://github.com/operator-framework/community-operators/blob/master/community-operators/elasticsearch-operator/elasticsearch-operator.v4.1.0.clusterserviceversion.yaml#L90
This means we cannot list the targetNamespaces in the operatorgroup.
I could not find any documenation about operatorgroups, but I figured
out that if you do not set targetNamespaces in the operatorgroup it
will tell it to watch all namespaces:
`spec: {}`