### PR TITLE
Bug 1739558: rsyslog underperforming compared to fluentd

### DIFF
--- a/hack/logging-load-driver/README.md
+++ b/hack/logging-load-driver/README.md
@@ -1,0 +1,1 @@
+Copied from https://github.com/ViaQ/logging-load-driver

--- a/hack/logging-load-driver/loader
+++ b/hack/logging-load-driver/loader
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+#
+# ViaQ logging load generator
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+import sys
+import time
+import uuid
+import random
+import string
+import logging
+import logging.handlers
+import argparse
+
+
+DEFAULT_STDDEV = 32
+
+
+def msgsizgen_fixed(stats, mean, stddev = None):
+    '''Generate a series of "fixed" sizes, always yielding the given
+       "mean" as the value.
+
+       The stddev value is always ignored.
+    '''
+    while True:
+        yield stats.nextseq(mean)
+
+
+def msgsizgen_gaussian(stats, mean, stddev = DEFAULT_STDDEV):
+    '''Generate a series of random numbers with a Guassian distribution,
+       where the mean and standard deviation are given arguments.
+
+       The mean is a required parameter, while the stddev will default to
+       32.
+
+       The generator will yield numbers continuously.
+    '''
+    randomizer = random.Random()
+    while True:
+        yield stats.nextseq(int(round(randomizer.gauss(mean, stddev))))
+
+
+dist_methods = { 'fixed': msgsizgen_fixed, 'gaussian': msgsizgen_gaussian, 'normal': msgsizgen_gaussian }
+
+
+class StatsCtx(object):
+
+    def __init__(self, msgpersec, rptint):
+        self.start = self.past = time.time()
+        self.seq = 0
+        self.msgs = 0
+        self.total_size = 0
+        self.report_size = 0
+        self.msgpersec = msgpersec
+        if msgpersec > 0:
+            self.msgperiod = (1/msgpersec, self.start)
+        else:
+            self.msgperiod = None
+        self.rptint = rptint * (1024 * 1024)
+
+    def nextseq(self, size):
+        self.seq += 1
+        self.msgs += 1
+        self.total_size += size
+        self.report_size += size
+        if self.msgperiod is not None:
+            now = time.time()
+            while now < self.msgperiod[1]:
+                sleep_window = self.msgperiod[1] - now
+                time.sleep(sleep_window)
+                now = time.time()
+            # We have exited our rate-limit window, calculate next
+            # window and continue
+            self.msgperiod = (self.msgperiod[0], self.msgperiod[1] + self.msgperiod[0])
+        if self.report_size > self.rptint:
+            report = True
+            self.report_size = 0
+        else:
+            report = False
+        return size, self.seq, report
+
+    def statstr(self, seq_width):
+        now = time.time()
+        msg_rate = self.msgs / (now - self.past)
+        total_msg_rate = self.seq / (now - self.start)
+        if self.msgperiod is not None:
+            if msg_rate < (self.msgpersec - 0.50):
+                notice = " (too slow, %d)" % self.msgpersec
+            elif msg_rate > (self.msgpersec + 0.50):
+                notice = " (too fast, %d)" % self.msgpersec
+            else:
+                notice = ""
+        else:
+            notice = ""
+        self.past = now
+        self.msgs = 0
+        return "%.3fs %0*d %10.3f%s %10.3f" % (now, seq_width, self.seq, msg_rate, notice, total_msg_rate)
+
+
+chars = string.ascii_lowercase + string.digits
+def payload_random(size):
+    return ''.join(random.choice(chars) for x in range(size))
+
+
+def payload_fixed(size):
+    return 'x' * size
+
+
+gen_methods = { 'fixed': payload_fixed, 'random': payload_random }
+
+
+def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DEFAULT_STDDEV, report_interval=10, seq_width=10, msgpersec=0, total_size=0, payload_gen='random'):
+    '''Emit a formatted payload of random bytes, using a Gaussian
+       distribution using a given size as the mean.  The payload
+       is emitted using the output_method function, while statistics
+       about the output rate are reported through the report_method.
+
+       The reports are generated once every 10,000 payloads, no
+       more than once a second by default. Both parameters can be
+       changed by the caller.
+
+       The generated sequence number defaults to a width of 10.
+
+       The invocation ID, invocid, is required from the caller to
+       facilitate finding the output emitted by this instance.
+    '''
+    msgsizgen = dist_methods[dist]
+    payloadgen = gen_methods[payload_gen]
+    sep = ' - '
+    sep_len = len(sep)
+    prefix = "loader seq - %s - " % invocid
+    prefix_len = len(prefix)
+    sub_len = (prefix_len + seq_width + sep_len)
+
+    stats = StatsCtx(msgpersec, report_interval)
+    for asize, seq, report in msgsizgen(stats, size, stddev):
+        asize -= sub_len
+        if report_method is None and (report or (total_size > 0 and stats.total_size > total_size * (1024 * 1024))):
+            # Reporting is done inline as part of a sequence message payload.
+            stats_msg = "(stats: %s) " % stats.statstr(seq_width)
+            stats_msg_len = len(stats_msg)
+        else:
+            stats_msg = ""
+            stats_msg_len = 0
+        asize -= stats_msg_len
+        asize = 1 if asize <= 0 else asize
+        msg = stats_msg + payloadgen(asize)
+        output_method("%s%0*d%s%s" % (prefix, seq_width, seq, sep, msg))
+        if report_method is not None and report:
+            # Reporting is done out-of-band.
+            report_method("loader stat: %s" % stats.statstr(seq_width))
+        if total_size > 0 and (stats.total_size > total_size * (1024 * 1024)):
+            # We're done
+            if report_method is not None and not report:
+                # Reporting is done out-of-band.
+                report_method("loader stat: %s" % stats.statstr(seq_width))
+            break
+
+
+if __name__ == '__main__':
+    log = logging.getLogger(__name__)
+    log.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(module)s.%(funcName)s: %(message)s')
+    try:
+        handler = logging.handlers.SysLogHandler(address = '/dev/log')
+        handler.setFormatter(formatter)
+    except Exception as e:
+        print("*** Warning *** - could not open /dev/log, falling back to console handler for logger ... (exception: %s)" % e, file=sys.stderr)
+        consoleHandler = logging.StreamHandler()
+        consoleHandler.setFormatter(formatter)
+        log.addHandler(consoleHandler)
+    else:
+        log.addHandler(handler)
+
+    parser = argparse.ArgumentParser(description='Message payload generator.')
+    parser.add_argument('payload_size', metavar='SIZE', type=int, nargs='?',
+            default=1024,
+			help='an integer specifying the mean size of the payload using a Gaussian distribution')
+    parser.add_argument('--distribution', metavar='DIST', dest='payload_dist', action='store',
+            default='gaussian', choices=dist_methods,
+            help='the size distribution to use, e.g. "gaussian" (default), "normal" (alias for gaussian), or "fixed"')
+    parser.add_argument('--payload-gen', metavar='GEN', dest='payload_gen', action='store',
+            default='random', choices=gen_methods,
+            help='the payload generator to use, e.g. "random" (default), or "fixed"')
+    parser.add_argument('--invocid', metavar='INVOCID', dest='invocid', action='store',
+            default=uuid.uuid4().hex,
+			help='the unique invocation ID string to use (defaults to 32 char generated one)')
+    parser.add_argument('--stddev', metavar='STDDEV', dest='stddev', type=float,
+            default=DEFAULT_STDDEV,
+            help='the standard deviation to use with a random distribution (defaults to 32)')
+    parser.add_argument('--output', metavar='METHOD', dest='output', action='store',
+            default='stdout',
+            help='where to emit the output, one of: "stdout", "stderr", "syslog", "<file name>" (defaults to "stdout")')
+    parser.add_argument('--report', metavar='METHOD', dest='report', action='store',
+            default='inline',
+            help='where to emit the report output, one of: "inline", "stdout", "stderr", "syslog", "<file name>" (defaults to "inline")')
+    parser.add_argument('--msgpersec', metavar='MSGPERSEC', dest='msgpersec', type=float,
+            default=0,
+            help='the # of logs per second (floating point) to emit (defaults to 0, unlimited)')
+    parser.add_argument('--report-interval', metavar='INTERVAL', dest='reportint', type=int,
+            default=10,
+            help='the # of megabytes of message data between reports (defaults to 10 MB)')
+    parser.add_argument('--total-size', metavar='TOTSIZE', dest='totalsize', type=int,
+            default=0,
+            help='the total # of megabytes to generate before ending (defaults to 0, unlimited)')
+    args = parser.parse_args()
+
+    # Determine the output method to emit logs
+    if args.output == 'syslog':
+        output_method = log.debug
+        ofp = None
+    else:
+        if args.output in ('stderr', 'stdout'):
+            ofp = getattr(sys, args.output)
+        else:
+            # Assume the parameter is a file name
+            ofp = open(args.output, "w")
+        def output_closure(payload):
+            ofp.write(payload + '\n')
+        output_method = output_closure
+
+    # Determine the report method to use
+    if args.report == 'inline':
+        report_method = None
+        rfp = None
+    elif args.report == 'syslog':
+        report_method = log.info
+        rfp = None
+    else:
+        if args.report in ('stderr', 'stdout'):
+            rfp = getattr(sys, args.report)
+        else:
+            # Assume the parameter is a file name
+            rfp = open(args.report, "w")
+        def report_closure(payload):
+            rfp.write(payload + '\n')
+            rfp.flush()
+        report_method = report_closure
+
+    try:
+        load(args.invocid, args.payload_size, output_method, report_method,
+                dist=args.payload_dist, stddev=args.stddev, msgpersec=args.msgpersec,
+                report_interval=args.reportint, total_size=args.totalsize,
+                payload_gen=args.payload_gen)
+    except KeyboardInterrupt:
+        if ofp:
+            ofp.flush()
+            ofp.close()
+        if rfp:
+            rfp.flush()
+            rfp.close()

