### PR TITLE
Bug 1733011: Inappropriate message when view rsyslog pod logs by `oc…

### DIFF
--- a/rsyslog/utils/logs
+++ b/rsyslog/utils/logs
@@ -42,7 +42,7 @@ done
 
 if [ $cmd = "cat" ] ; then
     if [ "$include_logrotation" = "true" ] ; then
-        if ls $pod_dir/rsyslog.* > /dev/null 2>&1 ; then
+        if ls $log_dir/rsyslog.* > /dev/null 2>&1 ; then
             echo "===== rsyslog logs ====="
             for log_file in $( ls $log_dir/rsyslog.* | sort -Vr ); do
                 cat $log_file
@@ -70,7 +70,7 @@ if [ $cmd = "cat" ] ; then
             done
         fi
     else
-        if ls $pod_dir/rsyslog.* > /dev/null 2>&1 ; then
+        if ls $log_dir/rsyslog.* > /dev/null 2>&1 ; then
             for log_file in $( ls $log_dir/rsyslog.* | sort -Vr ); do
                 cat $log_file
             done


### PR DESCRIPTION
… exec $rsyslog-pod -- logs` after setting `LOGGING_FILE_PATH=console`

Fixing wrong dir checkings.