### PR TITLE
use oal_sudo instead of sudo - other CI improvements

### DIFF
--- a/hack/testing/check-logs.sh
+++ b/hack/testing/check-logs.sh
@@ -10,7 +10,7 @@ docker_uses_journal() {
     # if "log-driver" is set in /etc/docker/daemon.json, assume that it is
     # authoritative
     # otherwise, look for /etc/sysconfig/docker
-    if type -p docker > /dev/null && sudo docker info | grep -q 'Logging Driver: journald' ; then
+    if type -p docker > /dev/null && oal_sudo docker info | grep -q 'Logging Driver: journald' ; then
         return 0
     elif grep -q '^[^#].*"log-driver":' /etc/docker/daemon.json 2> /dev/null ; then
         if grep -q '^[^#].*"log-driver":.*journald' /etc/docker/daemon.json 2> /dev/null ; then

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -141,7 +141,7 @@ monitor_fluentd_pos() {
         local cursor=$( get_journal_pos_cursor )
         if [ -n "$cursor" ] ; then
             local startts=$( date +%s )
-            local count=$( sudo journalctl -m -c $cursor | wc -l )
+            local count=$( oal_sudo journalctl -m -c $cursor | wc -l )
             local endts=$( date +%s )
             echo $endts $( expr $endts - $startts ) $count
         else
@@ -154,7 +154,7 @@ monitor_fluentd_pos() {
 monitor_journal_lograte() {
     local interval=60
     while true ; do
-        count=$( sudo journalctl -m -S "$( date +'%Y-%m-%d %H:%M:%S' --date="$interval seconds ago" )" | wc -l )
+        count=$( oal_sudo journalctl -m -S "$( date +'%Y-%m-%d %H:%M:%S' --date="$interval seconds ago" )" | wc -l )
         echo $( date +%s ) $count
         sleep $interval
     done  > $ARTIFACT_DIR/monitor_journal_lograte.log 2>&1

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -426,7 +426,11 @@ function add_test_message() {
 
 function flush_fluentd_pos_files() {
     echo oal_sudo rm -f /var/log/journal.pos /var/log/journal_pos.json
-    oal_sudo rm -f /var/log/journal.pos /var/log/journal_pos.json || :
+    if oal_sudo rm -f /var/log/journal.pos /var/log/journal_pos.json ; then
+        :
+    else
+        echo oal_sudo rm -f /var/log/journal.pos /var/log/journal_pos.json failed $?
+    fi
     os::cmd::expect_success "oal_sudo rm -f /var/log/journal.pos /var/log/journal_pos.json"
 }
 

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -26,10 +26,10 @@ if [ $(id -u) = 0 ] ; then
         case "$1" in
         \-[A-Za-z]) shift ;;
         esac
-        exec "$@"
+        "$@"
     }
 else
-    oal_sudo() { exec sudo "$@" ; }
+    oal_sudo() { sudo "$@" ; }
 fi
 export -f oal_sudo
 

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -425,6 +425,8 @@ function add_test_message() {
 }
 
 function flush_fluentd_pos_files() {
+    echo oal_sudo rm -f /var/log/journal.pos /var/log/journal_pos.json
+    oal_sudo rm -f /var/log/journal.pos /var/log/journal_pos.json || :
     os::cmd::expect_success "oal_sudo rm -f /var/log/journal.pos /var/log/journal_pos.json"
 }
 

--- a/test/cluster/functionality.sh
+++ b/test/cluster/functionality.sh
@@ -119,7 +119,7 @@ for elasticsearch_pod in $( get_es_pod ${OAL_ELASTICSEARCH_COMPONENT} ); do
 		for kibana_pod in $( oc get pods --selector component="${OAL_KIBANA_COMPONENT}"  -o jsonpath='{ .items[*].metadata.name }' ); do
 			os::log::info "Checking for index ${index} with Kibana pod ${kibana_pod}..."
 			# As we're checking system log files, we need to use `sudo`
-			os::cmd::expect_success "sudo -E env PATH=$PATH VERBOSE=true go run '${OS_O_A_L_DIR}/hack/testing/check-logs.go' '${kibana_pod}' '${elasticsearch_api}' '${index}' '${index_search_path}' '${query_size}' '${test_user}' '${test_token}' '${test_ip}'"
+			os::cmd::expect_success "oal_sudo -E env PATH=$PATH VERBOSE=true go run '${OS_O_A_L_DIR}/hack/testing/check-logs.go' '${kibana_pod}' '${elasticsearch_api}' '${index}' '${index_search_path}' '${query_size}' '${test_user}' '${test_token}' '${test_ip}'"
 		done
 	done
 

--- a/test/cluster/rollout.sh
+++ b/test/cluster/rollout.sh
@@ -32,9 +32,9 @@ cleanup() {
   get_all_logging_pod_logs
   oc get -n ${LOGGING_NS} --all 2>&1 | artifact_out
   if type -p docker > /dev/null 2>&1 ; then
-    sudo docker images|grep logging 2>&1 | artifact_out
-    sudo docker images|grep oauth 2>&1 | artifact_out
-    sudo docker images|grep eventrouter 2>&1 | artifact_out
+    oal_sudo docker images|grep logging 2>&1 | artifact_out
+    oal_sudo docker images|grep oauth 2>&1 | artifact_out
+    oal_sudo docker images|grep eventrouter 2>&1 | artifact_out
   fi
   oc get events > $ARTIFACT_DIR/events.txt 2>&1
 

--- a/test/docker_audit.sh
+++ b/test/docker_audit.sh
@@ -89,7 +89,7 @@ timestamp=$( date --iso-8601=seconds )
 docker run --rm centos:7 echo "running test container"
 
 if ! os::cmd::try_until_success "logs_count_is_ge $esopssvc '/.operations.*/' 4 $timestamp" $((second * 60)) ; then
-    sudo grep VIRT_CONTROL /var/log/audit/audit.log | tail -40 > $ARTIFACT_DIR/docker_audit_audit.log
+    oal_sudo grep VIRT_CONTROL /var/log/audit/audit.log | tail -40 > $ARTIFACT_DIR/docker_audit_audit.log
     get_fluentd_pod_log $fpod > $ARTIFACT_DIR/docker_audit_fluentd.log
     ops_logs_after=$( get_logs_count $esopssvc '/.operations.*/' )
     logs_after=$( get_logs_count $essvc '/project.*/' )

--- a/test/fluentd-forward.sh
+++ b/test/fluentd-forward.sh
@@ -174,8 +174,8 @@ create_forwarding_fluentd() {
        --from-file=fluent.conf=$OS_O_A_L_DIR/hack/templates/forward-fluent.conf 2>&1 | artifact_out
 
     # create a directory for file buffering so as not to conflict with fluentd
-    if ! sudo test -d /var/lib/fluentd-forward${id} ; then
-        sudo mkdir -p /var/lib/fluentd-forward${id}
+    if ! oal_sudo test -d /var/lib/fluentd-forward${id} ; then
+        oal_sudo mkdir -p /var/lib/fluentd-forward${id}
     fi
 
     # create forwarding daemonset

--- a/test/mux.sh
+++ b/test/mux.sh
@@ -248,7 +248,7 @@ write_and_verify_logs() {
     oc get pods | grep fluentd | artifact_out
     logger -i -p local6.info -t $uuid_es_ops $uuid_es_ops
     # get the cursor of this record - compare to the fluentd journal cursor position
-    local reccursor=$( sudo journalctl -m -o export -t $uuid_es_ops | awk -F__CURSOR= '/^__CURSOR=/ {print $2}' )
+    local reccursor=$( oal_sudo journalctl -m -o export -t $uuid_es_ops | awk -F__CURSOR= '/^__CURSOR=/ {print $2}' )
     oc get pods | grep fluentd | artifact_out
     local fcursor_after=$( get_journal_pos_cursor )
     artifact_log Cursors:
@@ -297,12 +297,12 @@ write_and_verify_logs() {
         curl_es $essvc /${myproject}.*/_search?sort=@timestamp:desc\&size=1 | python -mjson.tool | artifact_out
         if docker_uses_journal ; then
             artifact_log First matching record:
-            sudo journalctl -m | grep -m 1 "${mymessage}" | artifact_out || :
+            oal_sudo journalctl -m | grep -m 1 "${mymessage}" | artifact_out || :
             artifact_log Last matching record:
-            sudo journalctl -m -r | grep -m 1 "${mymessage}" | artifact_out || :
+            oal_sudo journalctl -m -r | grep -m 1 "${mymessage}" | artifact_out || :
         else
             artifact_log matching records:
-            sudo find /var/log/containers -name \*.log -exec grep "${mymessage}" {} /dev/null \; | artifact_out || :
+            oal_sudo find /var/log/containers -name \*.log -exec grep "${mymessage}" {} /dev/null \; | artifact_out || :
         fi
         exit 1
     fi
@@ -328,7 +328,7 @@ write_and_verify_logs() {
         curl_es $essvc /${myproject}.*/_search?sort=@timestamp:asc\&size=1 | python -mjson.tool | artifact_out
         curl_es $essvc /${myproject}.*/_search?sort=@timestamp:desc\&size=1 | python -mjson.tool | artifact_out
         # find the record in the journal
-        sudo journalctl -m -o export -t $uuid_es_ops | artifact_out || :
+        oal_sudo journalctl -m -o export -t $uuid_es_ops | artifact_out || :
         exit 1
     fi
     os::cmd::expect_success_and_not_text "curl_es $es_svc /_cat/indices" "project\.default"

--- a/test/zzz-rsyslog.sh
+++ b/test/zzz-rsyslog.sh
@@ -14,8 +14,8 @@ es_ops_pod=$( get_es_pod es-ops )
 es_ops_pod=${es_ops_pod:-$es_pod}
 
 clear_and_restart_journal() {
-    sudo journalctl --vacuum-size=$( expr 1024 \* 1024 \* 2 ) 2>&1 | artifact_out
-    sudo systemctl restart systemd-journald 2>&1 | artifact_out
+    oal_sudo journalctl --vacuum-size=$( expr 1024 \* 1024 \* 2 ) 2>&1 | artifact_out
+    oal_sudo systemctl restart systemd-journald 2>&1 | artifact_out
 }
 
 if oc get clusterlogging instance > /dev/null 2>&1 ; then
@@ -44,12 +44,12 @@ cleanup() {
         if [ -n "${tmpinv:-}" -a -f "${tmpinv:-}" ] ; then
             rm -f $tmpinv
         fi
-        sudo journalctl -m -u $rsyslog_service --since="-1hour" > $ARTIFACT_DIR/rsyslog-rsyslog.log 2>&1
+        oal_sudo journalctl -m -u $rsyslog_service --since="-1hour" > $ARTIFACT_DIR/rsyslog-rsyslog.log 2>&1
         if [ -n "${rsyslog_save}" -a -d "${rsyslog_save}" ] ; then
-            sudo rm -rf ${rsyslog__config_dir}/*
-            sudo cp -p ${rsyslog_save}/* ${rsyslog__config_dir} || :
+            oal_sudo rm -rf ${rsyslog__config_dir}/*
+            oal_sudo cp -p ${rsyslog_save}/* ${rsyslog__config_dir} || :
             rm -rf ${rsyslog_save}
-            sudo systemctl restart $rsyslog_service
+            oal_sudo systemctl restart $rsyslog_service
         fi
         # cleanup fluentd pos file and restart
         start_fluentd true 2>&1 | artifact_out
@@ -76,7 +76,7 @@ trap "cleanup" EXIT
 
 deploy_using_ansible() {
     rsyslog_save=$( mktemp -d )
-    sudo cp -p ${rsyslog__config_dir}/* ${rsyslog_save} || :
+    oal_sudo cp -p ${rsyslog__config_dir}/* ${rsyslog_save} || :
     pushd $OS_O_A_L_DIR/hack/testing/rsyslog > /dev/null
     tmpinv=$( mktemp )
     cat > $tmpinv <<EOF
@@ -116,12 +116,12 @@ EOF
     popd > /dev/null
 
     pushd /etc
-    sudo tar cf - rsyslog.conf rsyslog.d | (cd $ARTIFACT_DIR; tar xf -)
+    oal_sudo tar cf - rsyslog.conf rsyslog.d | (cd $ARTIFACT_DIR; tar xf -)
     popd > /dev/null
-    sudo systemctl stop $rsyslog_service
+    oal_sudo systemctl stop $rsyslog_service
     # make test run faster by resetting journal cursor to "now"
-    sudo journalctl -m -n 1 --show-cursor | awk '/^-- cursor/ {printf("%s",$3)}' | sudo tee /var/lib/rsyslog/imjournal.state > /dev/null
-    sudo systemctl start $rsyslog_service
+    oal_sudo journalctl -m -n 1 --show-cursor | awk '/^-- cursor/ {printf("%s",$3)}' | oal_sudo tee /var/lib/rsyslog/imjournal.state > /dev/null
+    oal_sudo systemctl start $rsyslog_service
 }
 
 deploy_using_operators() {

--- a/test/zzzz-bulk_rejection.sh
+++ b/test/zzzz-bulk_rejection.sh
@@ -33,8 +33,8 @@ function cleanup() {
         curl_es $esopssvc /bulkindextest -XDELETE | jq . | artifact_out
     fi
     fpod=$( get_running_pod fluentd )
-    if sudo test -f /var/log/fluentd/fluentd.log ; then
-        sudo cat /var/log/fluentd/fluentd.log > $ARTIFACT_DIR/fluentd-with-bulk-index-rejections.log
+    if oal_sudo test -f /var/log/fluentd/fluentd.log ; then
+        oal_sudo cat /var/log/fluentd/fluentd.log > $ARTIFACT_DIR/fluentd-with-bulk-index-rejections.log
     fi
     if [ -f /var/log/fluentd.log ] ; then
         cat /var/log/fluentd.log >> $ARTIFACT_DIR/fluentd-with-bulk-index-rejections.log
@@ -209,15 +209,15 @@ fi
 
 # check the logs to see if there are bulk index rejection errors between starttime and endtime
 fluentdlogfile=/var/log/fluentd/fluentd.log
-if sudo test -f $fluentdlogfile ; then
+if oal_sudo test -f $fluentdlogfile ; then
     if [ ! -f $fluentdlogfile ] ; then
-        sudo chmod o+rx /var/log/fluentd
-        sudo chmod o+r $fluentdlogfile
+        oal_sudo chmod o+rx /var/log/fluentd
+        oal_sudo chmod o+r $fluentdlogfile
     fi
 else
     fluentdlogfile=/var/log/fluentd.log
     if [ ! -f $fluentdlogfile ] ; then
-        sudo chmod o+r $fluentdlogfile
+        oal_sudo chmod o+r $fluentdlogfile
     fi
 fi
 
@@ -266,9 +266,9 @@ else
     os::log::error not found $countops record project .operations for $uuid_es_ops after timeout
     os::log::debug "$( curl_es ${esopssvc} /.operations.*/_search -X POST -d "$qsops" )"
     os::log::error "Checking journal for $uuid_es_ops..."
-    if sudo journalctl -m | grep -q $uuid_es_ops ; then
+    if oal_sudo journalctl -m | grep -q $uuid_es_ops ; then
         os::log::error "Found $uuid_es_ops in journal"
-        os::log::debug "$( sudo journalctl -m | grep $uuid_es_ops )"
+        os::log::debug "$( oal_sudo journalctl -m | grep $uuid_es_ops )"
     else
         os::log::error "Unable to find $uuid_es_ops in journal"
     fi


### PR DESCRIPTION
We use sudo in several places in logging CI.  Using sudo
as root in a container creates a lot of logs in the system
logs and audit logs, which is a lot of noise and
unnecessary work for our tests.  Instead, if running as root,
do not use sudo, just run the command directly.
Also includes various other CI improvements.