--- a/hack/logging-load-driver/verify-loader
+++ b/hack/logging-load-driver/verify-loader
@@ -1,0 +1,271 @@
+#!/usr/bin/env python
+#
+# ViaQ logging load generator
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+import os
+import time
+import argparse
+import signal
+from collections import defaultdict
+
+REPORT_INTERVAL = 10
+MB = 1024 * 1024
+
+# if running verify-loader as a background process,
+# we can still do a kill -2 $pid to make it exit
+# the main loop and print the stats
+def handle_sig_int(signum, frame):
+    raise KeyboardInterrupt
+
+signal.signal(signal.SIGINT, handle_sig_int)
+
+class Context(object):
+
+    def __init__(self):
+        self.prev = None
+        self.count = 0
+        self.bytes = 0
+        self.report_count = 0
+        self.report_bytes = 0
+        self.duplicates = 0
+        self.skips = 0
+
+    def msg(self, seq, length):
+        self.report_count += 1
+        self.report_bytes += length
+
+        if self.prev is None:
+            self.prev = seq
+            return None
+        elif seq == (self.prev + 1):
+            # normal and expected code path
+            self.prev = seq
+            return None
+        else:
+            ret_prev = self.prev
+            if seq <= self.prev:
+                self.duplicates += 1
+            else:
+                assert seq > (self.prev + 1), "Logic bomb! Should not be possible"
+                self.skips += 1
+                # Since the sequence jumped ahead, save the new value as the
+                # previous in order to be sure to stay with the jump.
+                self.prev = seq
+            return ret_prev
+
+    def report(self):
+        if self.report_count > 0:
+            self.count += self.report_count
+            self.bytes += self.report_bytes
+            self.report_count = 0
+            self.report_bytes = 0
+            ret_val = True
+        else:
+            ret_val = False
+
+
+def print_stats(invocid, ctx, payload):
+    try:
+        stats, _ = payload.rsplit(' ', 1)
+        rawvals = stats.strip()[:-1].split(' ')
+        vals = []
+        for val in rawvals:
+            if val:
+                vals.append(val)
+        if len(vals) == 5:
+            timestamp, statseq, lclrate, gblrate = vals[1], vals[2], vals[3], vals[4]
+        elif len(vals) == 8:
+            timestamp, statseq, lclrate, gblrate = vals[1], vals[2], vals[3], vals[7]
+        else:
+            print "Logic bomb!"
+            sys.exit(1)
+    except Exception:
+        print "Error: ", payload
+        sys.stdout.flush()
+    else:
+        try:
+            statseq = int(statseq)
+            ts = float(timestamp[:-1])
+            lclrate = float(lclrate)
+            gblrate = float(gblrate)
+        except Exception:
+            print "Error: ", payload
+            sys.stdout.flush()
+        else:
+            assert ctx.prev == statseq
+            assert timestamp[-1] == 's'
+            now = time.time()
+            print "%s: %.2fs (%5.2fs) %12.3f %12.3f %d %d %d %d" % (
+                    invocid, ts, now - ts, lclrate, gblrate, statseq,
+                    ctx.count, ctx.skips, ctx.duplicates)
+            sys.stdout.flush()
+
+
+def verify(input_gen, report_interval=REPORT_INTERVAL):
+    ret_val = 0
+
+    ignored_bytes = 0
+    ignored_count = 0
+
+    report_bytes = 0
+    report_bytes_target = report_interval * MB
+    report_ignored_bytes = 0
+    report_ignored_count = 0
+
+    contexts = defaultdict(Context)
+    start = time.time()
+    report_start = start
+
+    try:
+        for line in input_gen:
+            line_len = len(line)
+            if not line.startswith("loader seq - "):
+                report_ignored_bytes += line_len
+                report_ignored_count += 1
+            else:
+                try:
+                    _, invocid, seqval, payload = line.split('-', 4)
+                except Exception:
+                    report_ignored_bytes += line_len
+                    report_ignored_count += 1
+                else:
+                    try:
+                        seq = int(seqval)
+                    except Exception:
+                        report_ignored_bytes += line_len
+                        report_ignored_count += 1
+                    else:
+                        report_bytes += line_len
+                        invocid = invocid.strip()
+                        ctx = contexts[invocid]
+                        prev = ctx.msg(seq, line_len)
+                        if prev is not None:
+                            # Bad record encountered, flag it
+                            print "%s: %d %d  <-" % (invocid, seq, prev)
+                            sys.stdout.flush()
+                        if payload.startswith(" (stats:"):
+                            print_stats(invocid, ctx, payload)
+            if report_bytes_target > 0 and (report_bytes + report_ignored_bytes) >= report_bytes_target:
+                now = time.time()
+
+                ignored_bytes += report_ignored_bytes
+                ignored_count += report_ignored_count
+
+                total_bytes = 0
+                total_count = 0
+                report_count = 0
+
+                print "\n+++ verify-loader"
+
+                for invocid, ctx in contexts.items():
+                    report_count += ctx.report_count
+                    if ctx.report():
+                        print "%s: %d %d %d" % (invocid, ctx.count, ctx.skips, ctx.duplicates)
+                    total_bytes += ctx.bytes
+                    total_count += ctx.count
+
+                print "interval read rate: %.3f MB/sec, %.3f/sec " \
+                      "(ignored %.3f MB/sec, %.3f/sec); " \
+                      "overall read rate: %.3f MB/sec %.3f/sec " \
+                      "(ignored %.3f MB/sec, %.3f/sec)" % (
+                        (report_bytes / MB) / (now - report_start),
+                        (report_count / (now - report_start)),
+                        (report_ignored_bytes / MB) / (now - report_start),
+                        (report_ignored_count / (now - report_start)),
+                        (total_bytes / MB) / (now - start),
+                        (total_count / (now - start)),
+                        (ignored_bytes / MB) / (now - start),
+                        (ignored_count / (now - start)))
+                print "--- verify-loader\n"
+                sys.stdout.flush()
+
+                report_bytes = 0
+                report_count = 0
+                report_ignored_bytes = 0
+                report_ignored_count = 0
+                report_start = now
+    except KeyboardInterrupt:
+        pass
+    finally:
+        now = time.time()
+        ignored_bytes += report_ignored_bytes
+        ignored_count += report_ignored_count
+        total_bytes = 0
+        total_count = 0
+        tot_skips = 0
+        tot_dupes = 0
+        for invocid, ctx in contexts.items():
+            ctx.report()
+            total_bytes += ctx.bytes
+            total_count += ctx.count
+            tot_skips += ctx.skips
+            tot_dupes += ctx.duplicates
+        if ignored_count + total_count > 0:
+            print "\n+++ verify-loader"
+            for invocid, ctx in contexts.items():
+                print "%s: %d %d %d" % (invocid, ctx.count, ctx.skips, ctx.duplicates)
+            print "overall read rate: %.3f MB/sec %.3f/sec " \
+                  "(ignored %.3f MB/sec, %.3f/sec)" % (
+                    (total_bytes / MB) / (now - start),
+                    (total_count / (now - start)),
+                    (ignored_bytes / MB) / (now - start),
+                    (ignored_count / (now - start)))
+            print "--- verify-loader\n"
+        if tot_skips + tot_dupes > 0:
+            ret_val = 1
+    return ret_val
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Message payload generator.')
+    parser.add_argument('file', metavar='FILE', nargs='?',
+            default='-',
+            help='file to read, if empty, stdin is used')
+    parser.add_argument('--report-interval', metavar='INTERVAL', dest='reportint', type=int,
+            default=REPORT_INTERVAL,
+            help='the # of megabytes of message data between reports (defaults to 10 MB)')
+    parser.add_argument('--read-journal', dest='readjournal', action="store_true",
+            help='read directly from the systemd journal (defaults to False)')
+    args = parser.parse_args()
+
+    if args.file == '-':
+        if args.readjournal:
+            from systemd import journal
+            j = journal.Reader()
+            # the fileno() method ends up creating the inotify file descriptor
+            # which in turn prevents this client from leaking open journal log
+            # files.
+            j.fileno()
+            j.seek_tail()
+            j.get_previous()
+            def jreader():
+                while True:
+                    for entry in j:
+                        yield entry['MESSAGE']
+                    j.wait()
+            input_gen = jreader()
+        else:
+            input_gen = os.fdopen(sys.stdin.fileno(), 'r', 0)
+    else:
+        if args.readjournal:
+            print "*** Warning *** ignoring request to read from the systemd" \
+                  " journal (--read-journal) since we have an actual file" \
+                  " argument provided (%s) ..." % args.file
+        input_gen = open(args.file, 'r', 0)
+    sys.exit(verify(input_gen, args.reportint))

