### PR TITLE
Bug 1730652: Rsyslog prometheus stats not being reported correctly.

### DIFF
--- a/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/exporter.go
+++ b/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/exporter.go
@@ -20,6 +20,9 @@ const (
 	rsyslogQueue
 	rsyslogResource
 	rsyslogDynStat
+	rsyslogImjournal
+	rsyslogOmelasticsearch
+	rsyslogMmkubernetes
 )
 
 type rsyslogExporter struct {
@@ -87,6 +90,33 @@ func (re *rsyslogExporter) handleStatLine(rawbuf []byte) error {
 		}
 	case rsyslogDynStat:
 		s, err := newDynStatFromJSON(buf)
+		if err != nil {
+			return err
+		}
+		for _, p := range s.toPoints() {
+			re.set(p)
+		}
+
+	case rsyslogImjournal:
+		s, err := newImjournalFromJSON(buf)
+		if err != nil {
+			return err
+		}
+		for _, p := range s.toPoints() {
+			re.set(p)
+		}
+
+	case rsyslogOmelasticsearch:
+		s, err := newOmelasticsearchFromJSON(buf)
+		if err != nil {
+			return err
+		}
+		for _, p := range s.toPoints() {
+			re.set(p)
+		}
+
+	case rsyslogMmkubernetes:
+		s, err := newMmkubernetesFromJSON(buf)
 		if err != nil {
 			return err
 		}

--- a/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/exporter_test.go
+++ b/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/exporter_test.go
@@ -240,3 +240,216 @@ func TestHandleUnknown(t *testing.T) {
 		t.Errorf("want '%d', got '%d'", want, got)
 	}
 }
+
+func TestHandleLineWithImjournal(t *testing.T) {
+	tests := []*testUnit{
+		&testUnit{
+			Name:       "imjournal_submitted",
+			Val:        1994,
+			LabelValue: "test_imjournal",
+		},
+		&testUnit{
+			Name:       "imjournal_read",
+			Val:        1996,
+			LabelValue: "test_imjournal",
+		},
+		&testUnit{
+			Name:       "imjournal_discarded",
+			Val:        1,
+			LabelValue: "test_imjournal",
+		},
+		&testUnit{
+			Name:       "imjournal_failed",
+			Val:        1,
+			LabelValue: "test_imjournal",
+		},
+		// &testUnit{
+		// 	Name:       "imjournal_poll_failed",
+		// 	Val:        0,
+		// 	LabelValue: "test_imjournal",
+		// },
+		&testUnit{
+			Name:       "imjournal_rotations",
+			Val:        32,
+			LabelValue: "test_imjournal",
+		},
+		&testUnit{
+			Name:       "imjournal_recovery_attempts",
+			Val:        5,
+			LabelValue: "test_imjournal",
+		},
+		// &testUnit{
+		// 	Name:       "imjournal_ratelimit_discarded_in_interval",
+		// 	Val:        0,
+		// 	LabelValue: "test_imjournal",
+		// },
+		&testUnit{
+			Name:       "imjournal_disk_usage_bytes",
+			Val:        75501568,
+			LabelValue: "test_imjournal",
+		},
+	}
+
+	imjournalLog := []byte(`2017-08-30T08:10:04.786350+00:00 some-node.example.org rsyslogd-pstats: { "name": "test_imjournal", "origin": "imjournal", "submitted": 1994, "read": 1996, "discarded": 1, "failed": 1, "poll_failed": 0, "rotations": 32, "recovery_attempts": 5, "ratelimit_discarded_in_interval": 0, "disk_usage_bytes": 75501568 }`)
+	testHelper(t, imjournalLog, tests)
+}
+
+func TestHandleLineWithOmelasticsearch(t *testing.T) {
+	tests := []*testUnit{
+		&testUnit{
+			Name:       "omelasticsearch_submitted",
+			Val:        772,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_failedhttp",
+			Val:        10,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_failedhttprequests",
+			Val:        11,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_failedcheckconn",
+			Val:        12,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_failedes",
+			Val:        13,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_responsesuccess",
+			Val:        700,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_responsebad",
+			Val:        1,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_responseduplicate",
+			Val:        2,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_responsebadargument",
+			Val:        3,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_responsebulkrejection",
+			Val:        4,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_responseother",
+			Val:        5,
+			LabelValue: "test_omelasticsearch",
+		},
+		&testUnit{
+			Name:       "omelasticsearch_rebinds",
+			Val:        6,
+			LabelValue: "test_omelasticsearch",
+		},
+	}
+
+	omelasticsearchLog := []byte(`2017-08-30T08:10:04.786350+00:00 some-node.example.org rsyslogd-pstats: {
+		"name": "test_omelasticsearch", "origin": "omelasticsearch", "submitted": 772, "failed.http": 10,
+		"failed.httprequests": 11, "failed.checkConn": 12, "failed.es": 13, "response.success": 700,
+		"response.bad": 1, "response.duplicate": 2, "response.badargument": 3, "response.bulkrejection": 4,
+		"response.other": 5, "rebinds": 6 }`)
+	testHelper(t, omelasticsearchLog, tests)
+}
+
+func TestHandleLineWithMmkubernetes(t *testing.T) {
+	tests := []*testUnit{
+		&testUnit{
+			Name:       "mmkubernetes_recordseen",
+			Val:        9876,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_namespacemetadatasuccess",
+			Val:        11,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_namespacemetadatanotfound",
+			Val:        1,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_namespacemetadatabusy",
+			Val:        2,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_namespacemetadataerror",
+			Val:        3,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_podmetadatasuccess",
+			Val:        12,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_podmetadatanotfound",
+			Val:        4,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_podmetadatabusy",
+			Val:        5,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_podmetadataerror",
+			Val:        6,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_namespacecachenumentries",
+			Val:        13,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_podcachenumentries",
+			Val:        14,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_namespacecachehits",
+			Val:        15,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_podcachehits",
+			Val:        16,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_namespacecachemisses",
+			Val:        17,
+			LabelValue: "test_mmkubernetes",
+		},
+		&testUnit{
+			Name:       "mmkubernetes_podcachemisses",
+			Val:        18,
+			LabelValue: "test_mmkubernetes",
+		},
+	}
+
+	mmkubernetesLog := []byte(`2017-08-30T08:10:04.786350+00:00 some-node.example.org rsyslogd-pstats: {
+		"name": "test_mmkubernetes",
+		"origin": "mmkubernetes", "recordseen": 9876, "namespacemetadatasuccess": 11, "namespacemetadatanotfound": 1,
+		"namespacemetadatabusy": 2, "namespacemetadataerror": 3, "podmetadatasuccess": 12, "podmetadatanotfound": 4,
+		"podmetadatabusy": 5, "podmetadataerror": 6, "namespacecachenumentries": 13, "podcachenumentries": 14,
+		"namespacecachehits": 15, "podcachehits": 16, "namespacecachemisses": 17, "podcachemisses": 18 }`)
+	testHelper(t, mmkubernetesLog, tests)
+}

