### PR TITLE
[WIP] add xpack to es5 to be used when migrating to es6 per es docs

### DIFF
--- a/elasticsearch/prep-install.origin
+++ b/elasticsearch/prep-install.origin
@@ -5,4 +5,4 @@ fi
 if [ -z "${PROMETHEUS_EXPORTER_URL:-}" ] ; then
     PROMETHEUS_EXPORTER_URL=https://github.com/lukas-vlcek/elasticsearch-prometheus-exporter/releases/download/${PROMETHEUS_EXPORTER_VER}/prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
 fi
-es_plugins=($OSE_ES_URL $PROMETHEUS_EXPORTER_URL)
+es_plugins=($OSE_ES_URL $PROMETHEUS_EXPORTER_URL x-pack)

--- a/elasticsearch/prep-install.prod
+++ b/elasticsearch/prep-install.prod
@@ -1,4 +1,5 @@
 es_plugins=(
     ${MAVEN_REPO_URL}io/fabric8/elasticsearch/openshift-elasticsearch-plugin/$OSE_ES_VER/openshift-elasticsearch-plugin-$OSE_ES_VER.zip
     ${MAVEN_REPO_URL}org/elasticsearch/plugin/prometheus/elasticsearch-prometheus-exporter/$PROMETHEUS_EXPORTER_VER/elasticsearch-prometheus-exporter-$PROMETHEUS_EXPORTER_VER.zip
+    x-pack
 )

--- a/elasticsearch/run.sh
+++ b/elasticsearch/run.sh
@@ -95,4 +95,4 @@ info "ES_JAVA_OPTS: '${ES_JAVA_OPTS}'"
 DHE_TMP_KEY_SIZE=${DHE_TMP_KEY_SIZE:-2048}
 export ES_JAVA_OPTS="${ES_JAVA_OPTS:-} -Djdk.tls.ephemeralDHKeySize=$DHE_TMP_KEY_SIZE"
 
-exec ${ES_HOME}/bin/elasticsearch -E path.conf=$ES_CONF
+exec ${ES_HOME}/bin/elasticsearch -E path.conf=$ES_CONF -E xpack.security.enabled=false


### PR DESCRIPTION
As part of moving to es6 we want to verify that the indices and templates that we currently have are valid before migrating the cluster. There was no way to install this into an already running cluster due to lack of permissions in the container with `oc exec`

The intention is that the elasticsearch/clusterlogging operator would call this endpoint before beginning an upgrade.

Ref: https://www.elastic.co/guide/en/elastic-stack/6.8/upgrading-elastic-stack.html#xpack-stack-upgrade