--- a/hack/testing/templates/logging-load-driver-template.yaml
+++ b/hack/testing/templates/logging-load-driver-template.yaml
@@ -1,0 +1,79 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: logging-load-driver-template
+  annotations:
+    description: "For creating the logging-load-driver pod"
+objects:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: ${POD_NAME}
+    namespace: ${NAMESPACE}
+  spec:
+    restartPolicy: Never
+    terminationGracePeriodSeconds: 0
+    nodeSelector:
+      logging-ci-test: "true"
+    containers:
+    - name: logging-load-driver
+      image: ${IMAGE}
+      imagePullPolicy: Always
+      command: ["${LOADER_PATH}"]
+      args:
+      - "--msgpersec=${MSGPERSEC}"
+      - "--report-interval=${REPORT_INTERVAL}"
+      - "--total-size=${TOTAL_SIZE}"
+      - "--distribution=${DISTRIBUTION}"
+      - "--payload-gen=${PAYLOAD_GEN}"
+      - "--stddev=${STDDEV}"
+      - "--output=${OUTPUT}"
+      - "--report=${REPORT}"
+      - "--invocid=${INVOCID}"
+      - ${PAYLOAD_SIZE}
+parameters:
+- description: Namespace name to create pod in
+  value: openshift-logging
+  name: NAMESPACE
+- description: name of pod to create
+  value: logging-load-driver
+  name: POD_NAME
+- description: path to loader command in the image
+  value: "/loader"
+  name: LOADER_PATH
+- description: number of messages per second
+  value: "0"
+  name: MSGPERSEC
+- description: the number of megabytes of message data between reports
+  value: "10"
+  name: REPORT_INTERVAL
+- description: size of log message in bytes
+  value: "1024"
+  name: PAYLOAD_SIZE
+- description: payload size distribution - fixed or gaussian
+  value: fixed
+  name: DISTRIBUTION
+- description: payload generation method - random or fixed
+  value: random
+  name: PAYLOAD_GEN
+- description: standard deviation for gaussian distribution
+  value: "32"
+  name: STDDEV
+- description: where to write output
+  value: stdout
+  name: OUTPUT
+- description: where to write report stats - inline or other
+  value: inline
+  name: REPORT
+- description: total number of bytes to write (0 for unlimited)
+  value: "0"
+  name: TOTAL_SIZE
+- description: unique identifier for this group of logs
+  value: invocid
+  name: INVOCID
+- description: test image to use
+  value: logging-ci-test-runner:latest
+  name: IMAGE
+labels:
+  test: "true"
+  

--- a/hack/testing/test-perf-basic.sh
+++ b/hack/testing/test-perf-basic.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../lib/init.sh"
+
+exec ${OS_O_A_L_DIR}/test/perf-basic.sh

--- a/rsyslog/vendored_src/librdkafka/librdkafka.spec
+++ b/rsyslog/vendored_src/librdkafka/librdkafka.spec
@@ -1,6 +1,6 @@
 Name:		librdkafka
 Version:	0.11.4
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	The Apache Kafka C library
 
 Group:		Development/Libraries
@@ -77,6 +77,9 @@ find %{buildroot} -name '*.a' -delete -print
 
 
 %changelog
+* Mon Jun 03 2019 Radovan Sroka <rsroka@redhat.com> - 0.11.4-2
+- rebuild
+
 * Fri Feb 08 2019 Jiri Vymazal <jvymazal@redhat.com> - 0.11.4-1
 - rebase to v0.11.4 (0.11.5 was breaking rsyslog-kafka)
   resolves: rhbz#1614697

--- a/rsyslog/vendored_src/rsyslog/rsyslog.spec
+++ b/rsyslog/vendored_src/rsyslog/rsyslog.spec
@@ -6,7 +6,7 @@
 Summary: Enhanced system logging and kernel message trapping daemon
 Name: rsyslog
 Version: 8.37.0
-Release: 9%{?dist}
+Release: 13%{?dist}
 License: (GPLv3+ and ASL 2.0)
 Group: System Environment/Daemons
 ExcludeArch: i686
@@ -225,6 +225,14 @@ mv build doc
 %patch1 -p1 -b .default-tag
 %patch2 -p1 -b .imfile-symlink
 %patch3 -p1 -b .mmkubernetes-404
+%patch4 -p1 -b .endmsg-regex
+%patch5 -p1 -b .rotation-detection
+%patch6 -p1 -b .short-offmsg-crash
+%patch7 -p1 -b .preservecase-option
+%patch8 -p1 -b .imjournal-memleak
+%patch9 -p1 -b .imjournal-err-flood
+%patch10 -p1 -b .imrelp-old-syntax
+%patch11 -p1 -b .tls-CC
 
 %build
 %ifarch sparc64
@@ -428,6 +436,39 @@ done
 
 
 %changelog
+* Fri Aug 30 2019 Jiri Vymazal <jvymazal@redhat.com> - 8.37.0-13
+  RHEL 8.1.0 ERRATUM
+- added patch enabling stricter TLS certs checking conforming to 
+  common criteria requirements
+  resolves: rhbz#1733244
+
+* Mon Jul 22 2019 Jiri Vymazal <jvymazal@redhat.com> - 8.37.0-12
+  RHEL 8.1.0 ERRATUM
+- edited imjournal memleak patch to not cause double-free crash
+  resolves: rhbz#1729995
+- added patch calling journald API only when there are no
+  preceeding errors
+  resolves: rhbz#1722165
+- added patch fixing imrelp module when invoked with old syntax
+  resolves: rhbz#1724218
+
+* Wed Jun 05 2019 Jiri Vymazal <jvymazal@redhat.com> - 8.37.0-11
+  RHEL 8.1.0 ERRATUM
+- fixed memory leak in imjournal by proper cursor releasing
+  resolves: rhbz#1716867
+
+* Fri May 10 2019 Jiri Vymazal <jvymazal@redhat.com> - 8.37.0-10
+  RHEL 8.1.0 ERRATUM
+- added option for imfile endmsg.regex
+  resolves: rhbz#1627941
+- added patch enhancing imfile rotation detection
+  resolves: rhbz#1674471
+- added patch fixing msgOffset datatype preventing crash on
+  message with too long other fields
+  resolves: rhbz#1677037
+- added patch introducing "preservecase" option for imudp/imtcp
+  resolves: rhbz#1614181
+
 * Mon Dec 17 2018 Jiri Vymazal <jvymazal@redhat.com> - 8.37.0-9
   RHEL 8.0.0 ERRATUM
 - added back legacy option for imjournal default tag

--- a/rsyslog/vendored_src/rsyslog/rsyslog/plugins/imfile/imfile.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/plugins/imfile/imfile.c
@@ -731,8 +731,19 @@ detect_updates(fs_edge_t *const edge)
 			act_obj_unlink(act);
 			restart = 1;
 			break;
+		} else if(fileInfo.st_ino != act->ino) {
+			DBGPRINTF("file '%s' inode changed from %llu to %llu, unlinking from "
+				"internal lists\n", act->name, (long long unsigned) act->ino,
+				(long long unsigned) fileInfo.st_ino);
+			if(act->pStrm != NULL) {
+				/* we do no need to re-set later, as act_obj_unlink
+				 * will destroy the strm obj */
+				strmSet_checkRotation(act->pStrm, STRM_ROTATION_DO_NOT_CHECK);
+			}
+			act_obj_unlink(act);
+			restart = 1;
+			break;
 		}
-		// TODO: add inode check for change notification!
 
 	}
 
@@ -984,10 +995,10 @@ chk_active(const act_obj_t *act, const act_obj_t *const deleted)
 /* unlink act object from linked list and then
  * destruct it.
  */