--- a/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/imjournal.go
+++ b/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/imjournal.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type imjournal struct {
+	Name      string `json:"name"`
+	Submitted int64  `json:"submitted"`
+	Read      int64  `json:"read"`
+	Discarded int64  `json:"discarded"`
+	Failed    int64  `json:"failed"`
+	//PollFailed                   int64  `json:"poll_failed"`
+	Rotations        int64 `json:"rotations"`
+	RecoveryAttempts int64 `json:"recovery_attempts"`
+	//RatelimitDiscardedInInterval int64  `json:"ratelimit_discarded_in_interval"`
+	DiskUsageBytes int64 `json:"disk_usage_bytes"`
+}
+
+func newImjournalFromJSON(b []byte) (*imjournal, error) {
+	var pstat imjournal
+	err := json.Unmarshal(b, &pstat)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding imjournal stat `%v`: %v", string(b), err)
+	}
+	return &pstat, nil
+}
+
+func (i *imjournal) toPoints() []*point {
+	/* should be 9 - PollFailed and RatelimitDiscardedInInterval are unused */
+	points := make([]*point, 7)
+	ii := 0
+
+	points[ii] = &point{
+		Name:        "imjournal_submitted",
+		Type:        counter,
+		Value:       i.Submitted,
+		Description: "messages submitted",
+		LabelName:   "imjournal",
+		LabelValue:  i.Name,
+	}
+	ii = ii + 1
+
+	points[ii] = &point{
+		Name:        "imjournal_read",
+		Type:        counter,
+		Value:       i.Read,
+		Description: "messages read from journal",
+		LabelName:   "imjournal",
+		LabelValue:  i.Name,
+	}
+	ii = ii + 1
+
+	points[ii] = &point{
+		Name:        "imjournal_discarded",
+		Type:        counter,
+		Value:       i.Discarded,
+		Description: "messages that were read but discarded",
+		LabelName:   "imjournal",
+		LabelValue:  i.Name,
+	}
+	ii = ii + 1
+
+	points[ii] = &point{
+		Name:        "imjournal_failed",
+		Type:        counter,
+		Value:       i.Failed,
+		Description: "messages that could not be read due to failure",
+		LabelName:   "imjournal",
+		LabelValue:  i.Name,
+	}
+	ii = ii + 1
+
+	/* currently unused
+	points[ii] = &point{
+		Name:        "imjournal_poll_failed",
+		Type:        counter,
+		Value:       i.PollFailed,
+		Description: "number of times got a failure polling journal",
+		LabelName:   "imjournal",
+		LabelValue:  i.Name,
+	}
+	ii = ii + 1
+	*/
+
+	points[ii] = &point{
+		Name:        "imjournal_rotations",
+		Type:        counter,
+		Value:       i.Rotations,
+		Description: "number of journal rotations detected",
+		LabelName:   "imjournal",
+		LabelValue:  i.Name,
+	}
+	ii = ii + 1
+
+	points[ii] = &point{
+		Name:        "imjournal_recovery_attempts",
+		Type:        counter,
+		Value:       i.RecoveryAttempts,
+		Description: "number of recovery attempts",
+		LabelName:   "imjournal",
+		LabelValue:  i.Name,
+	}
+	ii = ii + 1
+
+	/* currently unused
+	points[ii] = &point{
+		Name:        "imjournal_ratelimit_discarded_in_interval",
+		Type:        counter,
+		Value:       i.RatelimitDiscardedInInterval,
+		Description: "number of ratelimit discards during poll interval",
+		LabelName:   "imjournal",
+		LabelValue:  i.Name,
+	}
+	ii = ii + 1
+	*/
+
+	points[ii] = &point{
+		Name:        "imjournal_disk_usage_bytes",
+		Type:        gauge,
+		Value:       i.DiskUsageBytes,
+		Description: "disk usage of journal in bytes",
+		LabelName:   "imjournal",
+		LabelValue:  i.Name,
+	}
+	ii = ii + 1
+
+	return points
+}

