### PR TITLE
Bug 1741591: remote-syslog error when the record has level=unknown

### DIFF
--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -70,7 +70,14 @@ module Fluent
       es.each {|time,record|
         if @use_record
           @packet.hostname = record['hostname'] || hostname
-          @packet.severity = (record['level'].eql? 'warning')? 'warn' : record['level'] || @severity
+          case record['level']
+          when 'warning'
+            @packet.severity = 'warn'
+          when 'unknown', nil
+            @packet.severity = @severity
+          else
+            @packet.severity = record['level']
+          end
           if @use_record && record.key?('systemd') && (record['systemd']).key?('u') && (record['systemd']['u']).key?('SYSLOG_FACILITY')
             begin
               @packet.facility = record['systemd']['u']['SYSLOG_FACILITY']

--- a/fluentd/out_syslog_buffered.rb
+++ b/fluentd/out_syslog_buffered.rb
@@ -95,7 +95,14 @@ module Fluent
       tag = tag.sub(@remove_tag_prefix, '') if @remove_tag_prefix
       if @use_record
         @packet.hostname = record['hostname'] || hostname
-        @packet.severity = (record['level'].eql? 'warning')? 'warn' : record['level'] || @severity
+        case record['level']
+        when 'warning'
+          @packet.severity = 'warn'
+        when 'unknown', nil
+          @packet.severity = @severity
+        else
+          @packet.severity = record['level']
+        end
         if @use_record && record.key?('systemd') && (record['systemd']).key?('u') && (record['systemd']['u']).key?('SYSLOG_FACILITY')
           begin
             @packet.facility = record['systemd']['u']['SYSLOG_FACILITY']


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1741591
We recently switched most container logs to use log level=unknown.  This causes problems for the remote-syslog plugin as `unknown` isn't in the list of levels/severities:
https://github.com/eric/syslog_protocol/blob/master/lib/syslog_protocol/common.rb#L58

```
2019-08-15 01:00:20 +0000 [warn]: emit transaction failed: error_class=ArgumentError error="'unknown' is not a designated severity" location="/opt/app-root/src/gems/syslog_protocol-0.9.2/lib/syslog_protocol/packet.rb:72:in `severity='" tag="output_ops_tag"
2019-08-15 01:00:20 +0000 [warn]: /opt/app-root/src/gems/syslog_protocol-0.9.2/lib/syslog_protocol/packet.rb:72:in `severity='
```

The fix is to use the configured `@severity` if level is unknown, which is
the same as what happens if level is not set.

(cherry picked from commit 484eef6c1c25892c2b1a2c966fc14ee6db6cebc0)