### PR TITLE
Bug 1730945: Rsyslog pod always restart when set `ES_REBIND_INTERVAL…

### DIFF
--- a/rsyslog/vendored_src/rsyslog/rsyslog/plugins/omelasticsearch/omelasticsearch.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/plugins/omelasticsearch/omelasticsearch.c
@@ -1482,6 +1482,12 @@ curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls
 		/* by default, reuse existing connections */
 		curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 0);
 	}
+	if ((pWrkrData->pData->rebindInterval > -1) &&
+		(pWrkrData->nOperations == pWrkrData->pData->rebindInterval)) {
+		curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1);
+	} else {
+		curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 0);
+	}
 
 	if(pWrkrData->pData->numServers > 1) {
 		/* needs to be called to support ES HA feature */


### PR DESCRIPTION
…` to a small value.

omelasticsearch - force to close connection by setting CURLOPT_FORBID_REUSE to 1
                  when the count of operation reaches rebindinterval.