-static void //ATTR_NONNULL()
+static void ATTR_NONNULL()
 act_obj_unlink(act_obj_t *act)
 {
-	DBGPRINTF("act_obj_unlink %p: %s\n", act, act->name);
+	DBGPRINTF("act_obj_unlink %p: %s, pStrm %p\n", act, act->name, act->pStrm);
 	if(act->prev == NULL) {
 		act->edge->active = act->next;
 	} else {

--- a/rsyslog/vendored_src/rsyslog/rsyslog/plugins/imrelp/imrelp.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/plugins/imrelp/imrelp.c
@@ -346,6 +346,8 @@ static rsRetVal addInstance(void __attribute__((unused)) *pVal, uchar *pNewVal)
 		CHKmalloc(inst->pszBindRuleset = ustrdup(cs.pszBindRuleset));
 	}
 	inst->pBindRuleset = NULL;
+
+	inst->bEnableLstn = -1; /* all ok, ready to start up */
 finalize_it:
 	free(pNewVal);
 	RETiRet;

--- a/rsyslog/vendored_src/rsyslog/rsyslog/plugins/imtcp/imtcp.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/plugins/imtcp/imtcp.c
@@ -100,6 +100,7 @@ static struct configSettings_s {
 	int bDisableLFDelim;
 	int discardTruncatedMsg;
 	int bUseFlowControl;
+	int bPreserveCase;
 	uchar *gnutlsPriorityString;
 	uchar *pszStrmDrvrAuthMode;
 	uchar *pszInputName;
@@ -128,6 +129,8 @@ struct modConfData_s {
 	int iTCPSessMax; /* max number of sessions */
 	int iTCPLstnMax; /* max number of sessions */
 	int iStrmDrvrMode; /* mode for stream driver, driver-dependent (0 mostly means plain tcp) */
+	int iStrmDrvrExtendedCertCheck; /* verify also purpose OID in certificate extended field */
+	int iStrmDrvrSANPreference; /* ignore CN when any SAN set */
 	int iAddtlFrameDelim; /* addtl frame delimiter, e.g. for netscreen, default none */
 	int maxFrameSize;
 	int bSuppOctetFram;
@@ -144,6 +147,7 @@ struct modConfData_s {
 	uchar *pszStrmDrvrAuthMode; /* authentication mode to use */
 	struct cnfarray *permittedPeers;
 	sbool configSetViaV2Method;
+	sbool bPreserveCase; /* preserve case of fromhost; true by default */
 };
 
 static modConfData_t *loadModConf = NULL;/* modConf ptr to use for the current load process */
@@ -164,12 +168,15 @@ static struct cnfparamdescr modpdescr[] = {
 	{ "streamdriver.mode", eCmdHdlrNonNegInt, 0 },
 	{ "streamdriver.authmode", eCmdHdlrString, 0 },
 	{ "streamdriver.name", eCmdHdlrString, 0 },
+	{ "streamdriver.CheckExtendedKeyPurpose", eCmdHdlrBinary, 0 },
+	{ "streamdriver.PrioritizeSAN", eCmdHdlrBinary, 0 },
 	{ "permittedpeer", eCmdHdlrArray, 0 },
 	{ "keepalive", eCmdHdlrBinary, 0 },
 	{ "keepalive.probes", eCmdHdlrPositiveInt, 0 },
 	{ "keepalive.time", eCmdHdlrPositiveInt, 0 },
 	{ "keepalive.interval", eCmdHdlrPositiveInt, 0 },
-	{ "gnutlsprioritystring", eCmdHdlrString, 0 }
+	{ "gnutlsprioritystring", eCmdHdlrString, 0 },
+	{ "preservecase", eCmdHdlrBinary, 0 }
 };
 static struct cnfparamblk modpblk =
 	{ CNFPARAMBLK_VERSION,
@@ -359,6 +366,8 @@ addListner(modConfData_t *modConf, instanceConf_t *inst)
 		CHKiRet(tcpsrv.SetSessMax(pOurTcpsrv, modConf->iTCPSessMax));
 		CHKiRet(tcpsrv.SetLstnMax(pOurTcpsrv, modConf->iTCPLstnMax));
 		CHKiRet(tcpsrv.SetDrvrMode(pOurTcpsrv, modConf->iStrmDrvrMode));
+		CHKiRet(tcpsrv.SetDrvrCheckExtendedKeyUsage(pOurTcpsrv, modConf->iStrmDrvrExtendedCertCheck));
+		CHKiRet(tcpsrv.SetDrvrPrioritizeSAN(pOurTcpsrv, modConf->iStrmDrvrSANPreference));
 		CHKiRet(tcpsrv.SetUseFlowControl(pOurTcpsrv, modConf->bUseFlowControl));
 		CHKiRet(tcpsrv.SetAddtlFrameDelim(pOurTcpsrv, modConf->iAddtlFrameDelim));
 		CHKiRet(tcpsrv.SetMaxFrameSize(pOurTcpsrv, modConf->maxFrameSize));
@@ -375,6 +384,7 @@ addListner(modConfData_t *modConf, instanceConf_t *inst)
 		if(pPermPeersRoot != NULL) {
 			CHKiRet(tcpsrv.SetDrvrPermPeers(pOurTcpsrv, pPermPeersRoot));
 		}
+		CHKiRet(tcpsrv.SetPreserveCase(pOurTcpsrv, modConf->bPreserveCase));
 	}
 
 	/* initialized, now add socket and listener params */
@@ -458,6 +468,8 @@ CODESTARTbeginCnfLoad
 	loadModConf->iTCPLstnMax = 20;
 	loadModConf->bSuppOctetFram = 1;
 	loadModConf->iStrmDrvrMode = 0;
+	loadModConf->iStrmDrvrExtendedCertCheck = 0;
+	loadModConf->iStrmDrvrSANPreference = 0;
 	loadModConf->bUseFlowControl = 1;
 	loadModConf->bKeepAlive = 0;
 	loadModConf->iKeepAliveIntvl = 0;
@@ -473,6 +485,7 @@ CODESTARTbeginCnfLoad
 	loadModConf->pszStrmDrvrAuthMode = NULL;
 	loadModConf->permittedPeers = NULL;
 	loadModConf->configSetViaV2Method = 0;
+	loadModConf->bPreserveCase = 1; /* default to true */
 	bLegacyCnfModGlobalsPermitted = 1;
 	/* init legacy config variables */
 	cs.pszStrmDrvrAuthMode = NULL;
@@ -537,12 +550,18 @@ CODESTARTsetModCnf
 			loadModConf->gnutlsPriorityString = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(modpblk.descr[i].name, "streamdriver.mode")) {
 			loadModConf->iStrmDrvrMode = (int) pvals[i].val.d.n;
+		} else if(!strcmp(modpblk.descr[i].name, "streamdriver.CheckExtendedKeyPurpose")) {
+			loadModConf->iStrmDrvrExtendedCertCheck = (int) pvals[i].val.d.n;
+		} else if(!strcmp(modpblk.descr[i].name, "streamdriver.PrioritizeSAN")) {
+			loadModConf->iStrmDrvrSANPreference = (int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "streamdriver.authmode")) {
 			loadModConf->pszStrmDrvrAuthMode = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(modpblk.descr[i].name, "streamdriver.name")) {
 			loadModConf->pszStrmDrvrName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(modpblk.descr[i].name, "permittedpeer")) {
 			loadModConf->permittedPeers = cnfarrayDup(pvals[i].val.d.ar);
+		} else if(!strcmp(modpblk.descr[i].name, "preservecase")) {
+			loadModConf->bPreserveCase = (int) pvals[i].val.d.n;
 		} else {
 			dbgprintf("imtcp: program error, non-handled "
 			  "param '%s' in beginCnfLoad\n", modpblk.descr[i].name);
@@ -584,6 +603,7 @@ CODESTARTendCnfLoad
 			loadModConf->pszStrmDrvrAuthMode = cs.pszStrmDrvrAuthMode;
 			cs.pszStrmDrvrAuthMode = NULL;
 		}
+		pModConf->bPreserveCase = cs.bPreserveCase;
 	}
 	free(cs.pszStrmDrvrAuthMode);
 	cs.pszStrmDrvrAuthMode = NULL;
@@ -731,6 +751,7 @@ resetConfigVariables(uchar __attribute__((unused)) *pp, void __attribute__((unus
 	cs.pszInputName = NULL;
 	free(cs.pszStrmDrvrAuthMode);
 	cs.pszStrmDrvrAuthMode = NULL;
+	cs.bPreserveCase = 1;
 	return RS_RET_OK;
 }
 
@@ -797,7 +818,8 @@ CODEmodInit_QueryRegCFSLineHdlr
 			   NULL, &cs.bEmitMsgOnClose, STD_LOADABLE_MODULE_ID, &bLegacyCnfModGlobalsPermitted));
 	CHKiRet(regCfSysLineHdlr2(UCHAR_CONSTANT("inputtcpserverstreamdrivermode"), 0, eCmdHdlrInt,
 			   NULL, &cs.iStrmDrvrMode, STD_LOADABLE_MODULE_ID, &bLegacyCnfModGlobalsPermitted));
-
+	CHKiRet(regCfSysLineHdlr2(UCHAR_CONSTANT("inputtcpserverpreservecase"), 1, eCmdHdlrBinary,
+			   NULL, &cs.bPreserveCase, STD_LOADABLE_MODULE_ID, &bLegacyCnfModGlobalsPermitted));
 	CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("resetconfigvariables"), 1, eCmdHdlrCustomHandler,
 				   resetConfigVariables, NULL, STD_LOADABLE_MODULE_ID));
 ENDmodInit

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/msg.h
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/msg.h
@@ -67,8 +67,8 @@ struct msg {
 	sbool	bParseSuccess;	/* set to reflect state of last executed higher level parser */
 	unsigned short	iSeverity;/* the severity  */
 	unsigned short	iFacility;/* Facility code */
-	short	offAfterPRI;	/* offset, at which raw message WITHOUT PRI part starts in pszRawMsg */
-	short	offMSG;		/* offset at which the MSG part starts in pszRawMsg */
+	uint32_t offAfterPRI;	/* offset, at which raw message WITHOUT PRI part starts in pszRawMsg */
+	uint32_t offMSG;		/* offset at which the MSG part starts in pszRawMsg */
 	short	iProtocolVersion;/* protocol version of message received 0 - legacy, 1 syslog-protocol) */
 	int	msgFlags;	/* flags associated with this message */
 	int	iLenRawMsg;	/* length of raw message */
@@ -156,6 +156,8 @@ struct msg {
 /* check UDP ACLs after DNS resolution has been done in main queue consumer */
 #define NO_PRI_IN_RAW	0x100
 /* rawmsg does not include a PRI (Solaris!), but PRI is already set correctly in the msg object */
+#define PRESERVE_CASE	0x200
+/* preserve case in fromhost */
 
 /* (syslog) protocol types */
 #define MSG_LEGACY_PROTOCOL 0
@@ -192,8 +194,8 @@ void MsgSetRcvFromStr(smsg_t *const pMsg, const uchar* pszRcvFrom, const int, pr
 rsRetVal MsgSetRcvFromIP(smsg_t *pMsg, prop_t*);
 rsRetVal MsgSetRcvFromIPStr(smsg_t *const pThis, const uchar *psz, const int len, prop_t **ppProp);
 void MsgSetHOSTNAME(smsg_t *pMsg, const uchar* pszHOSTNAME, const int lenHOSTNAME);
-rsRetVal MsgSetAfterPRIOffs(smsg_t *pMsg, short offs);
-void MsgSetMSGoffs(smsg_t *pMsg, short offs);
+rsRetVal MsgSetAfterPRIOffs(smsg_t *pMsg, uint32_t offs);
+void MsgSetMSGoffs(smsg_t *pMsg, uint32_t offs);
 void MsgSetRawMsgWOSize(smsg_t *pMsg, char* pszRawMsg);
 void ATTR_NONNULL() MsgSetRawMsg(smsg_t *const pThis, const char*const pszRawMsg, const size_t lenMsg);
 rsRetVal MsgReplaceMSG(smsg_t *pThis, const uchar* pszMSG, int lenMSG);

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/net.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/net.c
@@ -1152,7 +1152,7 @@ cvthname(struct sockaddr_storage *f, prop_t **localName, prop_t **fqdn, prop_t *
 {
 	DEFiRet;
 	assert(f != NULL);
-	iRet = dnscacheLookup(f, NULL, fqdn, localName, ip);
+	iRet = dnscacheLookup(f, fqdn, NULL, localName, ip);
 	RETiRet;
 }
 

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/netstrm.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/netstrm.c
@@ -209,6 +209,26 @@ SetDrvrPermPeers(netstrm_t *pThis, permittedPeers_t *pPermPeers)
 	RETiRet;
 }
 
+/* Mandate also verification of Extended key usage / purpose field */
+static rsRetVal
+SetDrvrCheckExtendedKeyUsage(netstrm_t *pThis, int ChkExtendedKeyUsage)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrm);
+	iRet = pThis->Drvr.SetCheckExtendedKeyUsage(pThis->pDrvrData, ChkExtendedKeyUsage);
+	RETiRet;
+}
+
+/* Mandate stricter name checking per RFC 6125 - ignoce CN if any SAN present */
+static rsRetVal
+SetDrvrPrioritizeSAN(netstrm_t *pThis, int prioritizeSan)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrm);
+	iRet = pThis->Drvr.SetPrioritizeSAN(pThis->pDrvrData, prioritizeSan);
+	RETiRet;
+}
+
 
 /* End of methods to shuffle autentication settings to the driver.
  * -------------------------------------------------------------------------- */
