### PR TITLE
Bug 1735530: rsyslog undefined field handling - fluentd parity

### DIFF
--- a/rsyslog/undefined_field/undefined_field.go
+++ b/rsyslog/undefined_field/undefined_field.go
@@ -143,7 +143,7 @@ func onInit() {
 	} else {
 		checkMaxNumFields = true
 	}
-	if cfg.UseUndefined {
+	if cfg.UseUndefined || checkMaxNumFields {
 		tmpDefault := strings.Split(cfg.DefaultKeepFields, ",")
 		tmpExtra := strings.Split(cfg.ExtraKeepFields, ",")
 		keepFields = make(map[string]string)


### PR DESCRIPTION
Fixing the cases:
 - CDM_UNDEFINED_TO_STRING=true && CDM_USE_UNDEFINED=true (BAD_1 in bz)
 - CDM_USE_UNDEFINED=false && CDM_UNDEFINED_MAX_NUM_FIELDS=<NUM> (BAD_2 in bz)