### PR TITLE
Bug 1707176 - JOURNAL_READ_FROM_HEAD defaults to true

### DIFF
--- a/fluentd/configs.d/openshift/input-pre-systemd.conf
+++ b/fluentd/configs.d/openshift/input-pre-systemd.conf
@@ -2,7 +2,7 @@
   @type systemd
   @id systemd-input
   @label @INGRESS
-  path "#{ENV['JOURNAL_SOURCE'] || '/run/log/journal'}"
+  path "#{if (val = ENV.fetch('JOURNAL_SOURCE','')) && (val.length > 0); val; else '/run/log/journal'; end}"
   <storage>
     @type local
     persistent true
@@ -12,5 +12,5 @@
   </storage>
   matches "#{ENV['JOURNAL_FILTERS_JSON'] || '[]'}"
   tag journal
-  read_from_head "#{ENV['JOURNAL_READ_FROM_HEAD'] || 'false'}"
+  read_from_head "#{if (val = ENV.fetch('JOURNAL_READ_FROM_HEAD','')) && (val.length > 0); val; else 'false'; end}"
 </source>


### PR DESCRIPTION
For the JOURNAL env vars, only use the value if it is set *and* the value is not an empty string.
Otherwise, if `JOURNAL_READ_FROM_HEAD` is set to an empty value, this
```
      read_from_head "#{ENV['JOURNAL_READ_FROM_HEAD'] || 'false'}"
```
will expand to this
```
     read_from_head
```
since `read_from_head` is a boolean parameter, this tells Fluentd to set the value to `true`, which is the opposite of the intention.