### PR TITLE
Bug 1705589. Consume newer version of plugin to mitigate blank page

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -13,7 +13,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     INSTANCE_RAM=512G \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.13.5-redhat-1 \
+    OSE_ES_VER=5.6.13.6-redhat-1 \
     PROMETHEUS_EXPORTER_VER=5.6.13.2-redhat-3 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     container=oci
 
-ARG OSE_ES_VER=5.6.13.5-redhat-1
+ARG OSE_ES_VER=5.6.13.6-redhat-1
 ARG OSE_ES_URL
 ARG PROMETHEUS_EXPORTER_VER=5.6.13.2-redhat-3
 ARG PROMETHEUS_EXPORTER_URL

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -14,7 +14,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_VER=1.8.0 \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.13.5 \
+    OSE_ES_VER=5.6.13.6 \
     PROMETHEUS_EXPORTER_VER=5.6.13.2 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     RELEASE_STREAM=origin
 
-ARG OSE_ES_VER=5.6.13.5
+ARG OSE_ES_VER=5.6.13.6
 ARG SG_VER=5.6.13-19.2
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \

--- a/elasticsearch/sgconfig/sg_action_groups.yml
+++ b/elasticsearch/sgconfig/sg_action_groups.yml
@@ -70,6 +70,8 @@ INDEX_ANY_ADMIN:
   - indices:admin/mappings/fields/get*
   - indices:admin/validate/query*
   - indices:admin/get*
+  - "indices:data/read/field_stats"
+  - "indices:data/read/field_caps"
   - READ
 
 INDEX_KIBANA:
@@ -93,7 +95,7 @@ INDEX_PROJECT:
 METRICS:
   - CLUSTER_MONITOR
 USER_ALL_INDEX_OPS:
-  - "indices:data/read/field_caps*"
+  - "indices:data/read/field_caps"
 USER_CLUSTER_OPERATIONS:
   - CLUSTER_COMPOSITE_OPS_RO
   - MONITOR
@@ -118,7 +120,7 @@ CLUSTER_OPERATIONS:
 
 CLUSTER_COMPOSITE_OPS_RO:
   - "indices:data/read/coordinate-msearch*"
-  - "indices:data/read/field_caps*"
+  - "indices:data/read/field_caps"
   - "indices:data/read/mget"
   - "indices:data/read/msearch"
   - "indices:data/read/mtv"


### PR DESCRIPTION
This PR consumes a newer version of the multi-tenant plugin to mitigate:

https://bugzilla.redhat.com/show_bug.cgi?id=1705589

blocked by fabric8io/openshift-elasticsearch-plugin#179