### PR TITLE
Bug 1741663: Fluentd single pod logging performance regression in 4.x

### DIFF
--- a/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
+++ b/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
@@ -63,6 +63,10 @@ def get_all_throttle_files()
   return Dir.glob("#{container_pos_file_prefix}*.log.pos")
 end
 
+def get_refresh_interval()
+  return ENV['CONTAINER_LOGS_REFRESH_INTERVAL'] || '60'
+end
+
 def move_pos_file_project_entry(source_file, dest_file, project, log)
   log.debug "moving project #{project} pos entry from #{source_file} to #{dest_file}"
   if File.file?(source_file)
@@ -125,6 +129,7 @@ def seed_file(file_name, project, log)
   @label @INGRESS
   path #{path}
   pos_file #{pos_file}
+  refresh_interval #{get_refresh_interval}
     CONF
   }
 
@@ -185,6 +190,7 @@ def create_default_container_input(input_conf_file, excluded, log, options={})
   @id container-input
   path "#{options[:cont_logs_path] || cont_logs_path}"
   pos_file "#{options[:cont_pos_file] || cont_pos_file}"
+  refresh_interval #{get_refresh_interval}
   tag kubernetes.*
   read_from_head "#{options[:read_from_head] || read_from_head}"
   exclude_path #{excluded}

--- a/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
+++ b/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
@@ -27,6 +27,7 @@ describe 'generate_throttle_configs' do
   @id container-input
   path "/var/log/containers/*.log"
   pos_file "/var/log/es-containers.log.pos"
+  refresh_interval 60
   tag kubernetes.*
   read_from_head "true"
   exclude_path []
@@ -77,6 +78,7 @@ describe 'generate_throttle_configs' do
   @id container-input
   path "/tmp/foo/*.logs"
   pos_file "/tmp/foo/test.logs.pos"
+  refresh_interval 60
   tag kubernetes.*
   read_from_head "false"
   exclude_path []
@@ -156,6 +158,7 @@ secondproject:
   @id container-input
   path \"/tmp/*.log\"
   pos_file \"#{@pos_file}\"
+  refresh_interval 60
   tag kubernetes.*
   read_from_head \"true\"
   exclude_path [\"#{cont_log_dir}/*_firstproject_*.log\", \"#{cont_log_dir}/*_secondproject_*.log\"]
@@ -201,6 +204,7 @@ secondproject:
   @label @INGRESS
   path /tmp/*_#{project}_*.log
   pos_file #{pos_file}
+  refresh_interval 60
   read_lines_limit #{limit}
   tag kubernetes.*
   read_from_head \"true\"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1741663
This isn't a fix.  It only allows setting the fluentd in_tail plugin
`refresh_interval` parameter via a new environment variable
`CONTAINER_LOGS_REFRESH_INTERVAL`.  The default value is 60 (seconds).
For example, to use a value of 5 seconds:
`oc set env ds/fluentd CONTAINER_LOGS_REFRESH_INTERVAL=5`