### PR TITLE
Bug 1748769: Lots of `program '\/usr\/local\/bin\/undefined_field' e…

### DIFF
--- a/rsyslog/undefined_field/undefined_field.go
+++ b/rsyslog/undefined_field/undefined_field.go
@@ -449,13 +449,17 @@ func main() {
 		reader = bufio.NewReader(os.Stdin)
 	}
 	scanner := bufio.NewScanner(reader)
+	// Mitigating bufio.Scanner: token too long error
+	const maxScanBufferSize = 256 * 1024
+	scanBuffer := make([]byte, maxScanBufferSize)
+	scanner.Buffer(scanBuffer, maxScanBufferSize)
 	scanner.Split(bufio.ScanLines)
 
 	for scanner.Scan() {
 		jsonMap := make(map[string]interface{})
 		rawStr := scanner.Text()
 		if cfg.Debug {
-			fmt.Fprintln(logfile, "Source: ", rawStr)
+			fmt.Fprintf(logfile, "Source (%d): %s\n", len(rawStr), rawStr)
 		}
 		if err := json.Unmarshal(scanner.Bytes(), &jsonMap); err != nil {
 			fmt.Fprintln(logfile, "json.Unmarshal failed (", err, "): ", rawStr)
@@ -498,6 +502,6 @@ func main() {
 	}
 
 	if err := scanner.Err(); err != nil {
-		fmt.Fprintf(logfile, "Scanner error [%v]", err)
+		fmt.Fprintf(logfile, "Scanner error [%v]\n", err)
 	}
 }


### PR DESCRIPTION
…xited normally, state 0` logs in rsyslog pod logs with data lost

Rsyslog mmexternal plugin undefined_field could fail with Scanner error:
[bufio.Scanner: token too long].
Adding a larger custom buffer (256KB) in undefined_field.