### PR TITLE
Bug 1738411: Bump openshift-elasticsearch-client to 5.6.13.10

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -13,7 +13,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     INSTANCE_RAM=512G \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.13.8-redhat-1 \
+    OSE_ES_VER=5.6.13.10-redhat-1 \
     PROMETHEUS_EXPORTER_VER=5.6.13.2-redhat-3 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     container=oci
 
-ARG OSE_ES_VER=5.6.13.8-redhat-1
+ARG OSE_ES_VER=5.6.13.10-redhat-1
 ARG OSE_ES_URL
 ARG PROMETHEUS_EXPORTER_VER=5.6.13.2-redhat-3
 ARG PROMETHEUS_EXPORTER_URL

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -14,7 +14,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_VER=1.8.0 \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.13.8 \
+    OSE_ES_VER=5.6.13.10 \
     PROMETHEUS_EXPORTER_VER=5.6.13.2 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     RELEASE_STREAM=origin
 
-ARG OSE_ES_VER=5.6.13.8
+ARG OSE_ES_VER=5.6.13.10
 ARG SG_VER=5.6.13-19.2
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -218,6 +218,7 @@ EOF
             os::cmd::try_until_success "oc login -u '$username' -p '$pwd'" $((3 * minute)) 3
             oc login -u system:admin
             if [ $isadmin = true ] ; then
+                os::cmd::try_until_success "oc get user $username" $((3 * minute))
                 echo adding cluster-admin role to user "$username"
                 oc adm policy add-cluster-role-to-user cluster-admin "$username"
             else

--- a/test/access_control.sh
+++ b/test/access_control.sh
@@ -28,7 +28,7 @@ function check_es_acls() {
   local ts=$( date +%s )
   for doc in roles rolesmapping actiongroups; do
     artifact_log Checking that Elasticsearch pod ${espod} has expected acl definitions $ARTIFACT_DIR/$doc.$ts
-    oc exec -c elasticsearch ${espod} -- es_acl get --doc=${doc} > $ARTIFACT_DIR/$doc.$ts 2>&1
+    oc -n $LOGGING_NS exec -c elasticsearch ${espod} -- es_acl get --doc=${doc} > $ARTIFACT_DIR/$doc.$ts 2>&1
   done
 }
 
@@ -49,8 +49,8 @@ function cleanup() {
     fi
     if [ -n "${espod:-}" ] ; then
         check_es_acls
-        oc logs -c elasticsearch $espod > $ARTIFACT_DIR/es.log
-        oc exec -c elasticsearch $espod -- logs >> $ARTIFACT_DIR/es.log
+        oc -n $LOGGING_NS logs -c elasticsearch $espod > $ARTIFACT_DIR/es.log
+        oc -n $LOGGING_NS exec -c elasticsearch $espod -- logs >> $ARTIFACT_DIR/es.log
         curl_es_pod $espod /project.access-control-* -XDELETE > /dev/null
     fi
     for proj in access-control-1 access-control-2 access-control-3 ; do


### PR DESCRIPTION
This PR fixes:

* https://bugzilla.redhat.com/show_bug.cgi?id=1738411
* https://bugzilla.redhat.com/show_bug.cgi?id=1745011
* https://bugzilla.redhat.com/show_bug.cgi?id=1746695