### PR TITLE
Bug 1753936: fluentd couldn't forward logs to rsyslog out:syslog: inv…

### DIFF
--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -85,7 +85,7 @@ module Fluent
               begin
                 @packet.facility = Integer(record['systemd']['u']['SYSLOG_FACILITY'])
               rescue
-                log.warn "out:syslog: invalid facility value #{record['systemd']['u']['SYSLOG_FACILITY']}; reset to default #{@facility}"
+                log.debug "out:syslog: invalid facility value #{record['systemd']['u']['SYSLOG_FACILITY']}; reset to default #{@facility}"
                 @packet.facility = @facility
               end
             end

--- a/fluentd/out_syslog_buffered.rb
+++ b/fluentd/out_syslog_buffered.rb
@@ -110,7 +110,7 @@ module Fluent
             begin
               @packet.facility = Integer(record['systemd']['u']['SYSLOG_FACILITY'])
             rescue
-              log.warn "out:syslog: invalid facility value #{record['systemd']['u']['SYSLOG_FACILITY']}; reset to default #{@facility}"
+              log.debug "out:syslog: invalid facility value #{record['systemd']['u']['SYSLOG_FACILITY']}; reset to default #{@facility}"
               @packet.facility = @facility
             end
           end

--- a/hack/testing/entrypoint.sh
+++ b/hack/testing/entrypoint.sh
@@ -85,7 +85,7 @@ if oc -n ${LOGGING_NS} get clusterlogging instance > /dev/null 2>&1 ; then
     # cannot mount file inside pod into another pod - rewrite to use a configmap or secret
     # test-viaq-data-model
     expected_failures=(
-        test-out_rawtcp test-remote-syslog test-zzz-duplicate-entries
+        test-out_rawtcp test-zzz-duplicate-entries
         test-read-throttling test-viaq-data-model test-zzzz-bulk-rejection
     )
 else

--- a/hack/testing/templates/remote-syslog-listener-template.yaml
+++ b/hack/testing/templates/remote-syslog-listener-template.yaml
@@ -1,0 +1,60 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: remote-syslog-listener-template
+  annotations:
+    description: "For creating the remote-syslog-listener pod"
+objects:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    name: remote-syslog-listener
+    namespace: ${NAMESPACE}
+  spec:
+    restartPolicy: Never
+    terminationGracePeriodSeconds: 0
+    containers:
+    - name: remote-syslog-listener
+      image: ${IMAGE}
+      imagePullPolicy: Always
+      env:
+      ports:
+      - containerPort: 24285
+        name: syslogudp
+        protocol: UDP
+      - containerPort: 24286
+        name: syslogtcp
+        protocol: TCP
+      command:
+      - bash
+      - -c
+      - |-
+        cat > /etc/fluent/fluent.conf <<EOF
+        <source>
+          @type syslog
+          port 24285
+          bind 0.0.0.0
+          protocol_type udp
+          tag inputudp
+        </source>
+        <source>
+          @type syslog
+          port 24286
+          bind 0.0.0.0
+          protocol_type tcp
+          tag inputtcp
+        </source>
+        <match **>
+          @type stdout
+        </match>
+        EOF
+        scl enable rh-ruby25 -- fluentd -vv -c /etc/fluent/fluent.conf
+parameters:
+- description: Namespace name to create pod in
+  value: openshift-logging
+  name: NAMESPACE
+- description: test image to use
+  value: fluentd:latest
+  name: IMAGE
+labels:
+  test: "true"


### PR DESCRIPTION
…alid facility value DEVICE

https://bugzilla.redhat.com/show_bug.cgi?id=1753936
Do not print the error at the `warn` level - use `debug` instead
This also re-enables the remote-syslog CI test, by rewriting to
use a custom fluentd pod syslog listener instead of using rsyslog
on the node.  It also gets rid of the mux stuff from the test.