--- a/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/imjournal_test.go
+++ b/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/imjournal_test.go
@@ -1,0 +1,239 @@
+package main
+
+import "testing"
+
+var (
+	imjournalLog = []byte(`{ "name": "test_imjournal", "origin": "imjournal", "submitted": 1994, "read": 1996, "discarded": 1, "failed": 1, "poll_failed": 0, "rotations": 32, "recovery_attempts": 5, "ratelimit_discarded_in_interval": 0, "disk_usage_bytes": 75501568 }`)
+)
+
+func TestGetImjournal(t *testing.T) {
+	logType := getStatType(imjournalLog)
+	if logType != rsyslogImjournal {
+		t.Errorf("detected pstat type should be %d but is %d", rsyslogImjournal, logType)
+	}
+
+	pstat, err := newImjournalFromJSON([]byte(imjournalLog))
+	if err != nil {
+		t.Fatalf("expected parsing imjournal stat not to fail, got: %v", err)
+	}
+
+	if want, got := "test_imjournal", pstat.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(1994), pstat.Submitted; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(1996), pstat.Read; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(1), pstat.Discarded; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(1), pstat.Failed; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	/* not yet supported
+	if want, got := int64(0), pstat.PollFailed; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+	*/
+
+	if want, got := int64(32), pstat.Rotations; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(5), pstat.RecoveryAttempts; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	/* not yet supported
+	if want, got := int64(0), pstat.RatelimitDiscardedInInterval; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+	*/
+
+	if want, got := int64(75501568), pstat.DiskUsageBytes; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+}
+
+func TestImjournaltoPoints(t *testing.T) {
+	pstat, err := newImjournalFromJSON([]byte(imjournalLog))
+	if err != nil {
+		t.Fatalf("expected parsing imjournal stat not to fail, got: %v", err)
+	}
+
+	points := pstat.toPoints()
+
+	ii := 0
+	point := points[ii]
+	if want, got := "imjournal_submitted", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(1994), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_imjournal", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+	ii = ii + 1
+
+	point = points[ii]
+	if want, got := "imjournal_read", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(1996), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_imjournal", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+	ii = ii + 1
+
+	point = points[ii]
+	if want, got := "imjournal_discarded", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(1), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_imjournal", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+	ii = ii + 1
+
+	point = points[ii]
+	if want, got := "imjournal_failed", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(1), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_imjournal", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+	ii = ii + 1
+
+	/* not yet supported
+	point = points[ii]
+	if want, got := "imjournal_poll_failed", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(0), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_imjournal", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+	ii = ii + 1
+	*/
+
+	point = points[ii]
+	if want, got := "imjournal_rotations", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(32), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_imjournal", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+	ii = ii + 1
+
+	point = points[ii]
+	if want, got := "imjournal_recovery_attempts", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(5), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_imjournal", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+	ii = ii + 1
+
+	/* not yet supported
+	point = points[ii]
+	if want, got := "imjournal_ratelimit_discarded_in_interval", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(0), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_imjournal", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+	ii = ii + 1
+	*/
+
+	point = points[ii]
+	if want, got := "imjournal_disk_usage_bytes", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(75501568), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := gauge, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_imjournal", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+	ii = ii + 1
+}

