### PR TITLE
Bug 1741663: Fluentd single pod logging performance regression in 4.x

### DIFF
--- a/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
+++ b/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
@@ -64,7 +64,7 @@ def get_all_throttle_files()
 end
 
 def get_refresh_interval()
-  return ENV['CONTAINER_LOGS_REFRESH_INTERVAL'] || '60'
+  return ENV['CONTAINER_LOGS_REFRESH_INTERVAL'] || '5'
 end
 
 def get_rotate_wait()

--- a/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
+++ b/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
@@ -27,7 +27,7 @@ describe 'generate_throttle_configs' do
   @id container-input
   path "/var/log/containers/*.log"
   pos_file "/var/log/es-containers.log.pos"
-  refresh_interval 60
+  refresh_interval 5
   rotate_wait 5
   tag kubernetes.*
   read_from_head "true"
@@ -79,7 +79,7 @@ describe 'generate_throttle_configs' do
   @id container-input
   path "/tmp/foo/*.logs"
   pos_file "/tmp/foo/test.logs.pos"
-  refresh_interval 60
+  refresh_interval 5
   rotate_wait 5
   tag kubernetes.*
   read_from_head "false"
@@ -160,7 +160,7 @@ secondproject:
   @id container-input
   path \"/tmp/*.log\"
   pos_file \"#{@pos_file}\"
-  refresh_interval 60
+  refresh_interval 5
   rotate_wait 5
   tag kubernetes.*
   read_from_head \"true\"
@@ -207,7 +207,7 @@ secondproject:
   @label @INGRESS
   path /tmp/*_#{project}_*.log
   pos_file #{pos_file}
-  refresh_interval 60
+  refresh_interval 5
   rotate_wait 5
   read_lines_limit #{limit}
   tag kubernetes.*


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1741663
Lower the default value of refresh_interval in the fluentd in_tail plugin from 60 to 5.