@@ -392,6 +412,8 @@ CODESTARTobjQueryInterface(netstrm)
 	pIf->SetKeepAliveTime = SetKeepAliveTime;
 	pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
 	pIf->SetGnutlsPriorityString = SetGnutlsPriorityString;
+	pIf->SetDrvrCheckExtendedKeyUsage = SetDrvrCheckExtendedKeyUsage;
+	pIf->SetDrvrPrioritizeSAN = SetDrvrPrioritizeSAN;
 finalize_it:
 ENDobjQueryInterface(netstrm)
 

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/netstrm.h
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/netstrm.h
@@ -76,8 +76,11 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetKeepAliveTime)(netstrm_t *pThis, int keepAliveTime);
 	rsRetVal (*SetKeepAliveIntvl)(netstrm_t *pThis, int keepAliveIntvl);
 	rsRetVal (*SetGnutlsPriorityString)(netstrm_t *pThis, uchar *priorityString);
+	/* v12 -- two new binary flags added to gtls driver enabling stricter operation */
+	rsRetVal (*SetDrvrCheckExtendedKeyUsage)(netstrm_t *pThis, int ChkExtendedKeyUsage);
+	rsRetVal (*SetDrvrPrioritizeSAN)(netstrm_t *pThis, int prioritizeSan);
 ENDinterface(netstrm)
-#define netstrmCURR_IF_VERSION 10 /* increment whenever you change the interface structure! */
+#define netstrmCURR_IF_VERSION 12 /* increment whenever you change the interface structure! */
 /* interface version 3 added GetRemAddr()
  * interface version 4 added EnableKeepAlive() -- rgerhards, 2009-06-02
  * interface version 5 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/netstrms.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/netstrms.c
@@ -248,6 +248,49 @@ GetDrvrMode(netstrms_t *pThis)
 }
 
 
+/* set the driver cert extended key usage check setting -- jvymazal, 2019-08-16 */
+static rsRetVal
+SetDrvrCheckExtendedKeyUsage(netstrms_t *pThis, int ChkExtendedKeyUsage)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrms);
+	pThis->DrvrChkExtendedKeyUsage = ChkExtendedKeyUsage;
+	RETiRet;
+}
+
+
+/* return the driver cert extended key usage check setting
+ * jvymazal, 2019-08-16
+ */
+static int
+GetDrvrCheckExtendedKeyUsage(netstrms_t *pThis)
+{
+	ISOBJ_TYPE_assert(pThis, netstrms);
+	return pThis->DrvrChkExtendedKeyUsage;
+}
+
+
+/* set the driver name checking policy -- jvymazal, 2019-08-16 */
+static rsRetVal
+SetDrvrPrioritizeSAN(netstrms_t *pThis, int prioritizeSan)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrms);
+	pThis->DrvrPrioritizeSan = prioritizeSan;
+	RETiRet;
+}
+
+
+/* return the driver name checking policy
+ * jvymazal, 2019-08-16
+ */
+static int
+GetDrvrPrioritizeSAN(netstrms_t *pThis)
+{
+	ISOBJ_TYPE_assert(pThis, netstrms);
+	return pThis->DrvrPrioritizeSan;
+}
+
 /* create an instance of a netstrm object. It is initialized with default
  * values. The current driver is used. The caller may set netstrm properties
  * and must call ConstructFinalize().
@@ -304,6 +347,10 @@ CODESTARTobjQueryInterface(netstrms)
 	pIf->GetDrvrGnutlsPriorityString = GetDrvrGnutlsPriorityString;
 	pIf->SetDrvrPermPeers = SetDrvrPermPeers;
 	pIf->GetDrvrPermPeers = GetDrvrPermPeers;
+	pIf->SetDrvrCheckExtendedKeyUsage = SetDrvrCheckExtendedKeyUsage;
+	pIf->GetDrvrCheckExtendedKeyUsage = GetDrvrCheckExtendedKeyUsage;
+	pIf->SetDrvrPrioritizeSAN = SetDrvrPrioritizeSAN;
+	pIf->GetDrvrPrioritizeSAN = GetDrvrPrioritizeSAN;
 finalize_it:
 ENDobjQueryInterface(netstrms)
 

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/netstrms.h
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/netstrms.h
@@ -33,6 +33,8 @@ struct netstrms_s {
 	uchar *pDrvrName;	/**< full base driver name (set when driver is loaded) */
 	int iDrvrMode;		/**< current default driver mode */
 	uchar *pszDrvrAuthMode;	/**< current driver authentication mode */
+	int DrvrChkExtendedKeyUsage;		/**< if true, verify extended key usage in certs */
+	int DrvrPrioritizeSan;		/**< if true, perform stricter checking of names in certs */
 	uchar *gnutlsPriorityString; /**< priorityString for connection */
 	permittedPeers_t *pPermPeers;/**< current driver's permitted peers */
 
@@ -55,6 +57,10 @@ BEGINinterface(netstrms) /* name must also be changed in ENDinterface macro! */
 	permittedPeers_t* (*GetDrvrPermPeers)(netstrms_t *pThis);
 	rsRetVal (*SetDrvrGnutlsPriorityString)(netstrms_t *pThis, uchar*);
 	uchar*   (*GetDrvrGnutlsPriorityString)(netstrms_t *pThis);
+	rsRetVal (*SetDrvrCheckExtendedKeyUsage)(netstrms_t *pThis, int ChkExtendedKeyUsage);
+	int      (*GetDrvrCheckExtendedKeyUsage)(netstrms_t *pThis);
+	rsRetVal (*SetDrvrPrioritizeSAN)(netstrms_t *pThis, int prioritizeSan);
+	int      (*GetDrvrPrioritizeSAN)(netstrms_t *pThis);
 ENDinterface(netstrms)
 #define netstrmsCURR_IF_VERSION 1 /* increment whenever you change the interface structure! */
 

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/nsd.h
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/nsd.h
@@ -84,8 +84,11 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetKeepAliveProbes)(nsd_t *pThis, int keepAliveProbes);
 	rsRetVal (*SetKeepAliveTime)(nsd_t *pThis, int keepAliveTime);
 	rsRetVal (*SetGnutlsPriorityString)(nsd_t *pThis, uchar *gnutlsPriorityString);
+	/* v13 -- two new binary flags added to gtls driver enabling stricter operation */
+	rsRetVal (*SetCheckExtendedKeyUsage)(nsd_t *pThis, int ChkExtendedKeyUsage);
+	rsRetVal (*SetPrioritizeSAN)(nsd_t *pThis, int prioritizeSan);
 ENDinterface(nsd)
