### PR TITLE
Bug 1715370: Some orphaned logs sent to .operations.* index

### DIFF
--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -99,6 +99,12 @@ if [ -z $ES_PORT ]; then
     exit 1
 fi
 
+# Check bearer_token_file for fluent-plugin-kubernetes_metadata_filter.
+if [ ! -s /var/run/secrets/kubernetes.io/serviceaccount/token ] ; then
+    echo "ERROR: Bearer_token_file (/var/run/secrets/kubernetes.io/serviceaccount/token) to access the Kubernetes API server is missing or empty."
+    exit 1
+fi
+
 # How many outputs?
 # check ES_HOST vs. OPS_HOST; ES_PORT vs. OPS_PORT
 if [ "$ES_HOST" = ${OPS_HOST:-""} -a $ES_PORT -eq ${OPS_PORT:-0} ]; then


### PR DESCRIPTION
 by mistake.

Adding a check to fluentd/run.sh if bearer_token_file (/var/run/secrets/kubernetes.io/serviceaccount/token)
for the kubernetes api server exists and is not empty.