### PR TITLE
Fixing bugs in "oc exec rsyslog_pod -- logs".

### DIFF
--- a/rsyslog/utils/logs
+++ b/rsyslog/utils/logs
@@ -36,8 +36,9 @@ done
 
 if [ $cmd = "cat" ] ; then
     for log_file in $( ls $log_dir/rsyslog* | sort -Vr ); do
-        cat $log_dir/$log_file
+        cat $log_file
     done
 else
-    exec tail "$tail_args" $log_dir/rsyslog.log
+    log_file=`basename ${LOGGING_FILE_PATH:-/var/log/rsyslog/rsyslog.log}`
+    exec tail "$tail_args" $log_dir/$log_file
 fi


### PR DESCRIPTION
1) cat: /var/log/rsyslog//var/log/rsyslog/rsyslog.log: No such file or directory
2) when -f option was given and a log file name was customized, the name was not used.