### PR TITLE
imagePullPolicy Always - ensure admin user

### DIFF
--- a/hack/test-logging.sh
+++ b/hack/test-logging.sh
@@ -48,6 +48,35 @@ wait_for_condition()
     return 0
 }
 
+switch_to_admin_user() {
+    # make sure we are using the admin credentials for the remote repo
+    if [ -z "${KUBECONFIG:-}" ] ; then
+        echo WARNING: KUBECONFIG is not set - assuming you have set credentials
+        echo via ~/.kube/config or otherwise
+    fi
+
+    if ! oc auth can-i view pods/log -n default > /dev/null 2>&1 ; then
+        local adminname
+        local oldcontext=$( oc config current-context )
+        # see if there is already an admin context in the kubeconfig
+        for adminname in admin system:admin kube:admin ; do
+            if oc config use-context $adminname > /dev/null 2>&1 ; then
+                break
+            fi
+        done
+        if oc auth can-i view pods/log -n default > /dev/null 2>&1 ; then
+            echo INFO: switched from context [$oldcontext] to [$(oc config current-context)]
+        else
+            echo ERROR: could not get an admin context to use - make sure you have
+            echo set KUBECONFIG or ~/.kube/config correctly
+            oc config use-context $oldcontext
+            exit 1
+        fi
+    fi
+}
+
+switch_to_admin_user
+
 ARTIFACT_DIR=${ARTIFACT_DIR:-"$( pwd )/_output"}
 if [ ! -d $ARTIFACT_DIR ] ; then
     mkdir -p $ARTIFACT_DIR


### PR DESCRIPTION
When running `hack/get-cluster-run-tests.sh` - set env var
`LOGGING_IMAGE_PULL_POLICY=Always` in order to make sure you
are using your latest images.
Or add this to your `~/.config/get-cluster-run-tests.sh`

Also, it is possible to do an `oc login` to another cluster with
your newly minted `kubeconfig` and change the current context.
This fix ensures that you are using an `admin` context when the
script needs it.