### PR TITLE
Upgrade model to 2020.01.23.0

### DIFF
--- a/docs/com.redhat.viaq-openshift-operations.asciidoc
+++ b/docs/com.redhat.viaq-openshift-operations.asciidoc
@@ -207,10 +207,15 @@ will give you the exact document corresponding to the record.
 
 type: keyword
 
-example: project.my-cool-project-in-lab04.748e92c2-70d7-11e9-b387-000d3af2d83b.2019.05.09
+example: container.app-write
 
-Index name in which this message will be stored within the Elasticsearch.
-The value of this field is generated based on the source of the message. 
+For Elasticsearch 6.x and later this is a name of a write index alias. The value depends on a log type
+of this message. Detailed documentation is found at
+https://github.com/openshift/enhancements/blob/master/enhancements/cluster-logging/cluster-logging-es-rollover-data-design.md#data-model
+
+For Elasticsearch 5.x and earlier an index name in which this message will be stored within the Elasticsearch.
+The value of this field is generated based on the source of the message. Example of the value
+is 'project.my-cool-project-in-lab04.748e92c2-70d7-11e9-b387-000d3af2d83b.2019.05.09'.
 
 
 

--- a/docs/com.redhat.viaq-openshift-project.asciidoc
+++ b/docs/com.redhat.viaq-openshift-project.asciidoc
@@ -207,10 +207,15 @@ will give you the exact document corresponding to the record.
 
 type: keyword
 
-example: project.my-cool-project-in-lab04.748e92c2-70d7-11e9-b387-000d3af2d83b.2019.05.09
+example: container.app-write
 
-Index name in which this message will be stored within the Elasticsearch.
-The value of this field is generated based on the source of the message. 
+For Elasticsearch 6.x and later this is a name of a write index alias. The value depends on a log type
+of this message. Detailed documentation is found at
+https://github.com/openshift/enhancements/blob/master/enhancements/cluster-logging/cluster-logging-es-rollover-data-design.md#data-model
+
+For Elasticsearch 5.x and earlier an index name in which this message will be stored within the Elasticsearch.
+The value of this field is generated based on the source of the message. Example of the value
+is 'project.my-cool-project-in-lab04.748e92c2-70d7-11e9-b387-000d3af2d83b.2019.05.09'.
 
 
 

--- a/docs/org.ovirt.viaq-collectd.asciidoc
+++ b/docs/org.ovirt.viaq-collectd.asciidoc
@@ -202,10 +202,15 @@ will give you the exact document corresponding to the record.
 
 type: keyword
 
-example: project.my-cool-project-in-lab04.748e92c2-70d7-11e9-b387-000d3af2d83b.2019.05.09
+example: container.app-write
 
-Index name in which this message will be stored within the Elasticsearch.
-The value of this field is generated based on the source of the message. 
+For Elasticsearch 6.x and later this is a name of a write index alias. The value depends on a log type
+of this message. Detailed documentation is found at
+https://github.com/openshift/enhancements/blob/master/enhancements/cluster-logging/cluster-logging-es-rollover-data-design.md#data-model
+
+For Elasticsearch 5.x and earlier an index name in which this message will be stored within the Elasticsearch.
+The value of this field is generated based on the source of the message. Example of the value
+is 'project.my-cool-project-in-lab04.748e92c2-70d7-11e9-b387-000d3af2d83b.2019.05.09'.
 
 
 

--- a/elasticsearch/index_templates/com.redhat.viaq-openshift-operations.template.json
+++ b/elasticsearch/index_templates/com.redhat.viaq-openshift-operations.template.json
@@ -2,10 +2,14 @@
   "aliases": {
     ".all": {}
   },
+  "index_patterns": [
+    "infra-*",
+    "audit.infra-*"
+  ],
   "mappings": {
-    "_default_": {
+    "_doc": {
       "_meta": {
-        "version": "2019.12.16.0"
+        "version": "2020.01.23.0"
       },
       "date_detection": false,
       "dynamic_templates": [
@@ -970,6 +974,5 @@
   "order": 10,
   "settings": {
     "index.refresh_interval": "5s"
-  },
-  "template": ".operations.*"
+  }
 }

--- a/elasticsearch/index_templates/com.redhat.viaq-openshift-project.template.json
+++ b/elasticsearch/index_templates/com.redhat.viaq-openshift-project.template.json
@@ -2,10 +2,11 @@
   "aliases": {
     ".all": {}
   },
+  "index_patterns": "app-*",
   "mappings": {
-    "_default_": {
+    "_doc": {
       "_meta": {
-        "version": "2019.12.16.0"
+        "version": "2020.01.23.0"
       },
       "date_detection": false,
       "dynamic_templates": [
@@ -970,6 +971,5 @@
   "order": 10,
   "settings": {
     "index.refresh_interval": "5s"
-  },
-  "template": "project.*"
+  }
 }

--- a/elasticsearch/index_templates/org.ovirt.viaq-collectd.template.json
+++ b/elasticsearch/index_templates/org.ovirt.viaq-collectd.template.json
@@ -2,13 +2,14 @@
   "aliases": {
     ".all": {}
   },
+  "index_patterns": "project.ovirt-metrics-*",
   "mappings": {
-    "_default_": {
+    "_doc": {
       "_all": {
         "enabled": false
       },
       "_meta": {
-        "version": "2019.12.16.0"
+        "version": "2020.01.23.0"
       },
       "_source": {
         "enabled": false
@@ -1269,6 +1270,5 @@
   "order": 20,
   "settings": {
     "index.refresh_interval": "5s"
-  },
-  "template": "project.ovirt-metrics-*"
+  }
 }


### PR DESCRIPTION
This brings in [common data model 0.0.22](https://github.com/ViaQ/elasticsearch-templates/releases/tag/0.0.22).