### PR TITLE
Bug 1741663: Fluentd single pod logging performance regression in 4.x

### DIFF
--- a/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
+++ b/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
@@ -67,6 +67,10 @@ def get_refresh_interval()
   return ENV['CONTAINER_LOGS_REFRESH_INTERVAL'] || '60'
 end
 
+def get_rotate_wait()
+  return ENV['CONTAINER_LOGS_ROTATE_WAIT'] || '5'
+end
+
 def move_pos_file_project_entry(source_file, dest_file, project, log)
   log.debug "moving project #{project} pos entry from #{source_file} to #{dest_file}"
   if File.file?(source_file)
@@ -130,6 +134,7 @@ def seed_file(file_name, project, log)
   path #{path}
   pos_file #{pos_file}
   refresh_interval #{get_refresh_interval}
+  rotate_wait #{get_rotate_wait}
     CONF
   }
 
@@ -191,6 +196,7 @@ def create_default_container_input(input_conf_file, excluded, log, options={})
   path "#{options[:cont_logs_path] || cont_logs_path}"
   pos_file "#{options[:cont_pos_file] || cont_pos_file}"
   refresh_interval #{get_refresh_interval}
+  rotate_wait #{get_rotate_wait}
   tag kubernetes.*
   read_from_head "#{options[:read_from_head] || read_from_head}"
   exclude_path #{excluded}

--- a/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
+++ b/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
@@ -28,6 +28,7 @@ describe 'generate_throttle_configs' do
   path "/var/log/containers/*.log"
   pos_file "/var/log/es-containers.log.pos"
   refresh_interval 60
+  rotate_wait 5
   tag kubernetes.*
   read_from_head "true"
   exclude_path []
@@ -79,6 +80,7 @@ describe 'generate_throttle_configs' do
   path "/tmp/foo/*.logs"
   pos_file "/tmp/foo/test.logs.pos"
   refresh_interval 60
+  rotate_wait 5
   tag kubernetes.*
   read_from_head "false"
   exclude_path []
@@ -159,6 +161,7 @@ secondproject:
   path \"/tmp/*.log\"
   pos_file \"#{@pos_file}\"
   refresh_interval 60
+  rotate_wait 5
   tag kubernetes.*
   read_from_head \"true\"
   exclude_path [\"#{cont_log_dir}/*_firstproject_*.log\", \"#{cont_log_dir}/*_secondproject_*.log\"]
@@ -205,6 +208,7 @@ secondproject:
   path /tmp/*_#{project}_*.log
   pos_file #{pos_file}
   refresh_interval 60
+  rotate_wait 5
   read_lines_limit #{limit}
   tag kubernetes.*
   read_from_head \"true\"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1741663
Same as the previous commit for Bug 1741663.
This isn't a fix.  It only allows setting the fluentd in_tail plugin
`rotate_wait` parameter via a new environment variable
`CONTAINER_LOGS_ROTATE_WAIT`.  The default value is 5 (seconds).
For example, to use a value of 10 seconds:
`oc set env ds/fluentd CONTAINER_LOGS_ROTATE_WAIT=10