### PR TITLE
Bug 1751339: Drop rsyslog support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build-images:
 .PHONY: build-images
 
 test:
-	EXCLUDE_SUITE="upgrade" hack/testing/entrypoint.sh
+	EXCLUDE_SUITE="upgrade|zzz-rsyslog" hack/testing/entrypoint.sh
 .PHONY: test
 
 test-upgrade:


### PR DESCRIPTION
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1751339

blocks https://github.com/openshift/cluster-logging-operator/pull/243