### PR TITLE
Bug 1757180: ACL documents are _always_ reseeded

### DIFF
--- a/elasticsearch/init/0010-seed-acl
+++ b/elasticsearch/init/0010-seed-acl
@@ -17,16 +17,16 @@
 
 source "logging"
 
-force=${FORCE_SEED_ACL:-''}
+force=${FORCE_SEED_ACL:-"true"}
 config=${ES_CONF}/elasticsearch.yml
 index=$(python -c "import yaml; print yaml.load(open('${config}'))['searchguard']['config_index_name']" | xargs -i sh -c "echo {}")
 
-if [ -n "${force}" ] ; then
+if [ "${force}" = "false" ] ; then
   docs=(roles rolesmapping actiongroups internalusers config)
   for d in $docs; do
-    resp=$(es_util --query=${index}/$d/0 -w %{response_code} | cut -d '}' -f2)
+    resp=$(es_util --query=${index}/$d/0 -w %{response_code} --output /dev/null)
     #re-seed acls if any of them are missing
-    if [ "${resp}" != "200"]; then
+    if [ "${resp}" != "200" ]; then
       info "Missing ACL document '${d}'. Reseeding all ACL documents"
       force="true"
       break
@@ -36,6 +36,6 @@ else
   info "Forcing the seeding of ACL documents"
 fi
 
-if [ -z "${force}" ] ; then
+if [ "${force}" = "true" ] ; then
   es_seed_acl
 fi


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1757180
Fix logic/syntax errors in script.
Use curl `--output /dev/null` to throw away the output we don't
care about rather than trying to parse it with `cut`.

Cause: There were some logic errors and a bash syntax error in
the seed acls script.

Consequence: ACL documents were always being reseeded.

Fix: Correct the logic and syntax errors in the script.  Use
curl `--output /dev/null` to throw away the output we don't
care about rather than trying to parse it with `cut`.

Result: ACL documents are only reseeded if they need to be, or if
user specifies `FORCE_SEED_ACL=true`.