### PR TITLE
LOG-535 - Add IPv6 support to fluentd plugins

### DIFF
--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -33,7 +33,8 @@ module Fluent
       if not conf['remote_syslog']
         raise Fluent::ConfigError.new("remote syslog required")
       end
-      @socket = UDPSocket.new
+      addrfamily = IPAddr.new(IPSocket.getaddress(@remote_syslog)).ipv4? ? ::Socket::AF_INET : ::Socket::AF_INET6
+      @socket = UDPSocket.new(addrfamily)
       @packet = SyslogProtocol::Packet.new
       if remove_tag_prefix = conf['remove_tag_prefix']
           @remove_tag_prefix = Regexp.new('^' + Regexp.escape(remove_tag_prefix))


### PR DESCRIPTION
fluentd/out_syslog.rb (remote syslog plugin):
To create a UDPSocket for an address, it needs to check if the address
is in the INET or INET6 address family and specify in the creation.