-#define nsdCURR_IF_VERSION 11 /* increment whenever you change the interface structure! */
+#define nsdCURR_IF_VERSION 13 /* increment whenever you change the interface structure! */
 /* interface version 4 added GetRemAddr()
  * interface version 5 added EnableKeepAlive() -- rgerhards, 2009-06-02
  * interface version 6 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/nsd_gtls.h
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/nsd_gtls.h
@@ -49,6 +49,11 @@ struct nsd_gtls_s {
 		GTLS_AUTH_CERTVALID = 2,
 		GTLS_AUTH_CERTANON = 3
 	} authMode;
+	enum {
+		GTLS_NONE = 0,
+		GTLS_PURPOSE = 1
+	} dataTypeCheck;
+	int bSANpriority; /* if true, we do stricter checking (if any SAN present we do not cehck CN) */
 	gtlsRtryCall_t rtryCall;/**< what must we retry? */
 	int bIsInitiator;	/**< 0 if socket is the server end (listener), 1 if it is the initiator */
 	gnutls_session_t sess;

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/nsd_ossl.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/nsd_ossl.c
@@ -1570,6 +1570,40 @@ SetGnutlsPriorityString(__attribute__((unused)) nsd_t *pNsd, __attribute__((unus
 	RETiRet;
 }
 
+/* Set the driver cert extended key usage check setting, for now it is empty wrapper.
+ * TODO: implement openSSL version
+ * jvymazal, 2019-08-16
+ */
+static rsRetVal
+SetCheckExtendedKeyUsage(nsd_t __attribute__((unused)) *pNsd, int ChkExtendedKeyUsage)
+{
+	DEFiRet;
+	if(ChkExtendedKeyUsage != 0) {
+		LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "error: driver ChkExtendedKeyUsage %d "
+				"not supported by ossl netstream driver", ChkExtendedKeyUsage);
+		ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+	}
+finalize_it:
+	RETiRet;
+}
+
+/* Set the driver name checking strictness, for now it is empty wrapper.
+ * TODO: implement openSSL version
+ * jvymazal, 2019-08-16
+ */
+static rsRetVal
+SetPrioritizeSAN(nsd_t __attribute__((unused)) *pNsd, int prioritizeSan)
+{
+	DEFiRet;
+	if(prioritizeSan != 0) {
+		LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "error: driver prioritizeSan %d "
+				"not supported by ossl netstream driver", prioritizeSan);
+		ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+	}
+finalize_it:
+	RETiRet;
+}
+
 /* queryInterface function */
 BEGINobjQueryInterface(nsd_ossl)
 CODESTARTobjQueryInterface(nsd_ossl)
@@ -1603,6 +1637,8 @@ CODESTARTobjQueryInterface(nsd_ossl)
 	pIf->SetKeepAliveProbes = SetKeepAliveProbes;
 	pIf->SetKeepAliveTime = SetKeepAliveTime;
 	pIf->SetGnutlsPriorityString = SetGnutlsPriorityString; /* we don't NEED this interface! */
+	pIf->SetCheckExtendedKeyUsage = SetCheckExtendedKeyUsage; /* we don't NEED this interface! */
+	pIf->SetPrioritizeSAN = SetPrioritizeSAN; /* we don't NEED this interface! */
 
 finalize_it:
 ENDobjQueryInterface(nsd_ossl)

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/nsd_ptcp.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/nsd_ptcp.c
@@ -150,6 +150,37 @@ finalize_it:
 	RETiRet;
 }
 
+/* Set the driver cert extended key usage check setting, not supported in ptcp.
+ * jvymazal, 2019-08-16
+ */
+static rsRetVal
+SetCheckExtendedKeyUsage(nsd_t __attribute__((unused)) *pNsd, int ChkExtendedKeyUsage)
+{
+	DEFiRet;
+	if(ChkExtendedKeyUsage != 0) {
+		LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "error: driver ChkExtendedKeyUsage %d "
+				"not supported by ptcp netstream driver", ChkExtendedKeyUsage);
+		ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+	}
+finalize_it:
+	RETiRet;
+}
+
+/* Set the driver name checking strictness, not supported in ptcp.
+ * jvymazal, 2019-08-16
+ */
+static rsRetVal
+SetPrioritizeSAN(nsd_t __attribute__((unused)) *pNsd, int prioritizeSan)
+{
+	DEFiRet;
+	if(prioritizeSan != 0) {
+		LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "error: driver prioritizeSan %d "
+				"not supported by ptcp netstream driver", prioritizeSan);
+		ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+	}
+finalize_it:
+	RETiRet;
+}
 
 /* Set the authentication mode. For us, the following is supported:
  * anon - no certificate checks whatsoever (discouraged, but supported)
@@ -550,6 +581,8 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 		CHKiRet(pNS->Drvr.Construct(&pNewNsd));
 		CHKiRet(pNS->Drvr.SetSock(pNewNsd, sock));
 		CHKiRet(pNS->Drvr.SetMode(pNewNsd, netstrms.GetDrvrMode(pNS)));
+		CHKiRet(pNS->Drvr.SetCheckExtendedKeyUsage(pNewNsd, netstrms.GetDrvrCheckExtendedKeyUsage(pNS)));
+		CHKiRet(pNS->Drvr.SetPrioritizeSAN(pNewNsd, netstrms.GetDrvrPrioritizeSAN(pNS)));
 		CHKiRet(pNS->Drvr.SetAuthMode(pNewNsd, netstrms.GetDrvrAuthMode(pNS)));
 		CHKiRet(pNS->Drvr.SetPermPeers(pNewNsd, netstrms.GetDrvrPermPeers(pNS)));
 		CHKiRet(pNS->Drvr.SetGnutlsPriorityString(pNewNsd, netstrms.GetDrvrGnutlsPriorityString(pNS)));
@@ -898,6 +931,8 @@ CODESTARTobjQueryInterface(nsd_ptcp)
 	pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
 	pIf->SetKeepAliveProbes = SetKeepAliveProbes;
 	pIf->SetKeepAliveTime = SetKeepAliveTime;
+	pIf->SetCheckExtendedKeyUsage = SetCheckExtendedKeyUsage;
+	pIf->SetPrioritizeSAN = SetPrioritizeSAN;
 finalize_it:
 ENDobjQueryInterface(nsd_ptcp)
 

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/rsyslog.h
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/rsyslog.h
@@ -220,9 +220,9 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	/* begin regular error codes */
 	RS_RET_NOT_IMPLEMENTED = -7,	/**< implementation is missing (probably internal error or lazyness ;)) */
 	RS_RET_OUT_OF_MEMORY = -6,	/**< memory allocation failed */
-	RS_RET_PROVIDED_BUFFER_TOO_SMALL = -50,
-/*< the caller provided a buffer, but the called function sees the size of this buffer is too small -
-operation not carried out */
+	RS_RET_PROVIDED_BUFFER_TOO_SMALL = -50, /*< the caller provided a buffer, but the called function sees
+						  the size of this buffer is too small - operation not carried out */
+	RS_RET_FILE_TRUNCATED = -51,	/**< (input) file was truncated, not an error but a status */
 	RS_RET_TRUE = -3,		/**< to indicate a true state (can be used as TRUE, legacy) */
 	RS_RET_FALSE = -2,		/**< to indicate a false state (can be used as FALSE, legacy) */
 	RS_RET_NO_IRET = -8,	/**< This is a trick for the debuging system - it means no iRet is provided  */

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/stream.h
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/stream.h
@@ -91,6 +91,10 @@ typedef enum {				/* when extending, do NOT change existing modes! */
 	STREAMMODE_WRITE_APPEND = 4
 } strmMode_t;
 