--- a/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/mmkubernetes.go
+++ b/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/mmkubernetes.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type mmkubernetes struct {
+	Name                      string `json:"name"`
+	RecordSeen                int64  `json:"recordseen"`
+	NamespaceMetadataSuccess  int64  `json:"namespacemetadatasuccess"`
+	NamespaceMetadataNotfound int64  `json:"namespacemetadatanotfound"`
+	NamespaceMetadataBusy     int64  `json:"namespacemetadatabusy"`
+	NamespaceMetadataError    int64  `json:"namespacemetadataerror"`
+	PodMetadataSuccess        int64  `json:"podmetadatasuccess"`
+	PodMetadataNotfound       int64  `json:"podmetadatanotfound"`
+	PodMetadataBusy           int64  `json:"podmetadatabusy"`
+	PodMetadataError          int64  `json:"podmetadataerror"`
+	NamespaceCacheNumentries  int64  `json:"namespacecachenumentries"`
+	PodCacheNumentries        int64  `json:"podcachenumentries"`
+	NamespaceCacheHits        int64  `json:"namespacecachehits"`
+	PodCacheHits              int64  `json:"podcachehits"`
+	NamespaceCacheMisses      int64  `json:"namespacecachemisses"`
+	PodCacheMisses            int64  `json:"podcachemisses"`
+}
+
+func newMmkubernetesFromJSON(b []byte) (*mmkubernetes, error) {
+	var pstat mmkubernetes
+	err := json.Unmarshal(b, &pstat)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding mmkubernetes stat `%v`: %v", string(b), err)
+	}
+	return &pstat, nil
+}
+
+func (i *mmkubernetes) toPoints() []*point {
+	points := make([]*point, 15)
+
+	points[0] = &point{
+		Name:        "mmkubernetes_recordseen",
+		Type:        counter,
+		Value:       i.RecordSeen,
+		Description: "number of messages processed from Kubernetes container logs",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[1] = &point{
+		Name:        "mmkubernetes_namespacemetadatasuccess",
+		Type:        counter,
+		Value:       i.NamespaceMetadataSuccess,
+		Description: "number of successful queries for namespace metadata",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[2] = &point{
+		Name:        "mmkubernetes_namespacemetadatanotfound",
+		Type:        counter,
+		Value:       i.NamespaceMetadataNotfound,
+		Description: "number of unsuccessful queries for namespace metadata due to missing namespace (HTTP 404)",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[3] = &point{
+		Name:        "mmkubernetes_namespacemetadatabusy",
+		Type:        counter,
+		Value:       i.NamespaceMetadataBusy,
+		Description: "number of unsuccessful queries for namespace metadata due to busy (HTTP 429) response",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[4] = &point{
+		Name:        "mmkubernetes_namespacemetadataerror",
+		Type:        counter,
+		Value:       i.NamespaceMetadataError,
+		Description: "number of unsuccessful queries for namespace metadata due to unknown response",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[5] = &point{
+		Name:        "mmkubernetes_podmetadatasuccess",
+		Type:        counter,
+		Value:       i.PodMetadataSuccess,
+		Description: "number of successful queries for pod metadata",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[6] = &point{
+		Name:        "mmkubernetes_podmetadatanotfound",
+		Type:        counter,
+		Value:       i.PodMetadataNotfound,
+		Description: "number of unsuccessful queries for pod metadata due to missing pod (HTTP 404)",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[7] = &point{
+		Name:        "mmkubernetes_podmetadatabusy",
+		Type:        counter,
+		Value:       i.PodMetadataBusy,
+		Description: "number of unsuccessful queries for pod metadata due to busy (HTTP 429) response",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[8] = &point{
+		Name:        "mmkubernetes_podmetadataerror",
+		Type:        counter,
+		Value:       i.PodMetadataError,
+		Description: "number of unsuccessful queries for pod metadata due to unknown response",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[9] = &point{
+		Name:        "mmkubernetes_namespacecachenumentries",
+		Type:        gauge,
+		Value:       i.NamespaceCacheNumentries,
+		Description: "number of entries in namespace metadata cache",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[10] = &point{
+		Name:        "mmkubernetes_podcachenumentries",
+		Type:        gauge,
+		Value:       i.PodCacheNumentries,
+		Description: "number of entries in pod metadata cache",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[11] = &point{
+		Name:        "mmkubernetes_namespacecachehits",
+		Type:        counter,
+		Value:       i.NamespaceCacheHits,
+		Description: "number of namespace metadata cache hits",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[12] = &point{
+		Name:        "mmkubernetes_podcachehits",
+		Type:        counter,
+		Value:       i.PodCacheHits,
+		Description: "number of pod metadata cache hits",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[13] = &point{
+		Name:        "mmkubernetes_namespacecachemisses",
+		Type:        counter,
+		Value:       i.NamespaceCacheMisses,
+		Description: "number of namespace metadata cache misses",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	points[14] = &point{
+		Name:        "mmkubernetes_podcachemisses",
+		Type:        counter,
+		Value:       i.PodCacheMisses,
+		Description: "number of pod metadata cache misses",
+		LabelName:   "mmkubernetes",
+		LabelValue:  i.Name,
+	}
+
+	return points
+}

--- a/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/mmkubernetes_test.go
+++ b/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/mmkubernetes_test.go
@@ -1,0 +1,353 @@
+package main
+
+import "testing"
+
+var (
+	mmkubernetesLog = []byte(`{
+		"name": "test_mmkubernetes",
+		"origin": "mmkubernetes", "recordseen": 9876, "namespacemetadatasuccess": 11, "namespacemetadatanotfound": 1,
+		"namespacemetadatabusy": 2, "namespacemetadataerror": 3, "podmetadatasuccess": 12, "podmetadatanotfound": 4,
+		"podmetadatabusy": 5, "podmetadataerror": 6, "namespacecachenumentries": 13, "podcachenumentries": 14,
+		"namespacecachehits": 15, "podcachehits": 16, "namespacecachemisses": 17, "podcachemisses": 18 }`)
+)
+
+func TestGetMmkubernetes(t *testing.T) {
+	logType := getStatType(mmkubernetesLog)
+	if logType != rsyslogMmkubernetes {
+		t.Errorf("detected pstat type should be %d but is %d", rsyslogMmkubernetes, logType)
+	}
+
+	pstat, err := newMmkubernetesFromJSON([]byte(mmkubernetesLog))
+	if err != nil {
+		t.Fatalf("expected parsing omelasticsearch stat not to fail, got: %v", err)
+	}
+
+	if want, got := "test_mmkubernetes", pstat.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(9876), pstat.RecordSeen; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(11), pstat.NamespaceMetadataSuccess; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(1), pstat.NamespaceMetadataNotfound; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(2), pstat.NamespaceMetadataBusy; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(3), pstat.NamespaceMetadataError; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(12), pstat.PodMetadataSuccess; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(4), pstat.PodMetadataNotfound; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(5), pstat.PodMetadataBusy; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(6), pstat.PodMetadataError; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(13), pstat.NamespaceCacheNumentries; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(14), pstat.PodCacheNumentries; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(15), pstat.NamespaceCacheHits; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(16), pstat.PodCacheHits; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(17), pstat.NamespaceCacheMisses; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(18), pstat.PodCacheMisses; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+}
+
+func TestMmkubernetestoPoints(t *testing.T) {
+	pstat, err := newMmkubernetesFromJSON([]byte(mmkubernetesLog))
+	if err != nil {
+		t.Fatalf("expected parsing mmkubernetes stat not to fail, got: %v", err)
+	}
+
+	points := pstat.toPoints()
+
+	point := points[0]
+	if want, got := "mmkubernetes_recordseen", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(9876), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[1]
+	if want, got := "mmkubernetes_namespacemetadatasuccess", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(11), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[2]
+	if want, got := "mmkubernetes_namespacemetadatanotfound", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(1), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[3]
+	if want, got := "mmkubernetes_namespacemetadatabusy", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(2), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[4]
+	if want, got := "mmkubernetes_namespacemetadataerror", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(3), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[5]
+	if want, got := "mmkubernetes_podmetadatasuccess", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(12), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[6]
+	if want, got := "mmkubernetes_podmetadatanotfound", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(4), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[7]
+	if want, got := "mmkubernetes_podmetadatabusy", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(5), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[8]
+	if want, got := "mmkubernetes_podmetadataerror", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(6), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[9]
+	if want, got := "mmkubernetes_namespacecachenumentries", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(13), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := gauge, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[10]
+	if want, got := "mmkubernetes_podcachenumentries", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(14), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := gauge, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[11]
+	if want, got := "mmkubernetes_namespacecachehits", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(15), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[12]
+	if want, got := "mmkubernetes_podcachehits", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(16), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[13]
+	if want, got := "mmkubernetes_namespacecachemisses", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(17), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[14]
+	if want, got := "mmkubernetes_podcachemisses", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(18), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_mmkubernetes", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+}

--- a/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/omelasticsearch.go
+++ b/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/omelasticsearch.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type omelasticsearch struct {
+	Name                  string `json:"name"`
+	Submitted             int64  `json:"submitted"`
+	FailedHTTP            int64  `json:"failed.http"`
+	FailedHTTPRequests    int64  `json:"failed.httprequests"`
+	FailedCheckConn       int64  `json:"failed.checkConn"`
+	FailedEs              int64  `json:"failed.es"`
+	ResponseSuccess       int64  `json:"response.success"`
+	ResponseBad           int64  `json:"response.bad"`
+	ResponseDuplicate     int64  `json:"response.duplicate"`
+	ResponseBadArgument   int64  `json:"response.badargument"`
+	ResponseBulkRejection int64  `json:"response.bulkrejection"`
+	ResponseOther         int64  `json:"response.other"`
+	Rebinds               int64  `json:"rebinds"`
+}
+
+func newOmelasticsearchFromJSON(b []byte) (*omelasticsearch, error) {
+	var pstat omelasticsearch
+	err := json.Unmarshal(b, &pstat)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding omelasticsearch stat `%v`: %v", string(b), err)
+	}
+	return &pstat, nil
+}
+
+func (i *omelasticsearch) toPoints() []*point {
+	points := make([]*point, 12)
+
+	points[0] = &point{
+		Name:        "omelasticsearch_submitted",
+		Type:        counter,
+		Value:       i.Submitted,
+		Description: "number of messages submitted for output",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[1] = &point{
+		Name:        "omelasticsearch_failedhttp",
+		Type:        counter,
+		Value:       i.FailedHTTP,
+		Description: "number of messages rejected due to error returned from HTTP",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[2] = &point{
+		Name:        "omelasticsearch_failedhttprequests",
+		Type:        counter,
+		Value:       i.FailedHTTPRequests,
+		Description: "number of requests rejected due to error returned from the HTTP request",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[3] = &point{
+		Name:        "omelasticsearch_failedcheckconn",
+		Type:        counter,
+		Value:       i.FailedCheckConn,
+		Description: "number of times we failed to get a connection to Elasticsearch",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[4] = &point{
+		Name:        "omelasticsearch_failedes",
+		Type:        counter,
+		Value:       i.FailedEs,
+		Description: "number of times Elasticsearch response contained an error - detailed in responses",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[5] = &point{
+		Name:        "omelasticsearch_responsesuccess",
+		Type:        counter,
+		Value:       i.ResponseSuccess,
+		Description: "number of times Elasticsearch response was successful (HTTP 200)",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[6] = &point{
+		Name:        "omelasticsearch_responsebad",
+		Type:        counter,
+		Value:       i.ResponseBad,
+		Description: "number of times the Elasticsearch reponse could not be parsed, or was malformed",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[7] = &point{
+		Name:        "omelasticsearch_responseduplicate",
+		Type:        counter,
+		Value:       i.ResponseDuplicate,
+		Description: "number of duplicate records created e.g. by bulk index retry (HTTP 409)",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[8] = &point{
+		Name:        "omelasticsearch_responsebadargument",
+		Type:        counter,
+		Value:       i.ResponseBadArgument,
+		Description: "number of records rejected due to syntax errors, formatting, unknown arguments (e.g. HTTP 400)",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[9] = &point{
+		Name:        "omelasticsearch_responsebulkrejection",
+		Type:        counter,
+		Value:       i.ResponseBulkRejection,
+		Description: "number of records rejected due to Bulk Index Rejection (HTTP 429)",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[10] = &point{
+		Name:        "omelasticsearch_responseother",
+		Type:        counter,
+		Value:       i.ResponseOther,
+		Description: "number of records rejected due to unknown reasons",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	points[11] = &point{
+		Name:        "omelasticsearch_rebinds",
+		Type:        counter,
+		Value:       i.Rebinds,
+		Description: "number of times rsyslog reconnected to Elasticsearch",
+		LabelName:   "omelasticsearch",
+		LabelValue:  i.Name,
+	}
+
+	return points
+}

--- a/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/omelasticsearch_test.go
+++ b/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/omelasticsearch_test.go
@@ -1,0 +1,292 @@
+package main
+
+import "testing"
+
+var (
+	omelasticsearchLog = []byte(`{
+		"name": "test_omelasticsearch", "origin": "omelasticsearch", "submitted": 772, "failed.http": 10,
+		"failed.httprequests": 11, "failed.checkConn": 12, "failed.es": 13, "response.success": 700,
+		"response.bad": 1, "response.duplicate": 2, "response.badargument": 3, "response.bulkrejection": 4,
+		"response.other": 5, "rebinds": 6 }`)
+)
+
+func TestGetOmelasticsearch(t *testing.T) {
+	logType := getStatType(omelasticsearchLog)
+	if logType != rsyslogOmelasticsearch {
+		t.Errorf("detected pstat type should be %d but is %d", rsyslogOmelasticsearch, logType)
+	}
+
+	pstat, err := newOmelasticsearchFromJSON([]byte(omelasticsearchLog))
+	if err != nil {
+		t.Fatalf("expected parsing omelasticsearch stat not to fail, got: %v", err)
+	}
+
+	if want, got := "test_omelasticsearch", pstat.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(772), pstat.Submitted; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(10), pstat.FailedHTTP; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(11), pstat.FailedHTTPRequests; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(12), pstat.FailedCheckConn; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(12), pstat.FailedCheckConn; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(13), pstat.FailedEs; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(700), pstat.ResponseSuccess; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(1), pstat.ResponseBad; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(3), pstat.ResponseBadArgument; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(2), pstat.ResponseDuplicate; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(4), pstat.ResponseBulkRejection; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(5), pstat.ResponseOther; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := int64(6), pstat.Rebinds; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+}
+
+func TestOmelasticsearchtoPoints(t *testing.T) {
+	pstat, err := newOmelasticsearchFromJSON([]byte(omelasticsearchLog))
+	if err != nil {
+		t.Fatalf("expected parsing omelasticsearch stat not to fail, got: %v", err)
+	}
+
+	points := pstat.toPoints()
+
+	point := points[0]
+	if want, got := "omelasticsearch_submitted", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(772), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[1]
+	if want, got := "omelasticsearch_failedhttp", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(10), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[2]
+	if want, got := "omelasticsearch_failedhttprequests", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(11), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[3]
+	if want, got := "omelasticsearch_failedcheckconn", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(12), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[4]
+	if want, got := "omelasticsearch_failedes", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(13), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[5]
+	if want, got := "omelasticsearch_responsesuccess", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(700), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[6]
+	if want, got := "omelasticsearch_responsebad", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(1), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[7]
+	if want, got := "omelasticsearch_responseduplicate", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(2), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[8]
+	if want, got := "omelasticsearch_responsebadargument", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(3), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[9]
+	if want, got := "omelasticsearch_responsebulkrejection", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(4), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[10]
+	if want, got := "omelasticsearch_responseother", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(5), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+
+	point = points[11]
+	if want, got := "omelasticsearch_rebinds", point.Name; want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+
+	if want, got := int64(6), point.Value; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := counter, point.Type; want != got {
+		t.Errorf("want '%d', got '%d'", want, got)
+	}
+
+	if want, got := "test_omelasticsearch", point.LabelValue; want != got {
+		t.Errorf("wanted '%s', got '%s'", want, got)
+	}
+}

--- a/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/utils.go
+++ b/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter/utils.go
@@ -1,12 +1,27 @@
 package main
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	imjournalPattern        = regexp.MustCompile(`"origin"\s*:\s*"imjournal"`)
+	omelasticesearchPattern = regexp.MustCompile(`"origin"\s*:\s*"omelasticsearch"`)
+	mmkubernetesPattern     = regexp.MustCompile(`"origin"\s*:\s*"mmkubernetes"`)
+)
 
 func getStatType(buf []byte) rsyslogType {
 	line := string(buf)
 	if strings.Contains(line, "processed") {
 		return rsyslogAction
 	} else if strings.Contains(line, "submitted") {
+		// see if imjournal
+		if imjournalPattern.MatchString(line) {
+			return rsyslogImjournal
+		} else if omelasticesearchPattern.MatchString(line) {
+			return rsyslogOmelasticsearch
+		}
 		return rsyslogInput
 	} else if strings.Contains(line, "enqueued") {
 		return rsyslogQueue
@@ -14,6 +29,9 @@ func getStatType(buf []byte) rsyslogType {
 		return rsyslogResource
 	} else if strings.Contains(line, "dynstats") {
 		return rsyslogDynStat
+	} else if mmkubernetesPattern.MatchString(line) {
+		return rsyslogMmkubernetes
 	}
+
 	return rsyslogUnknown
 }

--- a/test/zzz-rsyslog.sh
+++ b/test/zzz-rsyslog.sh
@@ -9,9 +9,14 @@ os::util::environment::use_sudo
 
 os::test::junit::declare_suite_start "test/zzz-rsyslog"
 
+artifact_log Unit tests for undefined_field
 pushd ${OS_O_A_L_DIR}/rsyslog/undefined_field > /dev/null
 cp undefined_field.go $ARTIFACT_DIR || :
 cp undefined_field_test.go $ARTIFACT_DIR || :
+go test -v 2>&1 | artifact_out
+popd > /dev/null
+artifact_log Unit tests for rsyslog_exporter
+pushd ${OS_O_A_L_DIR}/rsyslog/go/src/github.com/soundcloud/rsyslog_exporter > /dev/null
 go test -v 2>&1 | artifact_out
 popd > /dev/null
 
@@ -254,7 +259,7 @@ rpod="$( get_running_pod rsyslog )"
 rpod_ip="$( oc get pod ${rpod} -o jsonpath='{.status.podIP}' )"
 
 os::cmd::try_until_success "curl -s -k https://${rpod_ip}:24231/metrics"
-curl -s -k https://${rpod_ip}:24231/metrics >> $ARTIFACT_DIR/${rpod}-metrics-scrape 2>&1 || :
+curl -s -k https://${rpod_ip}:24231/metrics > $ARTIFACT_DIR/${rpod}-metrics-scrape 2>&1
 
 # Test logrotation (LOG400) - OKD 4.2 and above
 # check rsyslog logs


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1730652
imjournal is a special case of an input plugin and its stats
look like this:
```
{ "name": "imjournal", "origin": "imjournal", "submitted": 538, "read": 538, "discarded": 0, "failed": 0, "poll_failed": 0, "rotations": 0, "recovery_attempts": 0, "ratelimit_discarded_in_interval": 0, "disk_usage_bytes": 67112960 }
```
Note that `poll_failed` and `ratelimit_discarded_in_interval` are not
currently used - rsyslog always writes a 0 for these fields.

omelasticsearch is special because it is both an output and an input
(for retries) and its stats look like this:
```
{ "name": "omelasticsearch", "origin": "omelasticsearch", "submitted": 772, "failed.http": 0, "failed.httprequests": 0, "failed.checkConn": 0, "failed.es": 0, "response.success": 0, "response.bad": 0, "response.duplicate": 0, "response.badargument": 0, "response.bulkrejection": 0, "response.other": 0, "rebinds": 0 }
```

mmkubernetes is special and has many Kubernetes specific stats:
```
{ "name": "mmkubernetes(https:\/\/kubernetes.default.svc.cluster.local:443)", "origin": "mmkubernetes", "recordseen": 253, "namespacemetadatasuccess": 12, "namespacemetadatanotfound": 0, "namespacemetadatabusy": 0, "namespacemetadataerror": 0, "podmetadatasuccess": 13, "podmetadatanotfound": 0, "podmetadatabusy": 0, "podmetadataerror": 0, "namespacecachenumentries": 12, "podcachenumentries": 13, "namespacecachehits": 1, "podcachehits": 240, "namespacecachemisses": 12, "podcachemisses": 13 }
```

All of these are now exported for Prometheus.