### PR TITLE
Bug 1756920: fluentd pods doesn't process kubernetes events

### DIFF
--- a/fluentd/configs.d/openshift/filter-viaq-data-model.conf
+++ b/fluentd/configs.d/openshift/filter-viaq-data-model.conf
@@ -35,6 +35,12 @@
     remove_keys "#{ENV['K8S_FILTER_REMOVE_KEYS'] || 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'}"
   </formatter>
   <formatter>
+    tag "kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-**"
+    type k8s_json_file
+    remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
+    process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'true'}"
+  </formatter>
+  <formatter>
     tag "kubernetes.var.log.containers**"
     type k8s_json_file
     remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME

--- a/fluentd/vendored_gem_src/fluent-plugin-viaq_data_model/fluent-plugin-viaq_data_model.gemspec
+++ b/fluentd/vendored_gem_src/fluent-plugin-viaq_data_model/fluent-plugin-viaq_data_model.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-viaq_data_model"
-  gem.version       = "0.0.20"
+  gem.version       = "0.0.21"
   gem.authors       = ["Rich Megginson"]
   gem.email         = ["rmeggins@redhat.com"]
   gem.description   = %q{Filter plugin to ensure data is in the ViaQ common data model}

--- a/fluentd/vendored_gem_src/fluent-plugin-viaq_data_model/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
+++ b/fluentd/vendored_gem_src/fluent-plugin-viaq_data_model/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
@@ -68,7 +68,7 @@ module ViaqDataModelFilterSystemd
 
   JOURNAL_TIME_FIELDS = ['_SOURCE_REALTIME_TIMESTAMP', '__REALTIME_TIMESTAMP']
 
-  def process_journal_fields(tag, time, record, fmtr_type)
+  def process_journal_fields(tag, time, record, fmtr)
     systemd_t = {}
     JOURNAL_FIELD_MAP_SYSTEMD_T.each do |jkey, key|
       if record.key?(jkey)
@@ -104,7 +104,7 @@ module ViaqDataModelFilterSystemd
         break
       end
     end
-    case fmtr_type
+    case fmtr.type
     when :sys_journal
       record['message'] = record['MESSAGE']
       if record['_HOSTNAME'].eql?('localhost') && @docker_hostname
@@ -136,7 +136,7 @@ module ViaqDataModelFilterSystemd
       else
         record['hostname'] = record['_HOSTNAME']
       end
-      transform_eventrouter(tag, record)
+      transform_eventrouter(tag, record, fmtr)
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1756920
Use the new feature of the viaq plugin to only do the
event transform for records with a specific tag.