### PR TITLE
Bug 1765646: Fluentd single pod logging performance regression 3.x

### DIFF
--- a/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
+++ b/fluentd/lib/generate_throttle_configs/lib/generate_throttle_configs.rb
@@ -64,6 +64,14 @@ def get_all_throttle_files()
   return Dir.glob('/var/log/es-container-*.log.pos')
 end
 
+def get_refresh_interval()
+  return ENV['CONTAINER_LOGS_REFRESH_INTERVAL'] || '5'
+end
+
+def get_rotate_wait()
+  return ENV['CONTAINER_LOGS_ROTATE_WAIT'] || '5'
+end
+
 def move_pos_file_project_entry(source_file, dest_file, project, log)
   log.debug "moving project #{project} pos entry from #{source_file} to #{dest_file}"
   if File.file?(source_file)
@@ -125,6 +133,8 @@ def seed_file(file_name, project, log)
   @id #{project}-input
   path #{path}
   pos_file #{pos_file}
+  refresh_interval #{get_refresh_interval}
+  rotate_wait #{get_rotate_wait}
     CONF
   }
 
@@ -210,6 +220,8 @@ def create_default_docker(input_conf_file, excluded, log, options)
   @id docker-input
   path "#{cont_logs_path}"
   pos_file "#{cont_pos_file}"
+  refresh_interval #{get_refresh_interval}
+  rotate_wait #{get_rotate_wait}
   exclude_path #{excluded}
   CONF
   }

--- a/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
+++ b/fluentd/lib/generate_throttle_configs/test/generate_throttle_configs_test.rb
@@ -27,6 +27,8 @@ describe 'generate_throttle_configs' do
   @id docker-input
   path "/var/log/containers/*.log"
   pos_file "/var/log/es-containers.log.pos"
+  refresh_interval 5
+  rotate_wait 5
   exclude_path []
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
@@ -46,6 +48,8 @@ describe 'generate_throttle_configs' do
   @id docker-input
   path "/var/log/containers/*.log"
   pos_file "/var/log/es-containers.log.pos"
+  refresh_interval 5
+  rotate_wait 5
   exclude_path []
   time_format %Y-%m-%dT%H:%M:%S.%N%:z
   tag kubernetes.*
@@ -78,6 +82,8 @@ describe 'generate_throttle_configs' do
   @id docker-input
   path "/var/log/containers/*.log"
   pos_file "/var/log/es-containers.log.pos"
+  refresh_interval 5
+  rotate_wait 5
   exclude_path []
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
@@ -116,6 +122,8 @@ describe 'generate_throttle_configs' do
   @id docker-input
   path "/tmp/foo/*.logs"
   pos_file "/tmp/foo/test.logs.pos"
+  refresh_interval 5
+  rotate_wait 5
   exclude_path []
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
@@ -171,6 +179,8 @@ secondproject:
   @id docker-input
   path \"/var/log/containers/*.log\"
   pos_file \"#{@pos_file}\"
+  refresh_interval 5
+  rotate_wait 5
   exclude_path [\"#{cont_log_dir}/*_firstproject_*.log\", \"#{cont_log_dir}/*_secondproject_*.log\"]
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
@@ -191,6 +201,8 @@ secondproject:
   @id #{project}-input
   path /tmp/*_#{project}_*.log
   pos_file #{pos_file}
+  refresh_interval 5
+  rotate_wait 5
   read_lines_limit #{limit}
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
@@ -214,6 +226,8 @@ secondproject:
   @id docker-input
   path \"/var/log/containers/*.log\"
   pos_file \"#{@pos_file}\"
+  refresh_interval 5
+  rotate_wait 5
   exclude_path [\"#{cont_log_dir}/*_firstproject_*.log\", \"#{cont_log_dir}/*_secondproject_*.log\"]
   time_format %Y-%m-%dT%H:%M:%S.%N%:z
   tag kubernetes.*
@@ -247,6 +261,8 @@ secondproject:
   @id #{project}-input
   path /tmp/*_#{project}_*.log
   pos_file #{pos_file}
+  refresh_interval 5
+  rotate_wait 5
   read_lines_limit #{limit}
   time_format %Y-%m-%dT%H:%M:%S.%N%:z
   tag kubernetes.*
@@ -282,6 +298,8 @@ secondproject:
   @id docker-input
   path \"/var/log/containers/*.log\"
   pos_file \"#{@pos_file}\"
+  refresh_interval 5
+  rotate_wait 5
   exclude_path [\"#{cont_log_dir}/*_firstproject_*.log\", \"#{cont_log_dir}/*_secondproject_*.log\"]
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*
@@ -314,6 +332,8 @@ secondproject:
   @id #{project}-input
   path /tmp/*_#{project}_*.log
   pos_file #{pos_file}
+  refresh_interval 5
+  rotate_wait 5
   read_lines_limit #{limit}
   time_format %Y-%m-%dT%H:%M:%S.%N%Z
   tag kubernetes.*


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1765646
Allows setting the fluentd in_tail plugin
`refresh_interval` parameter via a new environment variable
`CONTAINER_LOGS_REFRESH_INTERVAL`.  The new default value is 5 (seconds).
The old default value was 60 seconds, which could lead to missing
rotated files.
For example, to use a value of 60 seconds:
`oc set env ds/logging-fluentd CONTAINER_LOGS_REFRESH_INTERVAL=60`
This also adds support for setting the `rotate_wait` parameter via
a new environment variable `CONTAINER_LOGS_ROTATE_WAIT`.  The new
default value is `5` which helps when container logs are rotated
quickly.