### PR TITLE
Pin prometheus-client to 0.9.0

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -47,6 +47,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
      'elasticsearch-transport:5.0.5' \
      'elasticsearch-api:5.0.5' \
      'elasticsearch:5.0.5' \
+     'prometheus-client:0.9.0' \
       fluentd:${FLUENTD_VERSION} \
      'fluent-plugin-elasticsearch:1.17.2' \
      'fluent-plugin-record-modifier:0.6.2' \


### PR DESCRIPTION
We should pin prometheus-client to 0.9.0, because 0.10.0 requires ruby 2.3. CentOS ships with ruby 2.0.
Diff between 0.9.0 and 0.10.0: https://github.com/prometheus/client_ruby/compare/v0.9.0...v0.10.0
With prometheus-client in version 0.10.0 I get following error.
```
2019-10-08 13:19:09 +0200 [info]: reading config file path="/etc/fluent/fluent.conf"
2019-10-08 13:19:10 +0200 [warn]: 'block' action stops input process until the buffer full is resolved. Check your pipeline this action is fit or not
2019-10-08 13:19:10 +0200 [warn]: 'block' action stops input process until the buffer full is resolved. Check your pipeline this action is fit or not
/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require': /opt/app-root/src/gems/prometheus-client-0.10.0/lib/prometheus/client/registry.rb:40: syntax error, unexpected ',' (SyntaxError)
...  def counter(name, docstring:, labels: [], preset_labels: {...
...                               ^
/opt/app-root/src/gems/prometheus-client-0.10.0/lib/prometheus/client/registry.rb:48: syntax error, unexpected ','
...  def summary(name, docstring:, labels: [], preset_labels: {...
...                               ^
/opt/app-root/src/gems/prometheus-client-0.10.0/lib/prometheus/client/registry.rb:56: syntax error, unexpected ','
...    def gauge(name, docstring:, labels: [], preset_labels: {...
...                               ^
/opt/app-root/src/gems/prometheus-client-0.10.0/lib/prometheus/client/registry.rb:64: syntax error, unexpected ','
      def histogram(name, docstring:, labels: [], preset_labels: {},
                                     ^
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/app-root/src/gems/prometheus-client-0.10.0/lib/prometheus/client.rb:3:in `<top (required)>'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:126:in `require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:126:in `require'
        from /opt/app-root/src/gems/fluent-plugin-prometheus-0.4.0/lib/fluent/plugin/prometheus.rb:1:in `<top (required)>'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:135:in `require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:144:in `require'
        from /opt/app-root/src/gems/fluent-plugin-prometheus-0.4.0/lib/fluent/plugin/in_prometheus.rb:2:in `<top (required)>'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/plugin.rb:173:in `block in try_load_plugin'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/plugin.rb:170:in `each'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/plugin.rb:170:in `try_load_plugin'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/plugin.rb:130:in `new_impl'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/plugin.rb:55:in `new_input'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:154:in `add_source'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:95:in `block in configure'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:92:in `each'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:92:in `configure'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/engine.rb:129:in `configure'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/engine.rb:103:in `run_configure'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:498:in `run_configure'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:183:in `block in start'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:375:in `call'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:375:in `main_process'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:179:in `start'
        from /opt/app-root/src/gems/fluentd-0.12.43/lib/fluent/command/fluentd.rb:173:in `<top (required)>'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /opt/app-root/src/gems/fluentd-0.12.43/bin/fluentd:8:in `<top (required)>'
        from /opt/app-root/src/bin/fluentd:23:in `load'
        from /opt/app-root/src/bin/fluentd:23:in `<main>'
```