### PR TITLE
bug 1752162: Drop rsyslog support from 4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build-images:
 .PHONY: build-images
 
 test:
-	EXCLUDE_SUITE="upgrade" hack/testing/entrypoint.sh
+	EXCLUDE_SUITE="upgrade|zzz-rsyslog" hack/testing/entrypoint.sh
 .PHONY: test
 
 test-upgrade:


### PR DESCRIPTION
We never supported rsyslog in 4.1, and it causes test flakes trying
to merge 4.1 PRs.  Would rather just drop it.