### PR TITLE
Bug 1732364: Add jaeger permissions to create ES index templates

### DIFF
--- a/elasticsearch/sgconfig/sg_roles.yml
+++ b/elasticsearch/sgconfig/sg_roles.yml
@@ -58,6 +58,7 @@ sg_role_jaeger:
     - indices:data/write/bulk
     - SEARCH
     - CLUSTER_MONITOR
+    - MANAGE
   indices:
     '*jaeger-span-*':
       '*':


### PR DESCRIPTION
Jaeger now creates index templates at startup. Before it was creating an index with supplied mapping which could result in an index with incorrect mapping.

https://bugzilla.redhat.com/show_bug.cgi?id=1732364

Related Jaeger PR https://github.com/jaegertracing/jaeger/pull/1627