+/* settings for stream rotation (applies not to all processing modes!) */
+#define	STRM_ROTATION_DO_CHECK		0
+#define	STRM_ROTATION_DO_NOT_CHECK	1
+
 #define STREAM_ASYNC_NUMBUFS 2 /* must be a power of 2 -- TODO: make configurable */
 /* The strm_t data structure */
 typedef struct strm_s {
@@ -114,6 +118,7 @@ typedef struct strm_s {
 	sbool bDisabled; /* should file no longer be written to? (currently set only if omfile file size limit fails) */
 	sbool bSync;	/* sync this file after every write? */
 	sbool bReopenOnTruncate;
+	int rotationCheck; /* rotation check mode */
 	size_t sIOBufSize;/* size of IO buffer */
 	uchar *pszDir; /* Directory */
 	int lenDir;
@@ -124,6 +129,7 @@ typedef struct strm_s {
 	ino_t inode;	/* current inode for files being monitored (undefined else) */
 	uchar *pszCurrFName; /* name of current file (if open) */
 	uchar *pIOBuf;	/* the iobuffer currently in use to gather data */
+	char *pIOBuf_truncation; /* iobuffer used during trucation detection block re-reads */
 	size_t iBufPtrMax;	/* current max Ptr in Buffer (if partial read!) */
 	size_t iBufPtr;	/* pointer into current buffer */
 	int iUngetC;	/* char set via UngetChar() call or -1 if none set */
@@ -233,5 +239,6 @@ void strmSetReadTimeout(strm_t *const __restrict__ pThis, const int val);
 const uchar * ATTR_NONNULL() strmGetPrevLineSegment(strm_t *const pThis);
 const uchar * ATTR_NONNULL() strmGetPrevMsgSegment(strm_t *const pThis);
 int ATTR_NONNULL() strmGetPrevWasNL(const strm_t *const pThis);
+void ATTR_NONNULL() strmSet_checkRotation(strm_t *const pThis, const int val);
 
 #endif /* #ifndef STREAM_H_INCLUDED */

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/tcpsrv.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/tcpsrv.c
@@ -495,6 +495,15 @@ SessAccept(tcpsrv_t *pThis, tcpLstnPortList_t *pLstnInfo, tcps_sess_t **ppSess, 
 
 	/* get the host name */
 	CHKiRet(netstrm.GetRemoteHName(pNewStrm, &fromHostFQDN));
+	if (!pThis->bPreserveCase) {
+		/* preserve_case = off */
+		uchar *p;
+		for(p = fromHostFQDN; *p; p++) {
+			if (isupper((int) *p)) {
+				*p = tolower((int) *p);
+			}
+		}
+	}
 	CHKiRet(netstrm.GetRemoteIP(pNewStrm, &fromHostIP));
 	CHKiRet(netstrm.GetRemAddr(pNewStrm, &addr));
 	/* TODO: check if we need to strip the domain name here -- rgerhards, 2008-04-24 */
@@ -1001,6 +1010,7 @@ BEGINobjConstruct(tcpsrv) /* be sure to specify the object type also in END macr
 	pThis->ratelimitBurst = 10000;
 	pThis->bUseFlowControl = 1;
 	pThis->pszDrvrName = NULL;
+	pThis->bPreserveCase = 1; /* preserve case in fromhost; default to true. */
 ENDobjConstruct(tcpsrv)
 
 
@@ -1016,6 +1026,8 @@ tcpsrvConstructFinalize(tcpsrv_t *pThis)
 	if(pThis->pszDrvrName != NULL)
 		CHKiRet(netstrms.SetDrvrName(pThis->pNS, pThis->pszDrvrName));
 	CHKiRet(netstrms.SetDrvrMode(pThis->pNS, pThis->iDrvrMode));
+	CHKiRet(netstrms.SetDrvrCheckExtendedKeyUsage(pThis->pNS, pThis->DrvrChkExtendedKeyUsage));
+	CHKiRet(netstrms.SetDrvrPrioritizeSAN(pThis->pNS, pThis->DrvrPrioritizeSan));
 	if(pThis->pszDrvrAuthMode != NULL)
 		CHKiRet(netstrms.SetDrvrAuthMode(pThis->pNS, pThis->pszDrvrAuthMode));
 	if(pThis->pPermPeers != NULL)
@@ -1387,6 +1399,26 @@ SetDrvrPermPeers(tcpsrv_t *pThis, permittedPeers_t *pPermPeers)
 	RETiRet;
 }
 
+/* set the driver cert extended key usage check setting -- jvymazal, 2019-08-16 */
+static rsRetVal
+SetDrvrCheckExtendedKeyUsage(tcpsrv_t *pThis, int ChkExtendedKeyUsage)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, tcpsrv);
+	pThis->DrvrChkExtendedKeyUsage = ChkExtendedKeyUsage;
+	RETiRet;
+}
+
+/* set the driver name checking policy -- jvymazal, 2019-08-16 */
+static rsRetVal
+SetDrvrPrioritizeSAN(tcpsrv_t *pThis, int prioritizeSan)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, tcpsrv);
+	pThis->DrvrPrioritizeSan = prioritizeSan;
+	RETiRet;
+}
+
 
 /* End of methods to shuffle autentication settings to the driver.;
 
@@ -1429,6 +1461,16 @@ SetSessMax(tcpsrv_t *pThis, int iMax)
 	DEFiRet;
 	ISOBJ_TYPE_assert(pThis, tcpsrv);
 	pThis->iSessMax = iMax;
+	RETiRet;
+}
+
+
+static rsRetVal
+SetPreserveCase(tcpsrv_t *pThis, int bPreserveCase)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, tcpsrv);
+	pThis-> bPreserveCase = bPreserveCase;
 	RETiRet;
 }
 
@@ -1491,6 +1533,9 @@ CODESTARTobjQueryInterface(tcpsrv)
 	pIf->SetRuleset = SetRuleset;
 	pIf->SetLinuxLikeRatelimiters = SetLinuxLikeRatelimiters;
 	pIf->SetNotificationOnRemoteClose = SetNotificationOnRemoteClose;
+	pIf->SetPreserveCase = SetPreserveCase;
+	pIf->SetDrvrCheckExtendedKeyUsage = SetDrvrCheckExtendedKeyUsage;
+	pIf->SetDrvrPrioritizeSAN = SetDrvrPrioritizeSAN;
 
 finalize_it:
 ENDobjQueryInterface(tcpsrv)

--- a/rsyslog/vendored_src/rsyslog/rsyslog/runtime/tcpsrv.h
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/runtime/tcpsrv.h
@@ -61,6 +61,8 @@ struct tcpsrv_s {
 	int iKeepAliveTime;	/**< socket layer KEEPALIVE timeout */
 	netstrms_t *pNS;	/**< pointer to network stream subsystem */
 	int iDrvrMode;		/**< mode of the stream driver to use */
+	int DrvrChkExtendedKeyUsage;		/**< if true, verify extended key usage in certs */
+	int DrvrPrioritizeSan;		/**< if true, perform stricter checking of names in certs */
 	uchar *gnutlsPriorityString;	/**< priority string for gnutls */
 	uchar *pszDrvrAuthMode;	/**< auth mode of the stream driver to use */
 	uchar *pszDrvrName;	/**< name of stream driver to use */
@@ -85,6 +87,7 @@ struct tcpsrv_s {
 	int maxFrameSize;	/**< max frame size for octet counted*/
 	int bDisableLFDelim;	/**< if 1, standard LF frame delimiter is disabled (*very dangerous*) */
 	int discardTruncatedMsg;/**< discard msg part that has been truncated*/
+	sbool bPreserveCase;	/**< preserve case in fromhost */
 	int ratelimitInterval;
 	int ratelimitBurst;
 	tcps_sess_t **pSessions;/**< array of all of our sessions */
@@ -177,8 +180,13 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetbSPFramingFix)(tcpsrv_t*, sbool);
 	/* added v19 -- PascalWithopf, 2017-08-08 */
 	rsRetVal (*SetGnutlsPriorityString)(tcpsrv_t*, uchar*);
+	/* added v21 -- Preserve case in fromhost, 2018-08-16 */
+	rsRetVal (*SetPreserveCase)(tcpsrv_t *pThis, int bPreserveCase);
+	/* added v23 -- Options for stricter driver behavior, 2019-08-16 */
+	rsRetVal (*SetDrvrCheckExtendedKeyUsage)(tcpsrv_t *pThis, int ChkExtendedKeyUsage);
+	rsRetVal (*SetDrvrPrioritizeSAN)(tcpsrv_t *pThis, int prioritizeSan);
 ENDinterface(tcpsrv)
-#define tcpsrvCURR_IF_VERSION 20 /* increment whenever you change the interface structure! */
+#define tcpsrvCURR_IF_VERSION 23 /* increment whenever you change the interface structure! */
 /* change for v4:
  * - SetAddtlFrameDelim() added -- rgerhards, 2008-12-10
  * - SetInputName() added -- rgerhards, 2008-12-10

--- a/rsyslog/vendored_src/rsyslog/rsyslog/tools/omfwd.c
+++ b/rsyslog/vendored_src/rsyslog/rsyslog/tools/omfwd.c
@@ -82,6 +82,8 @@ typedef struct _instanceData {
 	uchar *pszStrmDrvrAuthMode;
 	permittedPeers_t *pPermPeers;
 	int iStrmDrvrMode;
+	int iStrmDrvrExtendedCertCheck; /* verify also purpose OID in certificate extended field */
+	int iStrmDrvrSANPreference; /* ignore CN when any SAN set */
 	char	*target;
 	char	*address;
 	char	*device;
@@ -187,6 +189,8 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "streamdrivermode", eCmdHdlrInt, 0 },
 	{ "streamdriverauthmode", eCmdHdlrGetWord, 0 },
 	{ "streamdriverpermittedpeers", eCmdHdlrGetWord, 0 },
+	{ "streamdriver.CheckExtendedKeyPurpose", eCmdHdlrBinary, 0 },
+	{ "streamdriver.PrioritizeSAN", eCmdHdlrBinary, 0 },
 	{ "resendlastmsgonreconnect", eCmdHdlrBinary, 0 },
 	{ "udp.sendtoall", eCmdHdlrBinary, 0 },
 	{ "udp.senddelay", eCmdHdlrInt, 0 },
@@ -745,6 +749,8 @@ static rsRetVal TCPSendInit(void *pvData)
 		CHKiRet(netstrms.CreateStrm(pWrkrData->pNS, &pWrkrData->pNetstrm));
 		CHKiRet(netstrm.ConstructFinalize(pWrkrData->pNetstrm));
 		CHKiRet(netstrm.SetDrvrMode(pWrkrData->pNetstrm, pData->iStrmDrvrMode));
