### PR TITLE
use docker login instead of podman login

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -182,7 +182,7 @@ function login_to_registry() {
       username=kubeadmin
     fi
   fi
-  podman login --tls-verify=false -u "$username" -p "$token" "$1" > /dev/null
+  docker login -u "$username" -p "$token" "$1" > /dev/null
 }
 
 function push_image() {


### PR DESCRIPTION
apparently we can no longer use `podman login` to login to the
internal OpenShift registry - we have to use `docker login`.
@nhosoi @jcantrill @ewolinetz ptal