### PR TITLE
Bug 1746377: Seed index patterns based on match to existing indices

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -13,7 +13,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     INSTANCE_RAM=512G \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.16.0-redhat-1 \
+    OSE_ES_VER=5.6.16.1-redhat-1 \
     PROMETHEUS_EXPORTER_VER=5.6.16.0-redhat-1 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     container=oci
 
-ARG OSE_ES_VER=5.6.16.0-redhat-1
+ARG OSE_ES_VER=5.6.16.1-redhat-1
 ARG OSE_ES_URL
 ARG PROMETHEUS_EXPORTER_VER=5.6.16.0-redhat-1
 ARG PROMETHEUS_EXPORTER_URL

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -14,7 +14,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_VER=1.8.0 \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.16.0 \
+    OSE_ES_VER=5.6.16.1 \
     PROMETHEUS_EXPORTER_VER=5.6.16.0 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     RELEASE_STREAM=origin
 
-ARG OSE_ES_VER=5.6.16.0
+ARG OSE_ES_VER=5.6.16.1
 ARG SG_VER=5.6.16-19.3
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746377 by consuming openshift-elasticsearch-plugin-5.6.16.1

Blocked by https://github.com/fabric8io/openshift-elasticsearch-plugin/pull/188/