### PR TITLE
Bug 1740263: enable the parsing of docker log-driver=json-file continuation lines using fluent concat plugin

### DIFF
--- a/fluentd/configs.d/filter-pre-systemd-multiline.conf
+++ b/fluentd/configs.d/filter-pre-systemd-multiline.conf
@@ -1,0 +1,23 @@
+# concat requires that every record to concat has
+# the field CONTAINER_PARTIAL_MESSAGE - but we don't
+# want to unconditionally add CONTAINER_PARTIAL_MESSAGE
+# to every journal record - this trick allows us to
+# add the field CONTAINER_PARTIAL_MESSAGE=false
+# only if this is a container log and the record does not
+# already have CONTAINER_PARTIAL_MESSAGE
+# does not work with record_transformer :-(
+<filter journal>
+  @type record_modifier
+  <record>
+    ignoreme ${if record.key?("CONTAINER_ID_FULL") && !record.key?("CONTAINER_PARTIAL_MESSAGE"); record["CONTAINER_PARTIAL_MESSAGE"] = "false"; end; "ignoreme"}
+  </record>
+  remove_keys ignoreme
+</filter>
+<filter journal>
+  @type concat
+  key MESSAGE
+  separator ""
+  stream_identity_key CONTAINER_ID_FULL
+  partial_key CONTAINER_PARTIAL_MESSAGE
+  partial_value true
+</filter>

