### PR TITLE
add method to deploy using operator make deploy

### DIFF
--- a/hack/get-cluster-run-tests.sh
+++ b/hack/get-cluster-run-tests.sh
@@ -145,7 +145,7 @@ fi
 if [ "${DEPLOY_LOGGING:-true}" = true ] ; then
     KUBECONFIG=$workdir/auth/kubeconfig ARTIFACT_DIR=$workdir/artifacts \
     USE_EO_LATEST_IMAGE=true USE_CLO_LATEST_IMAGE=true \
-    $scriptdir/deploy-logging-marketplace.sh
+    $scriptdir/deploy-logging.sh
 fi
 
 # run logging tests

--- a/hack/test-logging.sh
+++ b/hack/test-logging.sh
@@ -54,6 +54,15 @@ if [ ! -d $ARTIFACT_DIR ] ; then
 fi
 DEFAULT_TIMEOUT=${DEFAULT_TIMEOUT:-600}
 ESO_NS=${ESO_NS:-openshift-operators-redhat}
+esopod=$( oc -n $ESO_NS get pods | awk '/^elasticsearch-operator-.* Running / {print $1}' )
+if [ -z "$esopod" ] ; then
+    ESO_NS=openshift-logging
+    esopod=$( oc -n $ESO_NS get pods | awk '/^elasticsearch-operator-.* Running / {print $1}' )
+fi
+if [ -z "$esopod" ] ; then
+    echo ERROR: could not find elasticsearch-operator running in openshift-operators-redhat or openshift-logging
+    logging_err_exit
+fi
 
 # set elasticsearch to unmanaged - so that the elasticsearch-operator
 # won't try to do anything to elasticsearch when we shut it down

--- a/hack/undeploy-logging.sh
+++ b/hack/undeploy-logging.sh
@@ -26,6 +26,12 @@ set -euxo pipefail
 
 ESO_NS=${ESO_NS:-openshift-operators-redhat}
 
+if [ -d ${GOPATH:-}/src/github.com/openshift/cluster-logging-operator ] ; then
+    pushd ${GOPATH:-}/src/github.com/openshift/cluster-logging-operator > /dev/null
+    make undeploy || :
+    popd > /dev/null
+fi
+
 oc delete project openshift-logging || :
 wait_func() { ! oc get project openshift-logging > /dev/null 2>&1 ; }
 wait_for_condition wait_func 600 10

--- a/openshift/ci-operator/build-image/setup-logging-for-e2e.sh
+++ b/openshift/ci-operator/build-image/setup-logging-for-e2e.sh
@@ -8,6 +8,6 @@
 
 set -eux
 
-. hack/deploy-logging-marketplace.sh
+. hack/deploy-logging.sh
 
 . hack/test-logging.sh


### PR DESCRIPTION
Use the cluster-logging-operator source code and `make deploy`
to deploy logging if not using OLM.

Use the operator images from the public CI mirror at
`registry.svc.ci.openshift.org`

Rename scripts to get rid of `marketplace`.

Depends on https://github.com/openshift/cluster-logging-operator/pull/182