### PR TITLE
allow specifying the installer url

### DIFF
--- a/hack/deploy-openshift-cluster.sh
+++ b/hack/deploy-openshift-cluster.sh
@@ -39,6 +39,13 @@ fi
 
 if [ -n "${OPENSHIFT_INSTALLER:-}" -a -x "${OPENSHIFT_INSTALLER:-}" ] ; then
     INSTALLER=$OPENSHIFT_INSTALLER
+elif [ -n "${OPENSHIFT_INSTALLER_URL:-}" ] ; then
+    INSTALLER=$installdir/openshift-install
+    pushd $WORKDIR > /dev/null
+    curl -s -L -o openshift-installer.tar.gz "$OPENSHIFT_INSTALLER_URL"
+    tar xfz openshift-installer.tar.gz
+    mv openshift-install $INSTALLER
+    popd > /dev/null
 elif [ -n "${OPENSHIFT_INSTALL_VERSION:-}" ] ; then
     # download and use specific version
     INSTALLER=$installdir/openshift-install


### PR DESCRIPTION
Add a new env. var. OPENSHIFT_INSTALLER_URL

Use this to specify the URL of the installer.  For example, if you
wanted to use the latest 4.4 candidate installer (as of today),
then use something like
```
OPENSHIFT_INSTALLER_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.4.0-0.nightly-2019-11-19-060809/openshift-install-linux-4.4.0-0.nightly-2019-11-19-060809.tar.gz" hack/get-cluster-run-tests.sh
```