### PR TITLE
support CRI-O journald log driver

### DIFF
--- a/fluentd/configs.d/openshift/filter-k8s-meta.conf
+++ b/fluentd/configs.d/openshift/filter-k8s-meta.conf
@@ -3,7 +3,7 @@
   kubernetes_url "#{ENV['K8S_HOST_URL']}"
   cache_size "#{ENV['K8S_METADATA_CACHE_SIZE'] || '1000'}"
   watch "#{ENV['K8S_METADATA_WATCH'] || 'false'}"
-  use_journal "#{ENV['USE_JOURNAL'] || 'false'}"
+  use_journal "#{ENV['USE_JOURNAL'] || 'nil'}"
   ssl_partial_chain "#{ENV['SSL_PARTIAL_CHAIN'] || 'true'}"
 </filter>
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1722898
additional fix - use `'nil'` for the default value of use_journal -
allows the kubernetes plugin to auto-detect - we aren't using
cri-o with the journal log driver in 4.x yet, but this will
future proof us