+		CHKiRet(netstrm.SetDrvrCheckExtendedKeyUsage(pWrkrData->pNetstrm, pData->iStrmDrvrExtendedCertCheck));
+		CHKiRet(netstrm.SetDrvrPrioritizeSAN(pWrkrData->pNetstrm, pData->iStrmDrvrSANPreference));
 		/* now set optional params, but only if they were actually configured */
 		if(pData->pszStrmDrvrAuthMode != NULL) {
 			CHKiRet(netstrm.SetDrvrAuthMode(pWrkrData->pNetstrm, pData->pszStrmDrvrAuthMode));
@@ -1110,6 +1116,8 @@ setInstParamDefaults(instanceData *pData)
 	pData->pszStrmDrvr = NULL;
 	pData->pszStrmDrvrAuthMode = NULL;
 	pData->iStrmDrvrMode = 0;
+	pData->iStrmDrvrExtendedCertCheck = 0;
+	pData->iStrmDrvrSANPreference = 0;
 	pData->iRebindInterval = 0;
 	pData->bKeepAlive = 0;
 	pData->iKeepAliveProbes = 0;
@@ -1213,6 +1221,10 @@ CODESTARTnewActInst
 			pData->pszStrmDrvr = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "streamdrivermode")) {
 			pData->iStrmDrvrMode = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "streamdriver.CheckExtendedKeyPurpose")) {
+			pData->iStrmDrvrExtendedCertCheck = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "streamdriver.PrioritizeSAN")) {
+			pData->iStrmDrvrSANPreference = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriverauthmode")) {
 			pData->pszStrmDrvrAuthMode = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriverpermittedpeers")) {

--- a/test/perf-basic.sh
+++ b/test/perf-basic.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+# basic performance test
+
+source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
+source "${OS_O_A_L_DIR}/hack/testing/util.sh"
+os::util::environment::use_sudo
+
+LOGGING_NS=${LOGGING_NS:-openshift-logging}
+
+os::test::junit::declare_suite_start "test/perf-basic"
+
+cleanup() {
+    local return_code="$?"
+    set +e
+    if [ $return_code = 0 ] ; then
+        mycmd=os::log::info
+    else
+        mycmd=os::log::error
+    fi
+    $mycmd perf-basic test finished at $( date )
+    for proj in ${delete_project:-} ; do
+        oc delete project $proj --wait=true 2>&1 | artifact_out
+        curl_es $es_svc /project.${proj}.* -XDELETE 2>&1 | artifact_out
+    done
+    # this will call declare_test_end, suite_end, etc.
+    os::test::junit::reconcile_output
+    exit $return_code
+}
+trap "cleanup" EXIT
+
+get_load_driver_image() {
+    if [ -n "${OPENSHIFT_BUILD_NAMESPACE:-}" -a -n "${IMAGE_FORMAT:-}" ] ; then
+        imageprefix=$( echo "$IMAGE_FORMAT" | sed -e 's,/stable:.*$,/,' )
+        testimage=${imageprefix}pipeline:src
+        testroot=$( pwd )
+    elif [ "${USE_IMAGE_STREAM:-false}" = true ] ; then
+        # running in a dev env with imagestream builds
+        OPENSHIFT_BUILD_NAMESPACE=openshift
+        registry=$( oc -n $OPENSHIFT_BUILD_NAMESPACE get is -l logging-infra=development -o jsonpath='{.items[0].status.dockerImageRepository}' | \
+            sed 's,/[^/]*$,/,' )
+        testimage=${registry}logging-ci-test-runner:latest
+        testroot=/go/src/github.com/openshift/origin-aggregated-logging
+    else
+        # running in a dev env - pushed local builds
+        out=$( mktemp )
+        oc get is --all-namespaces | grep 'logging-ci-test-runner' > $out
+        while read ns name reg_and_name tag rest ; do
+            img="${reg_and_name}:${tag}"
+            case "$name" in
+            *logging-ci-test-runner) testimage="$img" ;;
+            esac
+        done < $out
+        rm -f $out
+        testroot=/go/src/github.com/openshift/origin-aggregated-logging
+    fi
+}
+
+es_svc=$( get_es_svc es )
+es_ops_svc=$( get_es_svc es-ops )
+es_ops_svc=${es_ops_svc:-$es_svc}
+
+get_load_driver_image
+test_template=$OS_O_A_L_DIR/hack/testing/templates/logging-load-driver-template.yaml
+
+# start N test pods in M namespaces
+N_PODS=${N_PODS:-1}
+N_NAMESPACES=${N_NAMESPACES:-1}
+N_RECORDS=${N_RECORDS:-81920}
+RECORD_SIZE=${RECORD_SIZE:-1024}
+TOTAL_SIZE=$(( N_RECORDS * RECORD_SIZE / ( 1024 * 1024 ) ))
+MSGPERSEC=${MSGPERSEC:-1000}
+
+timeout=$(( second * N_RECORDS / MSGPERSEC * 4 ))
+delete_project=""
+for ii in $( seq 1 $N_NAMESPACES ) ; do
+    ns=perfbasic$ii
+    if oc get project $ns 2>&1 | artifact_out ; then
+        artifact_log use existing project $ns
+    else
+        os::log::info Creating project $ns
+        oc adm new-project $ns --node-selector='' 2>&1 | artifact_out
+        os::cmd::try_until_success "oc get project $ns" "${timeout}" 2>&1 | artifact_out
+        delete_project="$delete_project $ns"
+    fi
+done
+
+jj=1
+message_uuid=$( openssl rand -hex 16 )
+starttime=$( date +%s )
+for ii in $( seq 1 $N_PODS ) ; do
+    if [ $jj -gt $N_NAMESPACES ] ; then
+        jj=1
+    fi
+    pod=perfbasic$ii
+    ns=perfbasic$jj
+    oc process -f $test_template \
+        -p POD_NAME=$pod \
+        -p NAMESPACE=$ns \
+        -p IMAGE=$testimage \
+        -p LOADER_PATH=$testroot/hack/logging-load-driver/loader \
+        -p INVOCID=$message_uuid \
+        -p MSGPERSEC=$MSGPERSEC \
+        -p PAYLOAD_SIZE=$RECORD_SIZE \
+        -p TOTAL_SIZE=$TOTAL_SIZE | oc create -f - 2>&1 | artifact_out
+    os::cmd::try_until_text "oc get -n $ns pods $pod" "^${pod}.* Running " "${timeout}"
+    jj=$( expr $jj + 1 )
+done
+
+jj=1
+for ii in $( seq 1 $N_PODS ) ; do
+    if [ $jj -gt $N_NAMESPACES ] ; then
+        jj=1
+    fi
+    pod=perfbasic$ii
+    ns=perfbasic$jj
+
+    es_rec_count() {
+        local cnt=$( curl_es $es_svc /project.$ns.*/_count?q=kubernetes.pod_name:$pod | get_count_from_json ) || :
+        test ${cnt:-0} -ge $N_RECORDS
+    }
+    os::cmd::try_until_success es_rec_count "${timeout}"
+done
+
+rc=0
+jj=1
+for ii in $( seq 1 $N_PODS ) ; do
+    if [ $jj -gt $N_NAMESPACES ] ; then
+        jj=1
+    fi
+    pod=perfbasic$ii
+    ns=perfbasic$jj
+    searchout=$ARTIFACT_DIR/search_out.json
+    curl_es_scroll $es_svc /project.$ns.*/_search?q=kubernetes.pod_name:${pod}\&sort=@timestamp:asc\&size=5000 > $searchout
+    verifyin=$ARTIFACT_DIR/verify-in.txt
+    cat $searchout | jq -r .hits.hits[]._source.message | sort -n > $verifyin
+    verifyout=$ARTIFACT_DIR/verify-out.txt
+    $OS_O_A_L_DIR/hack/logging-load-driver/verify-loader --report-interval=0 $verifyin > $verifyout 2>&1 || :
+    verifyrecs=$( awk '/^+++ verify-loader/ {found=1; next;}; found == 1 {print $2; exit}' $verifyout )
+    verifyskips=$( awk '/^+++ verify-loader/ {found=1; next;}; found == 1 {print $3; exit}' $verifyout )
+    verifydups=$( awk '/^+++ verify-loader/ {found=1; next;}; found == 1 {print $4; exit}' $verifyout )
+    localrc=0
+    if [ $verifyrecs -lt $N_RECORDS ] ; then
+        rc=1
+        localrc=1
+        os::log::error Expected $N_RECORDS or more but found $verifyrecs
+    fi
+    if [ $verifyskips -gt 0 ] ; then
+        rc=1
+        localrc=1
+        os::log::error $verifyskips records were skipped
+    fi
+    if [ $verifydups -gt 0 ] ; then
+        rc=1
+        localrc=1
+        os::log::error $verifydups records were duplicated
+    fi
+    if [ $localrc = 0 ] ; then
+        os::log::info Success - found $verifyrecs log records - no skips, no duplicates
+    fi
+done
+
+exit $rc


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1739558
imfile: followrename - continue to follow renamed files

Some applications do rotation by renaming the file, then continuing to
write to it for a short time, before recreating the original file. See
IMFILE for the gory details.

Introduce a new imfile parameter `followrename` (boolean) to handle this
case.  If this parameter is set, when inotify detects a rename event
(IN_MOVED_FROM), it will keep reading from the file until it sees that a
new file has been created with the same name.  It will then create a new
state file with state saved from the old state file e.g. prevLineSegment,
prevMsgSegment, and unlink the old file from the active list. the
moved_from file from the active list, and create a new active list entry
for the moved_to file, preserving the state file from the moved_from file. 
This also does some code refactoring in order to reuse some of the
functions for adding a new act_obj for the renamed file. Use
STREAMTYPE_FILE_SINGLE for monitored files instead of 
STREAMTYPE_FILE_MONITOR so that the stream module won't attempt to reopen
the file if it detects the filename has a different inode number.

Enabling valgrind testing on imfile revealed a memory leak which is fixed
in this PR.

Changed some "ignored" error messages to use LOG_INFO - if they are really
not that serious, they should not be printed by default.

Fixed some spelling errors.

(cherry picked from commit 678b7dc4fb9a74309781f260bb8ef8134ee3e6d2)

merge in latest rsyslog 8.1.z

Add a performance test
that runs a pod using logging-load-driver to write and verify logs for
records per second, skipped records, and duplicate records.