### PR TITLE
Bug 1735530: rsyslog undefined field handling - fluentd parity

### DIFF
--- a/rsyslog/undefined_field/undefined_field.go
+++ b/rsyslog/undefined_field/undefined_field.go
@@ -143,16 +143,14 @@ func onInit() {
 	} else {
 		checkMaxNumFields = true
 	}
-	if cfg.UseUndefined || checkMaxNumFields {
-		tmpDefault := strings.Split(cfg.DefaultKeepFields, ",")
-		tmpExtra := strings.Split(cfg.ExtraKeepFields, ",")
-		keepFields = make(map[string]string)
-		for _, str := range tmpDefault {
-			keepFields[str] = str
-		}
-		for _, str := range tmpExtra {
-			keepFields[str] = str
-		}
+	tmpDefault := strings.Split(cfg.DefaultKeepFields, ",")
+	tmpExtra := strings.Split(cfg.ExtraKeepFields, ",")
+	keepFields = make(map[string]string)
+	for _, str := range tmpDefault {
+		keepFields[str] = str
+	}
+	for _, str := range tmpExtra {
+		keepFields[str] = str
 	}
 	tmp := strings.Split(cfg.KeepEmptyFields, ",")
 	keepEmptyFields = make(map[string]string)
@@ -214,7 +212,7 @@ func processUndefinedAndMaxNumFields(input map[string]interface{}) (string, map[
 		for field := range undefMap {
 			delete(input, field)
 		}
-		if (checkMaxNumFields && count < 0) {
+		if checkMaxNumFields && count < 0 {
 			// undefined fields converted to string - no undefMap
 			b, err := json.Marshal(undefMap)
 			return string(b), nil, err
@@ -389,6 +387,50 @@ func processUndefinedAndEmpty(input map[string]interface{}, hasDefinedFields, ha
 	return inputWasModified
 }
 
+// The given rawStr is only used for logging purposes.  The given
+// input map is modified in-place.  The return value is false if there
+// were errors, or no changes were made to the given input.  If the
+// return value is true, the caller needs to handle outputting the
+// new fields.
+func processFields(rawStr string, input map[string]interface{}) bool {
+	changes := false
+	undefString, undefMap, err := processUndefinedAndMaxNumFields(input)
+	if err != nil {
+		// error marshalling undefined fields to JSON
+		if cfg.Debug {
+			fmt.Fprintf(logfile, "Unable to convert undefined fields to JSON string: %v : rawStr: %s\n", err, rawStr)
+		}
+		fmt.Println(noChanges)
+		return changes
+	}
+	if len(undefString) > 0 || undefMap != nil {
+		changes = true
+	}
+	if undefMap != nil {
+		// changes is already true, so ignore the return value
+		_ = processUndefinedAndEmpty(undefMap, false, true)
+	}
+	if len(input) > 0 {
+		if processUndefinedAndEmpty(input, true, (undefMap == nil)) {
+			changes = true
+		}
+	}
+	if !changes {
+		if cfg.Debug {
+			fmt.Fprintln(logfile, "No Need to Replace for ", rawStr)
+		}
+		fmt.Println(noChanges)
+		return changes
+	}
+	if len(undefString) > 0 {
+		input[cfg.UndefinedName] = undefString
+	} else if undefMap != nil && len(undefMap) > 0 {
+		// if len is 0, means all fields were empty
+		input[cfg.UndefinedName] = undefMap
+	}
+	return changes
+}
+
 func main() {
 
 	onInit()
@@ -432,41 +474,8 @@ func main() {
 			fmt.Println(noChanges)
 			continue
 		}
-		undefString, undefMap, err := processUndefinedAndMaxNumFields(topval)
-		if err != nil {
-			// error marshalling undefined fields to JSON
-			if cfg.Debug {
-				fmt.Fprintf(logfile, "Unable to convert undefined fields to JSON string: %v : rawStr: %s\n", err, rawStr)
-			}
-			fmt.Println(noChanges)
+		if !processFields(rawStr, topval) {
 			continue
-		}
-		changes := false
-		if len(undefString) > 0 || undefMap != nil {
-			changes = true
-		}
-		if undefMap != nil {
-			if processUndefinedAndEmpty(undefMap, false, true) {
-				changes = true
-			}
-		}
-		if len(topval) > 0 {
-			if processUndefinedAndEmpty(topval, true, (undefMap == nil)) {
-				changes = true
-			}
-		}
-		if !changes {
-			if cfg.Debug {
-				fmt.Fprintln(logfile, "No Need to Replace for ", rawStr)
-			}
-			fmt.Println(noChanges)
-			continue
-		}
-		if len(undefString) > 0 {
-			topval[cfg.UndefinedName] = undefString
-		} else if undefMap != nil && len(undefMap) > 0 {
-			// if len is 0, means all fields were empty
-			topval[cfg.UndefinedName] = undefMap
 		}
 		loggingAll := map[string]interface{}{
 			"openshift_logging_all": topval,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1735530
We have to do undefined field checking in all cases, not only
when `CDM_USE_UNDEFINED=true` or when checking for max num fields.
I also refactored the code somewhat so that we could easily test
combinations of `CDM_USE_UNDEFINED=true` and max num field checking
with `CDM_UNDEFINED_TO_STRING=true` and `CDM_UNDEFINED_DOT_REPLACE_CHAR`
and empty field processing.