### PR TITLE
Bug 1748769: Lots of `program '\/usr\/local\/bin\/undefined_field' e…

### DIFF
--- a/rsyslog/undefined_field/undefined_field.go
+++ b/rsyslog/undefined_field/undefined_field.go
@@ -496,4 +496,8 @@ func main() {
 			fmt.Println(string(outputString))
 		}
 	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(logfile, "Scanner error [%v]", err)
+	}
 }


### PR DESCRIPTION
…xited normally, state 0` logs in rsyslog pod logs with data lost

Adding an error check to undefined_field when scanner.Scan() quits the loop.

Note: not a fix, but for getting more info.