### PR TITLE
curator/Dockerfile: allow latest python-elasticsearch

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -23,7 +23,7 @@ RUN if [ -n "${LOCAL_REPO}" ] ; then \
     fi
 
 RUN yum install -y --setopt=skip_missing_names_on_install=False --setopt=tsflags=nodocs \
-        elastic-curator-${CURATOR_VER} python2-ruamel-yaml "python-elasticsearch < 5.5" \
+        elastic-curator-${CURATOR_VER} python2-ruamel-yaml python-elasticsearch \
  && yum clean all
 
 COPY run.sh lib/oalconverter/* ${HOME}/


### PR DESCRIPTION
I rebuilt the downstream with a bumped epoch, hoping that it will fix our grading problem.
The version ceiling excludes it, though. We can just remove that now.