--- a/fluentd/lib/filter_concat/filter_concat.gemspec
+++ b/fluentd/lib/filter_concat/filter_concat.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("rr", ["~> 1.0"])
   gem.add_development_dependency("test-unit", ["~> 3.2"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
+  gem.add_development_dependency "debase"
+  gem.add_development_dependency "ruby-debug-ide"
 end

--- a/fluentd/lib/filter_concat/test/filter_concat_test.rb
+++ b/fluentd/lib/filter_concat/test/filter_concat_test.rb
@@ -1,79 +1,1099 @@
 require 'fluent/test'
 require 'test/unit/rr'
+require 'rr'
 require File.join(File.dirname(__FILE__), '..', 'lib/filter_concat') 
 
 class ConcatFilterTest < Test::Unit::TestCase
   include Fluent
 
+  CONFIG = %[
+    key message
+    n_lines 3
+  ]
+
+  TEST_TAG = 'test'
+
   setup do
     Fluent::Test.setup
     @time = Fluent::Engine.now
-    log = Fluent::Engine.log
-    @timestamp = Time.now
-    @timestamp_str = @timestamp.utc.to_datetime.rfc3339(6)
-    stub(Time).now { @timestamp }
   end
 
-  def create_driver(conf = '')
-    d = Test::FilterTestDriver.new(ConcatFilter, 'this.is.a.tag').configure(conf, true)
-    d.instance.log_level = 'DEBUG'
-    @dlog = d.instance.log
-    d
+  def create_driver(conf = CONFIG)
+    Test::FilterTestDriver.new(ConcatFilter, TEST_TAG).configure(conf, true)
   end
 
-  def emit_with_tag(tag, msg0={}, msg1={}, msg2={}, conf='')
+  def filter(conf, messages, wait: nil)
     d = create_driver(conf)
-    d.run {
-      d.emit_with_tag(tag, msg0, @time)
-      d.emit_with_tag(tag, msg1, @time) unless msg1 == {}
-      d.emit_with_tag(tag, msg2, @time) unless msg2 == {}
-    }.filtered.instance_variable_get(:@record_array)[0]
-  end  
-
-  sub_test_case 'configure' do
-    test 'check setting all params to non-default values' do
-      d = create_driver('
-        key log
-        partial_key logtag
-        partial_value P
-      ')
-      assert_equal(false, d.instance.keep_partial_key)
-      assert_equal('log', d.instance.key)
-      assert_equal('logtag', d.instance.partial_key)
-      assert_equal('P', d.instance.partial_value)
+    def d.logs
+      @instance.log.logs
     end
+    yield d if block_given?
+    d.run do
+      sleep 0.1 # run event loop
+      messages.each do |message|
+        d.emit(message, @time)
+      end
+      sleep wait if wait
+    end
+    # return an array of records
+    d.filtered.collect{|time,record| record}
   end
 
-  sub_test_case 'merge multilines' do
+  def filter_with_time(conf, messages, wait: nil)
+    d = create_driver(conf)
+    def d.logs
+      @instance.log.logs
+    end
+    yield d if block_given?
+    d.run do
+      sleep 0.1 # run event loop
+      messages.each do |time, message|
+        d.emit(message, time)
+      end
+      sleep wait if wait
+    end
+    # return an array of [time, record]
+    d.filtered.collect{|time,record| [time, record]}
+  end
+
+  sub_test_case "crio" do
     test 'full log message remains intact' do
-      message0 = 'This is a full log message.'
-      rec = emit_with_tag('tag', {'log'=>message0, 'logtag'=>'F'}, {}, {}, '
+      config = <<-CONFIG
         key log
         partial_key logtag
         partial_value P
-      ')
-      assert_equal({'log'=>message0}, rec)
+        separator ""
+      CONFIG
+      message0 = 'This is a full log message.'
+      rec = filter(config, [{'log'=>message0, 'logtag'=>'F'}])
+      assert_equal({'log'=>message0}, rec[0])
     end
     test 'partial log + full log message' do
-      message0 = 'First_part'
-      message1 = 'Second_part'
-      rec = emit_with_tag('tag', {'log'=>message0, 'logtag'=>'P'}, {'log'=>message1, 'logtag'=>'F'}, {}, '
+      config = <<-CONFIG
         key log
         partial_key logtag
         partial_value P
-      ')
-      assert_equal({'log'=>message0+message1}, rec)
+        separator ""
+      CONFIG
+      message0 = 'First_part'
+      message1 = 'Second_part'
+      rec = filter(config, [{'log'=>message0, 'logtag'=>'P'}, {'log'=>message1, 'logtag'=>'F'}])
+      assert_equal({'log'=>message0+message1}, rec[0])
     end
     test 'partial log + partial log + full log message' do
+      config = <<-CONFIG
+        key log
+        partial_key logtag
+        partial_value P
+        separator ""
+      CONFIG
       message0 = 'First_part'
       message1 = 'Second_part'
       message2 = 'Thirrd_part'
-      rec = emit_with_tag('tag', {'log'=>message0, 'logtag'=>'P'}, {'log'=>message1, 'logtag'=>'P'}, {'log'=>message2, 'logtag'=>'F'}, '
+      rec = filter(config, [{'log'=>message0, 'logtag'=>'P'}, {'log'=>message1, 'logtag'=>'P'}, {'log'=>message2, 'logtag'=>'F'}])
+      assert_equal({'log'=>message0+message1+message2}, rec[0])
+    end
+  end
+
+  sub_test_case "multiline docker json" do
+    test 'full log message remains intact' do
+      config = <<-CONFIG
         key log
-        partial_key logtag
+        multiline_end_regexp /\\n$/
+        separator ""
+      CONFIG
+      message0 = "This is a full log message.\n"
+      rec = filter(config, [{'log'=>message0}])
+      assert_equal({'log'=>message0}, rec[0])
+    end
+    test 'partial log + full log message' do
+      config = <<-CONFIG
+        key log
+        multiline_end_regexp /\\n$/
+        separator ""
+      CONFIG
+      message0 = "First_part"
+      message1 = "Second_part\n"
+      rec = filter(config, [{'log'=>message0}, {'log'=>message1}])
+      assert_equal({'log'=>message0+message1}, rec[0])
+    end
+    test 'partial log + partial log + full log message' do
+      config = <<-CONFIG
+        key log
+        multiline_end_regexp /\\n$/
+        separator ""
+      CONFIG
+      message0 = "First_part"
+      message1 = "Second_part"
+      message2 = "Thirrd_part\n"
+      rec = filter(config, [{'log'=>message0}, {'log'=>message1}, {'log'=>message2}])
+      assert_equal({'log'=>message0+message1+message2}, rec[0])
+    end
+  end
+
+  sub_test_case "config" do
+    test "empty" do
+      assert_raise(Fluent::ConfigError.new("'key' parameter is required")) do
+        create_driver("")
+      end
+    end
+
+    test "exclusive" do
+      assert_raise(Fluent::ConfigError.new("n_lines and multiline_start_regexp/multiline_end_regexp are exclusive")) do
+        create_driver(<<-CONFIG)
+          key message
+          n_lines 10
+          multiline_start_regexp /^start/
+        CONFIG
+      end
+    end
+
+    test "either" do
+      assert_raise(Fluent::ConfigError.new("Either n_lines, multiline_start_regexp, multiline_end_regexp, partial_key or use_partial_metadata is required")) do
+        create_driver(<<-CONFIG)
+          key message
+        CONFIG
+      end
+    end
+
+    test "partial_key with n_lines" do
+      assert_raise(Fluent::ConfigError.new("partial_key and n_lines are exclusive")) do
+        create_driver(<<-CONFIG)
+          key message
+          n_lines 10
+          partial_key partial_message
+        CONFIG
+      end
+    end
+
+    test "partial_key with multiline_start_regexp" do
+      assert_raise(Fluent::ConfigError.new("partial_key and multiline_start_regexp/multiline_end_regexp are exclusive")) do
+        create_driver(<<-CONFIG)
+          key message
+          multiline_start_regexp /xxx/
+          partial_key partial_message
+        CONFIG
+      end
+    end
+
+    test "partial_key with multiline_end_regexp" do
+      assert_raise(Fluent::ConfigError.new("partial_key and multiline_start_regexp/multiline_end_regexp are exclusive")) do
+        create_driver(<<-CONFIG)
+          key message
+          multiline_end_regexp /xxx/
+          partial_key partial_message
+        CONFIG
+      end
+    end
+
+    test "partial_key is specified but partial_value is missing" do
+      assert_raise(Fluent::ConfigError.new("partial_value is required when partial_key is specified")) do
+        create_driver(<<-CONFIG)
+          key message
+          partial_key partial_message
+        CONFIG
+      end
+    end
+
+    test "n_lines" do
+      d = create_driver
+      assert_equal(:line, d.instance.instance_variable_get(:@mode))
+    end
+
+    test "multiline_start_regexp" do
+      d = create_driver(<<-CONFIG)
+        key message
+        multiline_start_regexp /^start/
+      CONFIG
+      assert_equal(:regexp, d.instance.instance_variable_get(:@mode))
+    end
+
+    test "multiline_end_regexp" do
+      d = create_driver(<<-CONFIG)
+        key message
+        multiline_end_regexp /^end/
+      CONFIG
+      assert_equal(:regexp, d.instance.instance_variable_get(:@mode))
+    end
+  end
+
+  sub_test_case "lines" do
+    test "filter" do
+      messages = [
+        { "host" => "example.com", "message" => "message 1" },
+        { "host" => "example.com", "message" => "message 2" },
+        { "host" => "example.com", "message" => "message 3" },
+      ]
+      expected = [
+        { "host" => "example.com", "message" => "message 1\nmessage 2\nmessage 3" }
+      ]
+      filtered = filter(CONFIG, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "filter excess" do
+      messages = [
+        { "host" => "example.com", "message" => "message 1" },
+        { "host" => "example.com", "message" => "message 2" },
+        { "host" => "example.com", "message" => "message 3" },
+        { "host" => "example.com", "message" => "message 4" },
+      ]
+      expected = [
+        { "host" => "example.com", "message" => "message 1\nmessage 2\nmessage 3" }
+      ]
+      filtered = filter(CONFIG, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "filter 2 groups" do
+      messages = [
+        { "host" => "example.com", "message" => "message 1" },
+        { "host" => "example.com", "message" => "message 2" },
+        { "host" => "example.com", "message" => "message 3" },
+        { "host" => "example.com", "message" => "message 4" },
+        { "host" => "example.com", "message" => "message 5" },
+        { "host" => "example.com", "message" => "message 6" },
+      ]
+      expected = [
+        { "host" => "example.com", "message" => "message 1\nmessage 2\nmessage 3" },
+        { "host" => "example.com", "message" => "message 4\nmessage 5\nmessage 6" },
+      ]
+      filtered = filter(CONFIG, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "missing keys" do
+      messages = [
+        { "host" => "example.com", "message" => "message 1" },
+        { "host" => "example.com", "message" => "message 2" },
+        { "host" => "example.com", "message" => "message 3" },
+        { "host" => "example.com", "message" => "message 4" },
+        { "host" => "example.com", "message" => "message 5" },
+        { "host" => "example.com", "message" => "message 6" },
+        { "host" => "example.com", "somekey" => "message 7" },
+      ]
+      expected = [
+        { "host" => "example.com", "message" => "message 1\nmessage 2\nmessage 3" },
+        { "host" => "example.com", "message" => "message 4\nmessage 5\nmessage 6" },
+        { "host" => "example.com", "somekey" => "message 7" },
+      ]
+      filtered = filter(CONFIG, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "stream identity" do
+      messages = [
+        { "container_id" => "1", "message" => "message 1" },
+        { "container_id" => "2", "message" => "message 2" },
+        { "container_id" => "1", "message" => "message 3" },
+        { "container_id" => "2", "message" => "message 4" },
+        { "container_id" => "1", "message" => "message 5" },
+        { "container_id" => "2", "message" => "message 6" },
+      ]
+      expected = [
+        { "container_id" => "1", "message" => "message 1\nmessage 3\nmessage 5" },
+        { "container_id" => "2", "message" => "message 2\nmessage 4\nmessage 6" },
+      ]
+      filtered = filter(CONFIG + "stream_identity_key container_id", messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "timeout" do
+      messages = [
+        { "container_id" => "1", "message" => "message 1" },
+        { "container_id" => "1", "message" => "message 2" },
+      ]
+      filtered = filter(CONFIG + "flush_interval 2s", messages, wait: 3) do |d|
+        errored = { "container_id" => "1", "message" => "message 1\nmessage 2" }
+        mock(d.instance.router).emit_error_event(TEST_TAG, anything, errored, anything)
+      end
+      assert_equal([], filtered)
+    end
+
+    test "timeout with timeout_label" do
+      messages = [
+        { "container_id" => "1", "message" => "message 1" },
+        { "container_id" => "1", "message" => "message 2" },
+      ]
+      filtered = filter(CONFIG + "flush_interval 2s\ntimeout_label @TIMEOUT", messages, wait: 3) do |d|
+        errored = { "container_id" => "1", "message" => "message 1\nmessage 2" }
+        event_router = mock(Object.new).emit(TEST_TAG, anything, errored)
+        label = mock(Object.new).event_router { event_router }
+        mock(Fluent::Engine.root_agent).find_label("@TIMEOUT") { label }
+      end
+      assert_equal([], filtered)
+    end
+
+    test "no timeout" do
+      messages = [
+        { "container_id" => "1", "message" => "message 1" },
+        { "container_id" => "1", "message" => "message 2" },
+        { "container_id" => "1", "message" => "message 3" },
+      ]
+      filtered = filter(CONFIG + "flush_interval 30s", messages, wait: 3) do |d|
+        errored = { "container_id" => "1", "message" => "message 1\nmessage 2\nmessage 3" }
+        mock(d.instance.router).emit_error_event(TEST_TAG, anything, errored, anything).times(0)
+      end
+      expected = [
+        { "container_id" => "1", "message" => "message 1\nmessage 2\nmessage 3" },
+      ]
+      assert_equal(expected, filtered)
+    end
+  end
+
+  sub_test_case "regexp" do
+    test "filter" do
+      config = <<-CONFIG
+        key message
+        multiline_start_regexp /^start/
+      CONFIG
+      messages = [
+        { "host" => "example.com", "message" => "start" },
+        { "host" => "example.com", "message" => "  message 1" },
+        { "host" => "example.com", "message" => "  message 2" },
+        { "host" => "example.com", "message" => "start" },
+        { "host" => "example.com", "message" => "  message 3" },
+        { "host" => "example.com", "message" => "  message 4" },
+        { "host" => "example.com", "message" => "start" },
+      ]
+      expected = [
+        { "host" => "example.com", "message" => "start\n  message 1\n  message 2" },
+        { "host" => "example.com", "message" => "start\n  message 3\n  message 4" },
+      ]
+      filtered = filter(config, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "stream identity" do
+      config = <<-CONFIG
+        key message
+        stream_identity_key container_id
+        multiline_start_regexp /^start/
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 1" },
+        { "container_id" => "1", "message" => "  message 2" },
+        { "container_id" => "2", "message" => "start" },
+        { "container_id" => "2", "message" => "  message 3" },
+        { "container_id" => "2", "message" => "  message 4" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "2", "message" => "  message 5" },
+        { "container_id" => "2", "message" => "start" },
+      ]
+      expected = [
+        { "container_id" => "1", "message" => "start\n  message 1\n  message 2" },
+        { "container_id" => "2", "message" => "start\n  message 3\n  message 4\n  message 5" },
+      ]
+      filtered = filter(config, messages) do |d|
+        errored1 = { "container_id" => "1", "message" => "start" }
+        errored2 = { "container_id" => "2", "message" => "start" }
+        router = d.instance.router
+        mock(router).emit_error_event(TEST_TAG, anything, errored1, anything)
+        mock(router).emit_error_event(TEST_TAG, anything, errored2, anything)
+      end
+      assert_equal(expected, filtered)
+    end
+
+    test "multiline_end_regexp" do
+      config = <<-CONFIG
+        key message
+        stream_identity_key container_id
+        multiline_start_regexp /^start/
+        multiline_end_regexp /^end/
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "2", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 1" },
+        { "container_id" => "2", "message" => "  message 3" },
+        { "container_id" => "1", "message" => "  message 2" },
+        { "container_id" => "2", "message" => "  message 4" },
+        { "container_id" => "1", "message" => "end" },
+        { "container_id" => "2", "message" => "end" },
+      ]
+      expected = [
+        { "container_id" => "1", "message" => "start\n  message 1\n  message 2\nend" },
+        { "container_id" => "2", "message" => "start\n  message 3\n  message 4\nend" },
+      ]
+      filtered = filter(config, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "multiline with single line logs" do
+      config = <<-CONFIG
+        key message
+        stream_identity_key container_id
+        multiline_start_regexp /^start/
+        multiline_end_regexp /^end/
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "single1" },
+        { "container_id" => "2", "message" => "single2" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "2", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 1" },
+        { "container_id" => "2", "message" => "  message 3" },
+        { "container_id" => "1", "message" => "  message 2" },
+        { "container_id" => "2", "message" => "  message 4" },
+        { "container_id" => "1", "message" => "end" },
+        { "container_id" => "2", "message" => "end" },
+        { "container_id" => "1", "message" => "single3" },
+        { "container_id" => "2", "message" => "single4" },
+      ]
+      expected = [
+        { "container_id" => "1", "message" => "single1" },
+        { "container_id" => "2", "message" => "single2" },
+        { "container_id" => "1", "message" => "start\n  message 1\n  message 2\nend" },
+        { "container_id" => "2", "message" => "start\n  message 3\n  message 4\nend" },
+        { "container_id" => "1", "message" => "single3" },
+        { "container_id" => "2", "message" => "single4" },
+      ]
+      filtered = filter(config, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "multiline_start_regexp and multiline_end_regexp" do
+      config = <<-CONFIG
+        key message
+        stream_identity_key container_id
+        multiline_start_regexp /^start/
+        multiline_end_regexp /end$/
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start message end" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => " message1" },
+        { "container_id" => "1", "message" => " message2" },
+        { "container_id" => "1", "message" => "end" },
+      ]
+      expected = [
+        { "container_id" => "1", "message" => "start message end" },
+        { "container_id" => "1", "message" => "start\n message1\n message2\nend" },
+      ]
+      filtered = filter(config, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "multiline_end_regexp only" do
+      config = <<-CONFIG
+        key message
+        stream_identity_key container_id
+        multiline_end_regexp /\\n$/
+      CONFIG
+      messages = [
+          { "host" => "example.com", "message" => "{\"key1\": \"value1\",\"key2\": \"value2\"}\n" },
+          { "host" => "example.com", "message" => "{\"key3\": \"value3\",\"key4\": \"value4\"," },
+          { "host" => "example.com", "message" => "\"key5\": \"value5\",\"key6\": \"value6\"," },
+          { "host" => "example.com", "message" => "\"key7\": \"value7\",\"key8\": \"value8\"}\n" },
+          { "host" => "example.com", "message" => "{\"key9\": \"value9\",\"key0\": \"value0\"," },
+          { "host" => "example.com", "message" => "\"key1\": \"value1\",\"key2\": \"value2\"}\n" },
+      ]
+      expected = [
+          { "host" => "example.com","message" => "{\"key1\": \"value1\",\"key2\": \"value2\"}\n" },
+          { "host" => "example.com","message" => "{\"key3\": \"value3\",\"key4\": \"value4\",\n\"key5\": \"value5\",\"key6\": \"value6\",\n\"key7\": \"value7\",\"key8\": \"value8\"}\n" },
+          { "host" => "example.com","message" => "{\"key9\": \"value9\",\"key0\": \"value0\",\n\"key1\": \"value1\",\"key2\": \"value2\"}\n" },
+      ]
+      filtered = filter(config, messages)
+      assert_equal(expected, filtered)
+    end
+
+    # https://github.com/okkez/fluent-plugin-concat/issues/14
+    test "multiline_start_regexp and multiline_end_regexp #14" do
+      config = <<-CONFIG
+        key message
+        stream_identity_key container_id
+        multiline_start_regexp /^start/
+        multiline_end_regexp /end$/
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start message1 end" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => " message3" },
+        { "container_id" => "1", "message" => "start message2 end" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => " message4" },
+        { "container_id" => "1", "message" => "end" },
+      ]
+      expected = [
+        { "container_id" => "1", "message" => "start message1 end" },
+        { "container_id" => "1", "message" => "start\n message3" },
+        { "container_id" => "1", "message" => "start message2 end" },
+        { "container_id" => "1", "message" => "start\n message4\nend" },
+      ]
+      filtered = filter(config, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "timeout" do
+      config = <<-CONFIG
+        key message
+        multiline_start_regexp /^start/
+        flush_interval 1s
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 1" },
+        { "container_id" => "1", "message" => "  message 2" },
+      ]
+      filtered = filter(config, messages, wait: 3) do |d|
+        errored = { "container_id" => "1", "message" => "start\n  message 1\n  message 2" }
+        mock(d.instance.router).emit_error_event(TEST_TAG, anything, errored, anything)
+      end
+      assert_equal([], filtered)
+    end
+
+    test "continuous_line_regexp" do
+      config = <<-CONFIG
+        key message
+        multiline_start_regexp /^start/
+        continuous_line_regexp /^ /
+        flush_interval 1s
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 1" },
+        { "container_id" => "1", "message" => "  message 2" },
+        { "container_id" => "1", "message" => "single line message 1" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 3" },
+        { "container_id" => "1", "message" => "  message 4" },
+        { "container_id" => "1", "message" => "single line message 2" },
+      ]
+      filtered = filter(config, messages, wait: 3)
+      expected = [
+        { "container_id" => "1", "message" => "start\n  message 1\n  message 2" },
+        { "container_id" => "1", "message" => "single line message 1" },
+        { "container_id" => "1", "message" => "start\n  message 3\n  message 4" },
+        { "container_id" => "1", "message" => "single line message 2" },
+      ]
+      assert_equal(expected, filtered)
+    end
+
+    test "missing keys" do
+      config = <<-CONFIG
+        key message
+        multiline_start_regexp /^start/
+        continuous_line_regexp /^ /
+        flush_interval 1s
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 1" },
+        { "container_id" => "1", "message" => "  message 2" },
+        { "container_id" => "1", "message" => "single line message 1" },
+        { "container_id" => "2", "nomessage" => "This is not message" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 3" },
+        { "container_id" => "1", "message" => "  message 4" },
+        { "container_id" => "1", "message" => "single line message 2" },
+      ]
+      filtered = filter(config, messages, wait: 3)
+      expected = [
+        { "container_id" => "1", "message" => "start\n  message 1\n  message 2" },
+        { "container_id" => "1", "message" => "single line message 1" },
+        { "container_id" => "2", "nomessage" => "This is not message" },
+        { "container_id" => "1", "message" => "start\n  message 3\n  message 4" },
+        { "container_id" => "1", "message" => "single line message 2" },
+      ]
+      assert_equal(expected, filtered)
+    end
+
+    test "value is nil" do
+      config = <<-CONFIG
+        key message
+        stream_identity_key container_id
+        multiline_start_regexp /^start/
+        continuous_line_regexp /^ /
+        flush_interval 1s
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 1" },
+        { "container_id" => "1", "message" => "  message 2" },
+        { "container_id" => "1", "message" => nil },
+        { "container_id" => "1", "message" => "single line message 1" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 3" },
+        { "container_id" => "1", "message" => "  message 4" },
+        { "container_id" => "1", "message" => "single line message 2" },
+      ]
+      filtered = filter(config, messages, wait: 3)
+      expected = [
+        { "container_id" => "1", "message" => "start\n  message 1\n  message 2" },
+        { "container_id" => "1", "message" => nil },
+        { "container_id" => "1", "message" => "single line message 1" },
+        { "container_id" => "1", "message" => "start\n  message 3\n  message 4" },
+        { "container_id" => "1", "message" => "single line message 2" },
+      ]
+      assert_equal(expected, filtered)
+    end
+  end
+
+  sub_test_case "partial_key" do
+    test "filter with docker style events" do
+      config = <<-CONFIG
+        key message
+        partial_key partial_message
+        partial_value true
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 1", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 2", "partial_message" => "true" },
+        { "container_id" => "1", "message" => "end", "partial_message" => "false" },
+        { "container_id" => "1", "message" => "start", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 3", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 4", "partial_message" => "true" },
+        { "container_id" => "1", "message" => "end", "partial_message" => "false" },
+      ]
+      filtered = filter(config, messages, wait: 3)
+      expected = [
+        { "container_id" => "1", "message" => "start\n message 1\n message 2\nend" },
+        { "container_id" => "1", "message" => "start\n message 3\n message 4\nend" },
+      ]
+      assert_equal(expected, filtered)
+    end
+
+    test "filter with docker style events keep partial_key" do
+      config = <<-CONFIG
+        key message
+        partial_key partial_message
+        partial_value true
+        keep_partial_key true
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 1", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 2", "partial_message" => "true" },
+        { "container_id" => "1", "message" => "end", "partial_message" => "false" },
+        { "container_id" => "1", "message" => "start", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 3", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 4", "partial_message" => "true" },
+        { "container_id" => "1", "message" => "end", "partial_message" => "false" },
+      ]
+      filtered = filter(config, messages, wait: 3)
+      expected = [
+        { "container_id" => "1", "message" => "start\n message 1\n message 2\nend", "partial_message" => "false" },
+        { "container_id" => "1", "message" => "start\n message 3\n message 4\nend", "partial_message" => "false" },
+      ]
+      assert_equal(expected, filtered)
+    end
+
+    test "filter with docker style events keep partial_key includes single line event" do
+      config = <<-CONFIG
+        key message
+        partial_key partial_message
+        partial_value true
+        keep_partial_key true
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 1", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 2", "partial_message" => "true" },
+        { "container_id" => "1", "message" => "end", "partial_message" => "false" },
+        { "container_id" => "1", "message" => "single line" },
+        { "container_id" => "1", "message" => "start", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 3", "partial_message" => "true" },
+        { "container_id" => "1", "message" => " message 4", "partial_message" => "true" },
+        { "container_id" => "1", "message" => "end", "partial_message" => "false" },
+      ]
+      filtered = filter(config, messages, wait: 3)
+      expected = [
+        { "container_id" => "1", "message" => "start\n message 1\n message 2\nend", "partial_message" => "false" },
+        { "container_id" => "1", "message" => "single line" },
+        { "container_id" => "1", "message" => "start\n message 3\n message 4\nend", "partial_message" => "false" },
+      ]
+      assert_equal(expected, filtered)
+    end
+
+    test "filter with containerd/cri style events" do
+      config = <<-CONFIG
+        key message
+        partial_key flag
         partial_value P
-      ')
-      assert_equal({'log'=>message0+message1+message2}, rec)
+      CONFIG
+      # These messages are parsed by a parser plugin before this plugin will process messages
+      messages = [
+        { "container_id" => "1", "message" => "start", "flag" => "P" },
+        { "container_id" => "1", "message" => " message 1", "flag" => "P" },
+        { "container_id" => "1", "message" => " message 2", "flag" => "P" },
+        { "container_id" => "1", "message" => "end", "flag" => "F" },
+        { "container_id" => "1", "message" => "start", "flag" => "P" },
+        { "container_id" => "1", "message" => " message 3", "flag" => "P" },
+        { "container_id" => "1", "message" => " message 4", "flag" => "P" },
+        { "container_id" => "1", "message" => "end", "flag" => "F" },
+      ]
+      filtered = filter(config, messages, wait: 3)
+      expected = [
+        { "container_id" => "1", "message" => "start\n message 1\n message 2\nend" },
+        { "container_id" => "1", "message" => "start\n message 3\n message 4\nend" },
+      ]
+      assert_equal(expected, filtered)
+    end
+  end
+
+  sub_test_case "partial meta (for Docker 19.03 or later)" do
+    test "partial messages only" do
+      config = <<-CONFIG
+        key message
+        use_partial_metadata true
+      CONFIG
+      messages = [
+        {
+          "container_id" => "1",
+          "message" => "start",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "1",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 1",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "2",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 2",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "3",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => "end",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "4",
+          "partial_last" => "true"
+        },
+        {
+          "container_id" => "1",
+          "message" => "start",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "1",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 3",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "2",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 4",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "3",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => "end",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "4",
+          "partial_last" => "true"
+        },
+      ]
+      filtered = filter(config, messages, wait: 3)
+      expected = [
+        { "container_id" => "1", "message" => "start\n message 1\n message 2\nend" },
+        { "container_id" => "1", "message" => "start\n message 3\n message 4\nend" },
+      ]
+      assert_equal(expected, filtered)
+    end
+
+    test "mixed" do
+      config = <<-CONFIG
+        key message
+        use_partial_metadata true
+      CONFIG
+      messages = [
+        {
+          "container_id" => "1",
+          "message" => "start",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "1",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 1",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "2",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 2",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "3",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => "end",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "4",
+          "partial_last" => "true"
+        },
+        { "container_id" => "1", "message" => "single line" },
+        {
+          "container_id" => "1",
+          "message" => "start",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "1",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 3",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "2",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 4",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "3",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => "end",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "4",
+          "partial_last" => "true"
+        },
+      ]
+      filtered = filter(config, messages, wait: 3)
+      expected = [
+        { "container_id" => "1", "message" => "start\n message 1\n message 2\nend" },
+        { "container_id" => "1", "message" => "single line" },
+        { "container_id" => "1", "message" => "start\n message 3\n message 4\nend" },
+      ]
+      assert_equal(expected, filtered)
+    end
+
+    test "unsorted" do
+      config = <<-CONFIG
+        key message
+        use_partial_metadata true
+      CONFIG
+      messages = [
+        {
+          "container_id" => "1",
+          "message" => "start",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "1",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 2",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "3",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 1",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "2",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => "end",
+          "partial_message" => "true",
+          "partial_id" => "partial1",
+          "partial_ordinal" => "4",
+          "partial_last" => "true"
+        },
+        { "container_id" => "1", "message" => "single line" },
+        {
+          "container_id" => "1",
+          "message" => "start",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "1",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 4",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "3",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => " message 3",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "2",
+          "partial_last" => "false"
+        },
+        {
+          "container_id" => "1",
+          "message" => "end",
+          "partial_message" => "true",
+          "partial_id" => "partial2",
+          "partial_ordinal" => "4",
+          "partial_last" => "true"
+        },
+      ]
+      filtered = filter(config, messages, wait: 3)
+      expected = [
+        { "container_id" => "1", "message" => "start\n message 1\n message 2\nend" },
+        { "container_id" => "1", "message" => "single line" },
+        { "container_id" => "1", "message" => "start\n message 3\n message 4\nend" },
+      ]
+      assert_equal(expected, filtered)
+    end
+  end
+
+  sub_test_case "use first timestamp" do
+    test "use_first_timestamp true" do
+      messages = [
+        [@time, { "host" => "example.com", "message" => "message 1" }],
+        [@time + 1, { "host" => "example.com", "message" => "message 2" }],
+        [@time + 2, { "host" => "example.com", "message" => "message 3" }],
+      ]
+      expected = [
+        [@time, { "host" => "example.com", "message" => "message 1\nmessage 2\nmessage 3" }]
+      ]
+      conf = CONFIG + "use_first_timestamp true"
+      filtered = filter_with_time(conf, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "use_first_timestamp false" do
+      messages = [
+        [@time, { "host" => "example.com", "message" => "message 1" }],
+        [@time + 1, { "host" => "example.com", "message" => "message 2" }],
+        [@time + 2, { "host" => "example.com", "message" => "message 3" }],
+      ]
+      expected = [
+        [@time + 2, { "host" => "example.com", "message" => "message 1\nmessage 2\nmessage 3" }]
+      ]
+      conf = CONFIG + "use_first_timestamp false"
+      filtered = filter_with_time(conf, messages)
+      assert_equal(expected, filtered)
+    end
+
+    test "timeout" do
+      config = <<-CONFIG
+        key message
+        multiline_start_regexp /^start/
+        flush_interval 1s
+        use_first_timestamp true
+      CONFIG
+      messages = [
+        [@time, { "container_id" => "1", "message" => "start" }],
+        [@time, { "container_id" => "1", "message" => "  message 1" }],
+        [@time, { "container_id" => "1", "message" => "  message 2" }],
+        [@time, { "container_id" => "1", "message" => "start" }],
+        [@time + 1, { "container_id" => "1", "message" => "  message 3" }],
+        [@time + 2, { "container_id" => "1", "message" => "  message 4" }],
+      ]
+      filtered = filter_with_time(config, messages, wait: 3) do |d|
+        errored = { "container_id" => "1", "message" => "start\n  message 3\n  message 4" }
+        mock(d.instance.router).emit_error_event(TEST_TAG, @time, errored, anything)
+      end
+      expected = [
+        [@time, { "container_id" => "1", "message" => "start\n  message 1\n  message 2" }]
+      ]
+      assert_equal(expected, filtered)
+    end
+
+    test "disable timeout" do
+      config = <<-CONFIG
+        key message
+        multiline_start_regexp /^start/
+        flush_interval 0s
+        use_first_timestamp true
+      CONFIG
+      messages = [
+        [@time, { "container_id" => "1", "message" => "start" }],
+        [@time, { "container_id" => "1", "message" => "  message 1" }],
+        [@time, { "container_id" => "1", "message" => "  message 2" }],
+        [@time, { "container_id" => "1", "message" => "start" }],
+      ]
+      filtered = filter_with_time(config, messages, wait: 3) do |d|
+        mock(d.instance).flush_timeout_buffer.at_most(0)
+        errored = { "container_id" => "1", "message" => "start" }
+        mock(d.instance.router).emit_error_event(TEST_TAG, @time, errored, anything)
+      end
+      expected = [
+        [@time, { "container_id" => "1", "message" => "start\n  message 1\n  message 2" }]
+      ]
+      assert_equal(expected, filtered)
+    end
+  end
+
+  sub_test_case "raise exception in on_timer" do
+    # See also https://github.com/fluent/fluentd/issues/1946
+    test "failed to flush timeout buffer" do
+      config = <<-CONFIG
+        key message
+        flush_interval 1s
+        multiline_start_regexp /^start/
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 1" },
+        { "container_id" => "1", "message" => "  message 2" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => "  message 3" },
+        { "container_id" => "1", "message" => "  message 4" },
+        { "container_id" => "1", "message" => "start" },
+      ]
+      lastrec = messages[-1]
+      logs = nil
+      filtered = filter(config, messages, wait: 3) do |d|
+        mock(d.instance).flush_timeout_buffer.times(3) { raise StandardError, "timeout" }
+        mock(d.instance.router).emit_error_event(TEST_TAG, anything, lastrec, anything)
+        logs = d.logs
+      end
+      expected = [
+        { "container_id" => "1", "message" => "start\n  message 1\n  message 2" },
+        { "container_id" => "1", "message" => "start\n  message 3\n  message 4" }
+      ]
+      expected_logs = [
+        "[error]: failed to flush timeout buffer error=#<StandardError: timeout>",
+        "[error]: failed to flush timeout buffer error=#<StandardError: timeout>",
+        "[error]: failed to flush timeout buffer error=#<StandardError: timeout>",
+        "[info]: Flush remaining buffer: test:default"
+      ]
+      log_messages = logs.map do |line|
+        line.chomp.gsub(/.+? (\[(?:error|info)\].+)/) {|m| $1 }
+      end
+      assert_equal(expected_logs, log_messages)
+      assert_equal(expected, filtered)
     end
   end
 end

--- a/fluentd/run.sh
+++ b/fluentd/run.sh
@@ -329,6 +329,12 @@ if [ "${ENABLE_UTF8_FILTER:-}" != true ] ; then
     touch $CFG_DIR/openshift/filter-pre-force-utf8.conf
 fi
 
+if [ "${USE_MULTILINE_JOURNAL:-false}" = true ] ; then
+    cp -f $CFG_DIR/filter-pre-systemd-multiline.conf $CFG_DIR/openshift
+else
+    rm -f $CFG_DIR/openshift/filter-pre-systemd-multiline.conf
+fi
+
 if type -p jemalloc-config > /dev/null 2>&1 && [ "${USE_JEMALLOC:-true}" = true ] ; then
     export LD_PRELOAD=$( jemalloc-config --libdir )/libjemalloc.so.$( jemalloc-config --revision )
     export LD_BIND_NOW=1 # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1544815

--- a/hack/testing/templates/test-template.yaml
+++ b/hack/testing/templates/test-template.yaml
@@ -23,7 +23,11 @@ objects:
         while true; do
           loops=$( expr $loops + 1 )
           for ii in $( seq 1 ${TEST_ITERATIONS} ) ; do
-            echo "${TEST_POD_MESSAGE} $loops $ii"
+            if [ "${FORMAT}" = json ] ; then
+              echo "{\"message\":\"${TEST_POD_MESSAGE}\",\"uniqueid\":\"${UNIQUEID}\",\"loops\":$loops,\"ii\":$ii}"
+            else
+              echo "${TEST_POD_MESSAGE} $loops $ii"
+            fi
           done
           sleep ${TEST_POD_SLEEP_TIME}
         done
@@ -43,5 +47,11 @@ parameters:
 - description: number of times to print message before sleeping
   value: "1"
   name: TEST_ITERATIONS
+- description: format - text or json
+  value: "text"
+  name: FORMAT
+- description: unique id for searching
+  value: ""
+  name: UNIQUEID
 labels:
   test: "true"

--- a/hack/testing/test-docker-multiline.sh
+++ b/hack/testing/test-docker-multiline.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/docker_multiline.sh

--- a/test/docker_multiline.sh
+++ b/test/docker_multiline.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# This is a test suite for the docker log driver
+# json-file and/or journald multiline logs
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+os::test::junit::declare_suite_start "test/docker_multiline"
+
+FLUENTD_WAIT_TIME=${FLUENTD_WAIT_TIME:-$(( 2 * minute ))}
+
+stop_fluentd() {
+  artifact_log at this point there should be 1 fluentd running in Running state
+  oc get pods 2>&1 | artifact_out
+  local fpod=$( get_running_pod fluentd )
+  oc label node --all logging-infra-fluentd- 2>&1 | artifact_out
+  os::cmd::try_until_text "oc get daemonset logging-fluentd -o jsonpath='{ .status.numberReady }'" "0" $FLUENTD_WAIT_TIME
+  artifact_log at this point there should be no fluentd running - number ready is 0
+  oc get pods 2>&1 | artifact_out
+  # for some reason, in this test, after .status.numberReady is 0, the fluentd pod hangs around
+  # in the Terminating state for many seconds, which seems to cause problems with subsequent tests
+  # so, we have to wait for the pod to completely disappear - we cannot rely on .status.numberReady == 0
+  if [ -n "${fpod:-}" ] ; then
+    os::cmd::try_until_failure "oc get pod $fpod > /dev/null 2>&1" $FLUENTD_WAIT_TIME
+  fi
+}
+
+start_fluentd() {
+  sudo rm -f /var/log/fluentd/fluentd.log
+  oc label node --all logging-infra-fluentd=true 2>&1 | artifact_out
+  os::cmd::try_until_text "oc get pods -l component=fluentd" "^logging-fluentd-.* Running " $FLUENTD_WAIT_TIME
+}
+
+cleanup() {
+    local return_code="$?"
+    set +e
+
+    if [ $return_code = 0 ] ; then
+        mycmd=os::log::info
+    else
+        mycmd=os::log::error
+    fi
+    $mycmd docker_multiline test finished at $( date )
+
+    if [ -n "${proj:-}" ] ; then
+        oc delete project $proj 2>&1 | artifact_out
+        os::cmd::try_until_failure "oc get project $proj -o yaml > /dev/null 2>&1" 2>&1 | artifact_out
+        curl_es $essvc "/project.${proj}.*" -XDELETE 2>&1 | artifact_out
+    fi
+    fpod=$( get_running_pod fluentd )
+    if [ -n "${fpod:-}" ] ; then
+        get_fluentd_pod_log > $ARTIFACT_DIR/docker-multiline-fluentd-pod.log
+    fi
+    if [ "${orig_MERGE_JSON_LOG:-}" = unset ] ; then
+        orig_MERGE_JSON_LOG="MERGE_JSON_LOG-"
+    fi
+    if [ "${orig_CDM_UNDEFINED_TO_STRING:-}" = unset ] ; then
+        orig_CDM_UNDEFINED_TO_STRING="CDM_UNDEFINED_TO_STRING-"
+    fi
+    if [ "${orig_USE_MULTILINE_JSON:-}" = unset ] ; then
+        orig_USE_MULTILINE_JSON="USE_MULTILINE_JSON-"
+    fi
+    if [ "${orig_USE_MULTILINE_JOURNAL:-}" = unset ] ; then
+        orig_USE_MULTILINE_JOURNAL="USE_MULTILINE_JOURNAL-"
+    fi
+    if [ -n "${orig_MERGE_JSON_LOG:-}" -o -n "${orig_CDM_UNDEFINED_TO_STRING:-}" -o -n "${orig_USE_MULTILINE_JSON:-}" -o -n "${orig_USE_MULTILINE_JOURNAL:-}" ] ; then
+        stop_fluentd
+        oc set env daemonset/logging-fluentd ${orig_USE_MULTILINE_JSON:-} ${orig_USE_MULTILINE_JOURNAL:-} ${orig_MERGE_JSON_LOG:-} ${orig_CDM_UNDEFINED_TO_STRING:-} 2>&1 | artifact_out
+        start_fluentd
+    fi
+
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
+
+# operations index can be in a separate cluster
+essvc=$( get_es_svc es )
+
+# create a test project
+proj=test-docker-multiline
+oc adm new-project $proj --node-selector='' 2>&1 | artifact_out
+os::cmd::try_until_success "oc get project $proj -o yaml > /dev/null 2>&1" 2>&1 | artifact_out
+
+# turn on MERGE_JSON_LOG if not already
+# enable merge json log
+orig_MERGE_JSON_LOG=$( oc set env daemonset/logging-fluentd --list | grep \^MERGE_JSON_LOG= ) || :
+if [ -z "$orig_MERGE_JSON_LOG" ] ; then
+    orig_MERGE_JSON_LOG=unset
+fi
+orig_CDM_UNDEFINED_TO_STRING=$( oc set env daemonset/logging-fluentd --list | grep \^CDM_UNDEFINED_TO_STRING= ) || :
+if [ -z "$orig_CDM_UNDEFINED_TO_STRING" ] ; then
+    orig_CDM_UNDEFINED_TO_STRING=unset
+fi
+orig_USE_MULTILINE_JSON=$( oc set env daemonset/logging-fluentd --list | grep \^USE_MULTILINE_JSON= ) || :
+if [ -z "$orig_USE_MULTILINE_JSON" ] ; then
+    orig_USE_MULTILINE_JSON=unset
+fi
+orig_USE_MULTILINE_JOURNAL=$( oc set env daemonset/logging-fluentd --list | grep \^USE_MULTILINE_JOURNAL= ) || :
+if [ -z "$orig_USE_MULTILINE_JOURNAL" ] ; then
+    orig_USE_MULTILINE_JOURNAL=unset
+fi
+stop_fluentd
+oc set env daemonset/logging-fluentd USE_MULTILINE_JSON=true USE_MULTILINE_JOURNAL=true MERGE_JSON_LOG=true CDM_UNDEFINED_TO_STRING=false 2>&1 | artifact_out
+start_fluentd
+
+# create a test pod to generate very long lines
+ident=$( openssl rand -hex 16 )
+rm -f $ARTIFACT_DIR/test-message
+for ii in $( seq 1 1638 ) ; do
+    printf "0123456789" >> $ARTIFACT_DIR/test-message
+done
+echo "" >> $ARTIFACT_DIR/test-message
+expected=10
+pod=$proj
+oc process -f $OS_O_A_L_DIR/hack/testing/templates/test-template.yaml \
+    -p TEST_NAMESPACE_NAME=$proj -p TEST_POD_NAME=$pod -p UNIQUEID=$ident \
+    -p TEST_POD_SLEEP_TIME=600 -p TEST_ITERATIONS=$expected -p FORMAT=json \
+    -p TEST_POD_MESSAGE=$( cat $ARTIFACT_DIR/test-message ) > $ARTIFACT_DIR/test-pod.yaml
+oc create -f $ARTIFACT_DIR/test-pod.yaml 2>&1 | artifact_out
+os::cmd::try_until_success "oc -n $proj get pod $pod -o yaml > /dev/null 2>&1" 2>&1 | artifact_out
+
+# wait until es msg count is 10
+rc=0
+qs='{"query":{"term":{"uniqueid":"'"${ident}"'"}}}'
+if os::cmd::try_until_text "curl_es ${essvc} /project.${proj}.*/_count -X POST -d '$qs' | get_count_from_json" "^${expected}\$" $(( 120 * second )); then
+    # verify messages
+    curl_es ${essvc} "/project.${proj}.*/_search" -X POST -d "$qs" > $ARTIFACT_DIR/records.json 2>&1 || :
+    for ii in $( seq 0 $(( expected - 1 )) ) ; do
+        cat $ARTIFACT_DIR/records.json | jq -r .hits.hits[$ii]._source.message > $ARTIFACT_DIR/message.$ii
+        if ! diff -q $ARTIFACT_DIR/test-message $ARTIFACT_DIR/message.$ii ; then
+            os::log::error "test message does not match $ARTIFACT_DIR/message.$ii"
+            rc=1
+            break
+        fi
+    done
+else
+    rc=1
+    os::log::error "Could not find test records"
+    curl_es ${essvc} "/project.${proj}.*/_search" -X POST -d "$qs" > $ARTIFACT_DIR/err_raw_search_output.txt 2>&1 || :
+    cat $ARTIFACT_DIR/err_raw_search_output.txt | jq . > $ARTIFACT_DIR/err_search_output.json 2>&1 || :
+    curl_es ${essvc} /_cat/indices?v 2>&1 | artifact_out
+fi
+oc -n $proj delete --force pod $pod 2>&1 | artifact_out
+
+exit $rc


### PR DESCRIPTION
This commit allows fluentd to reconstruct partial lines written
by the docker json-file and journald log drivers when logs
exceed the 16K byte limit.

There are two new environment variables:

* `USE_MULTILINE_JSON` - by default this is false - if you do
`oc set env ds/logging-fluentd USE_MULTILINE_JSON=true`
then fluentd will be able to reconstruct docker json-file
partial logs.

* `USE_MULTILINE_JOURNAL` - by default this is false - if you do
`oc set env ds/logging-fluentd USE_MULTILINE_JOURNAL=true`
then fluentd will be able to reconstruct docker journald
partial logs.

For json-file logs, the "log" field ends in `\n` for the final
part of the log, and does not end in `\n` for starting and
continuation lines.  For journald logs, the field
`CONTAINER_PARTIAL_MESSAGE=true` is present for starting and
continuation lines, but is omitted for final lines.

fluent-plugin-concat 2.4.0 was backported to work with ruby 2.0
and fluentd 0.12.  The main feature was the ability to have
only `multiline_end_regexp` without `multiline_start_regexp`
which is required for docker json-file log support.  The
partial_key support for journald was already there for cri-o.
The wrinkle with journald is that _all_ records to be
reconstructed must have the `CONTAINER_PARTIAL_MESSAGE` field,
so a filter was added to set `CONTAINER_PARTIAL_MESSAGE=false`
for container log records which did not already have the
`CONTAINER_PARTIAL_MESSAGE` field, in order to make the concat
filter work for partial_key.

If you want to try this out without building the image, you can
follow these steps:

Hack fluent.conf like this:
```
    #@include configs.d/dynamic/input-docker-*.conf
    <source>
      @type tail
      @id docker-input
      @label @INGRESS
      path "/var/log/containers/*.log"
      pos_file "/var/log/es-containers.log.pos"
      time_format %Y-%m-%dT%H:%M:%S.%N%Z
      tag kubernetes.*
      format json
      keep_time_key true
      read_from_head "true"
      exclude_path []
      @label @CONCAT
    </source>
    <label @CONCAT>
      <filter kubernetes.**>
        @type concat
        key log
        multiline_end_regexp /\n$/
      </filter>
      <match kubernetes.**>
        @type relabel
        @label @INGRESS
      </match>
    </label>
    ...
    <label @INGRESS>
    ## filters
      @include configs.d/openshift/filter-pre-*.conf
      <filter journal>
        @type record_modifier
        <record>
          ignoreme ${if record.key?("CONTAINER_ID_FULL") && !record.key?("CONTAINER_PARTIAL_MESSAGE"); record["CONTAINER_PARTIAL_MESSAGE"] = "false"; end; "ignoreme"}
        </record>
        remove_keys ignoreme
      </filter>
      <filter journal>
        @type concat
        key MESSAGE
        separator ""
        stream_identity_key CONTAINER_ID_FULL
        partial_key CONTAINER_PARTIAL_MESSAGE
        partial_value true
      </filter>

```

Create a special configmap for the plugin code:
```
mkdir cm-fluentd-plugin
oc get pods -l component=fluentd
fpod=logging-fluentd-xxx
for file in $( oc exec $fpod -- ls /etc/fluent/plugin ) ; do
  oc exec $fpod -- cat /etc/fluent/plugin/$file > cm-fluentd-plugin/$file
done
cp cm-fluentd-plugin/filter_concat.rb cm-fluentd-plugin/filter_concat.rb.orig
cp /path/to/new/filter_concat.rb cm-fluentd-plugin/filter_concat.rb
oc create configmap fluentd-plugin --from-file=cm-fluentd-plugin/
```
Then, add the volume and volumemount to the fluentd daemonset:
```
oc edit ds/logging-fluentd
```
Add to volumeMounts and volumes
```
        volumeMounts:
        - mountPath: /etc/fluent/plugin
          name: fluentd-plugin
          readOnly: true
        ...
      volumes:
      - configMap:
          defaultMode: 420
          name: fluentd-plugin
        name: fluentd-plugin
```
Restart fluentd
```
oc delete pods -l component=fluentd
```
You may see errors like this in the fluentd log:
```
/etc/fluent/plugin/viaq_docker_audit.rb:51: warning: already initialized constant Fluent::ViaqDockerAudit::ENV_HOSTNAME
```
You can ignore them.

add support for USE_MULTILINE_JOURNAL

If USE_MULTILINE_JOURNAL=true, then docker log-driver=journald logs
that are spread over multiple records using CONTAINER_PARTIAL_MESSAGE
will be concatenated together as a single record.

bug fixes

dump indices upon error