### PR TITLE
Add fluent-plugin-remote_syslog

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -77,7 +77,7 @@ COPY --from=builder /contents /contents
 
 RUN mkdir -p /etc/fluent/plugin
 ADD configs.d/ /etc/fluent/configs.d/
-ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb /etc/fluent/plugin/
+ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb out_remote_syslog.rb /etc/fluent/plugin/
 ADD run.sh generate_syslog_config.rb ${HOME}/
 ADD lib/generate_throttle_configs/lib/*.rb ${HOME}/
 ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -40,7 +40,7 @@ RUN cd ${HOME}/vendored_gem_src/ && ./install-gems.sh && cd / && rm -rf ${HOME}/
 
 RUN mkdir -p /etc/fluent/plugin
 ADD configs.d/ /etc/fluent/configs.d/
-ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb /etc/fluent/plugin/
+ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb out_remote_syslog.rb /etc/fluent/plugin/
 ADD run.sh generate_syslog_config.rb ${HOME}/
 ADD lib/generate_throttle_configs/lib/*.rb ${HOME}/
 ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/

--- a/fluentd/generate_syslog_config.rb
+++ b/fluentd/generate_syslog_config.rb
@@ -14,7 +14,7 @@ def init_environment_vars()
     # [2] = default value, if any
     # [3] = allowed values, if any
     vars = [
-      ['HOST', 'remote_syslog', nil, nil],
+      ['HOST', 'host', nil, nil],
       ['PORT', 'port', "514", nil],
       ['HOSTNAME', 'hostname', ENV['HOSTNAME'], nil],
       ['REMOVE_TAG_PREFIX', 'remove_tag_prefix', nil, nil],
@@ -24,7 +24,7 @@ def init_environment_vars()
       ['USE_RECORD', 'use_record', nil, nil],
       ['PAYLOAD_KEY', 'payload_key', nil, nil],
       # TYPE must be vars[-1]
-      ['TYPE', 'type', "syslog_buffered", ['syslog_buffered', 'syslog']]
+      ['TYPE', 'type', 'remote_syslog', nil]
     ]
     t = k.dup
     t.slice! group

--- a/fluentd/out_remote_syslog.rb
+++ b/fluentd/out_remote_syslog.rb
@@ -1,0 +1,154 @@
+require "remote_syslog_sender"
+
+module Fluent
+  module Plugin
+    class RemoteSyslogOutput < Output
+      Fluent::Plugin.register_output("remote_syslog", self)
+
+      helpers :formatter, :inject
+
+      config_param :hostname, :string, :default => ""
+
+      config_param :host, :string, :default => nil
+      config_param :port, :integer, :default => 514
+      config_param :host_with_port, :string, :default => nil
+
+      config_param :facility, :string, :default => "user"
+      config_param :severity, :string, :default => "notice"
+      config_param :program, :string, :default => "fluentd"
+
+      config_param :protocol, :enum, list: [:udp, :tcp], :default => :udp
+      config_param :tls, :bool, :default => false
+      config_param :ca_file, :string, :default => nil
+      config_param :verify_mode, :integer, default: nil
+      config_param :packet_size, :size, default: 1024
+      config_param :timeout, :time, default: nil
+      config_param :timeout_exception, :bool, default: false
+
+      config_param :keep_alive, :bool, :default => false
+      config_param :keep_alive_idle, :integer, :default => nil
+      config_param :keep_alive_cnt, :integer, :default => nil
+      config_param :keep_alive_intvl, :integer, :default => nil
+
+      config_section :buffer do
+        config_set_default :flush_mode, :interval
+        config_set_default :flush_interval, 5
+        config_set_default :flush_thread_interval, 0.5
+        config_set_default :flush_thread_burst_interval, 0.5
+      end
+
+      config_section :format do
+        config_set_default :@type, 'ltsv'
+      end
+
+      def initialize
+        super
+      end
+
+      def configure(conf)
+        super
+        if @host.nil? && @host_with_port.nil?
+          raise ConfigError, "host or host_with_port is required"
+        end
+
+        @formatter = formatter_create
+        unless @formatter.formatter_type == :text_per_line
+          raise ConfigError, "formatter_type must be text_per_line formatter"
+        end
+
+        validate_target = "host=#{@host}/host_with_port=#{@host_with_port}/hostname=#{@hostname}/facility=#{@facility}/severity=#{@severity}/program=#{@program}"
+        placeholder_validate!(:remote_syslog, validate_target)
+        @senders = []
+      end
+
+      def multi_workers_ready?
+        true
+      end
+
+      def close
+        super
+        @senders.each { |s| s.close if s }
+        @senders.clear
+      end
+
+      def format(tag, time, record)
+        r = inject_values_to_record(tag, time, record)
+        @formatter.format(tag, time, r)
+      end
+
+      def write(chunk)
+        return if chunk.empty?
+
+        host = extract_placeholders(@host, chunk.metadata)
+        port = @port
+
+        if @host_with_port
+          host, port = extract_placeholders(@host_with_port, chunk.metadata).split(":")
+        end
+
+        host_with_port = "#{host}:#{port}"
+
+        Thread.current[host_with_port] ||= create_sender(host, port)
+        sender = Thread.current[host_with_port]
+
+        facility = extract_placeholders(@facility, chunk.metadata)
+        severity = extract_placeholders(@severity, chunk.metadata)
+        program = extract_placeholders(@program, chunk.metadata)
+        hostname = extract_placeholders(@hostname, chunk.metadata)
+
+        packet_options = {facility: facility, severity: severity, program: program}
+        packet_options[:hostname] = hostname unless hostname.empty?
+
+        begin
+          chunk.open do |io|
+            io.each_line do |msg|
+              sender.transmit(msg.chomp!, packet_options)
+            end
+          end
+        rescue
+          if Thread.current[host_with_port]
+            Thread.current[host_with_port].close
+            @senders.delete(Thread.current[host_with_port])
+            Thread.current[host_with_port] = nil
+          end
+          raise
+        end
+      end
+
+      private
+
+      def create_sender(host, port)
+        if @protocol == :tcp
+          options = {
+            tls: @tls,
+            whinyerrors: true,
+            packet_size: @packet_size,
+            timeout: @timeout,
+            timeout_exception: @timeout_exception,
+            keep_alive: @keep_alive,
+            keep_alive_idle: @keep_alive_idle,
+            keep_alive_cnt: @keep_alive_cnt,
+            keep_alive_intvl: @keep_alive_intvl,
+            program: @program,
+          }
+          options[:ca_file] = @ca_file if @ca_file
+          options[:verify_mode] = @verify_mode if @verify_mode
+          sender = RemoteSyslogSender::TcpSender.new(
+            host,
+            port,
+            options
+          )
+        else
+          sender = RemoteSyslogSender::UdpSender.new(
+            host,
+            port,
+            whinyerrors: true,
+            program: @program,
+          )
+        end
+        @senders << sender
+        sender
+      end
+    end
+  end
+end

--- a/fluentd/out_remote_syslog.rb
+++ b/fluentd/out_remote_syslog.rb
@@ -56,7 +56,7 @@ module Fluent
           raise ConfigError, "formatter_type must be text_per_line formatter"
         end
 
-        validate_target = "host=#{@host}/host_with_port=#{@host_with_port}/hostname=#{@hostname}/facility=#{@facility}/severity=#{@severity}/program=#{@program}"
+        validate_target = "host=#{@host}/host_with_port=#{@host_with_port}/facility=#{@facility}/severity=#{@severity}/program=#{@program}"
         placeholder_validate!(:remote_syslog, validate_target)
         @senders = []
       end

--- a/fluentd/rh-manifest.txt
+++ b/fluentd/rh-manifest.txt
@@ -49,6 +49,7 @@ rubygem-recursive-open-struct 1.1.0 http://github.com/aetherknight/recursive-ope
 rubygem-rest-client 2.1.0 https://github.com/rest-client/rest-client
 rubygem-sigdump 0.2.4 https://github.com/frsyuki/sigdump
 rubygem-syslog_protocol 0.9.2 https://github.com/eric/syslog_protocol
+rubygem-remote_syslog_sender 1.2.1 https://github.com/reproio/remote_syslog_sender
 rubygem-systemd-journal 1.3.3 https://github.com/ledbettj/systemd-journal
 rubygem-tzinfo 2.0.0 https://tzinfo.github.io
 rubygem-tzinfo-data 1.2019.3 http://tzinfo.github.io

--- a/fluentd/vendored_gem_src/remote_syslog_sender/.gitignore
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/.gitignore
@@ -1,0 +1,3 @@
+Gemfile.lock
+.bundle
+pkg

--- a/fluentd/vendored_gem_src/remote_syslog_sender/Gemfile
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gemspec
+

--- a/fluentd/vendored_gem_src/remote_syslog_sender/LICENSE
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2017 joker1007
+Original Copyright (c) 2011 Eric Lindvall
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/fluentd/vendored_gem_src/remote_syslog_sender/README.md
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/README.md
@@ -1,0 +1,102 @@
+# Remote Syslog Sender
+
+This gem is syslog sender that is extracted from (papertrail/remote_syslog_logger)[https://github.com/papertrail/remote_syslog_logger]
+
+This can send message to remote syslog server via UDP, TCP, TCP+TLS.
+(Original does not support TCP, TCP+TLS protocol).
+
+## Installation
+
+The easiest way to install `remote_syslog_sender` is with Bundler. Add
+`remote_syslog_sender` to your `Gemfile`.
+
+If you are not using a `Gemfile`, run:
+
+    $ [sudo] gem install remote_syslog_sender
+
+
+## Usage
+
+```ruby
+sender = RemoteSyslogSender.new('syslog.domain.com', 514) # default protocol is UDP
+sender.transmit("message body")
+# or 
+sender.write("message body")
+
+
+## TCP
+sender = RemoteSyslogSender.new('syslog.domain.com', 514, protocol: :tcp)
+sender.transmit("message body")
+
+## TCP+TLS
+sender = RemoteSyslogSender.new('syslog.domain.com', 514, protocol: :tcp, tls: true, ca_file: "custom_ca.pem")
+sender.transmit("message body")
+```
+
+To point the logs to your local system, use `localhost` and ensure that
+the system's syslog daemon is bound to `127.0.0.1`.
+
+
+## Limitations
+
+If the specified host cannot be resolved, `syslog.domain.com` in the
+example under the usage section above, `remote_syslog_sender` will block
+for approximately 20 seconds before displaying an error.  This could
+result in the application failing to start or even stopping responding.
+
+Workarounds for this include:
+
+* use an IP address instead of a hostname.
+* put a hosts entry in `/etc/hosts` or equivalent, so that DNS is not
+actually consulted
+* instead of logging directly to the network, write to a file and
+transmit new entries with a standalone daemon like
+[remote_syslog](https://github.com/papertrail/remote_syslog),
+
+## Message length
+
+All log lines are truncated to a maximum of 1024 characters. This restriction
+comes from [RFC 3164 section 4.1][rfc-limit]:
+
+> The total length of the packet MUST be 1024 bytes or less.
+
+Additionally, the generally-accepted [MTU][] of the Internet is 1500 bytes, so
+regardless of the RFC, UDP syslog packets longer than 1500 bytes would not
+arrive. For details or to use TCP syslog for longer messages, see
+[help.papertrailapp.com][troubleshoot].
+
+[rfc-limit]: https://tools.ietf.org/html/rfc3164#section-4.1
+[MTU]: (https://en.wikipedia.org/wiki/Maximum_transmission_unit)
+[troubleshoot]: http://help.papertrailapp.com/kb/configuration/troubleshooting-remote-syslog-reachability/#message-length
+
+
+## Default program name
+
+By default, the `program` value is set to the name and ID of the invoking
+process. For example, `puma[12345]` or `rack[3456]`.
+
+The `program` value is used to populate the syslog "tag" field, must be 32
+or fewer characters. In a few cases, an artifact of how the app is launched
+may lead to a default `program` value longer than 32 characters. For example,
+the `thin` Web server may generate a default `program` value such
+as:
+
+    thin server (0.0.0.0:3001)[11179]
+
+If this occurs, the following exception will be raised when a
+`RemoteSyslogSender` is instantiated:
+
+    Tag must not be longer than 32 characters (ArgumentError)
+
+To remedy this, explicitly provide a `program` argument which is shorter than
+32 characters. See [Usage](#usage).
+
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/reproio/remote_syslog_sender.
+
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/fluentd/vendored_gem_src/remote_syslog_sender/Rakefile
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/Rakefile
@@ -1,0 +1,10 @@
+require "bundler/gem_tasks"
+
+require 'rake/testtask'
+Rake::TestTask.new(:test) do |test|
+  test.libs << 'lib' << 'test'
+  test.pattern = 'test/**/test_*.rb'
+  test.verbose = true
+end
+
+task :default => :test

--- a/fluentd/vendored_gem_src/remote_syslog_sender/lib/remote_syslog_sender.rb
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/lib/remote_syslog_sender.rb
@@ -1,0 +1,16 @@
+
+require 'remote_syslog_sender/udp_sender'
+require 'remote_syslog_sender/tcp_sender'
+
+module RemoteSyslogSender
+  VERSION = '1.0.3'
+
+  def self.new(remote_hostname, remote_port, options = {})
+    protocol = options.delete(:protocol)
+    if protocol && protocol.to_sym == :tcp
+      TcpSender.new(remote_hostname, remote_port, options)
+    else
+      UdpSender.new(remote_hostname, remote_port, options)
+    end
+  end
+end

--- a/fluentd/vendored_gem_src/remote_syslog_sender/lib/remote_syslog_sender/sender.rb
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/lib/remote_syslog_sender/sender.rb
@@ -1,0 +1,73 @@
+require 'socket'
+require 'syslog_protocol'
+
+module RemoteSyslogSender
+  class Sender
+    # To suppress initialize warning
+    class Packet < SyslogProtocol::Packet
+      def initialize(*)
+        super
+        @time = nil
+      end
+    end
+
+    attr_reader :socket
+    attr_accessor :packet
+
+    def initialize(remote_hostname, remote_port, options = {})
+      @remote_hostname = remote_hostname
+      @remote_port     = remote_port
+      @whinyerrors     = options[:whinyerrors]
+      @packet_size     = options[:packet_size] || 1024
+
+      @packet = Packet.new
+
+      local_hostname   = options[:hostname] || options[:local_hostname] || (Socket.gethostname rescue `hostname`.chomp)
+      local_hostname   = 'localhost' if local_hostname.nil? || local_hostname.empty?
+      @packet.hostname = local_hostname
+
+      @packet.facility = options[:facility] || 'user'
+      @packet.severity = options[:severity] || 'notice'
+      @packet.tag      = options[:tag] || options[:program]  || "#{File.basename($0)}[#{$$}]"
+
+      @socket = nil
+    end
+
+    def transmit(message, packet_options = nil)
+      message.split(/\r?\n/).each do |line|
+        begin
+          next if line =~ /^\s*$/
+          packet = @packet.dup
+          if packet_options
+            packet.tag = packet_options[:program] if packet_options[:program]
+            packet.hostname = packet_options[:local_hostname] if packet_options[:local_hostname]
+            %i(hostname facility severity tag).each do |key|
+              packet.send("#{key}=", packet_options[key]) if packet_options[key]
+            end
+          end
+          packet.content = line
+          send_msg(packet.assemble(@packet_size))
+        rescue
+          if @whinyerrors
+            raise
+          else
+            $stderr.puts "#{self.class} error: #{$!.class}: #{$!}\nOriginal message: #{line}"
+          end
+        end
+      end
+    end
+
+    # Make this act a little bit like an `IO` object
+    alias_method :write, :transmit
+
+    def close
+      @socket.close
+    end
+
+    private
+
+    def send_msg(payload)
+      raise NotImplementedError, "please override"
+    end
+  end
+end

--- a/fluentd/vendored_gem_src/remote_syslog_sender/lib/remote_syslog_sender/tcp_sender.rb
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/lib/remote_syslog_sender/tcp_sender.rb
@@ -1,0 +1,155 @@
+require 'socket'
+require 'syslog_protocol'
+require 'remote_syslog_sender/sender'
+
+module RemoteSyslogSender
+  class TcpSender < Sender
+    class NonBlockingTimeout < StandardError; end
+
+    def initialize(remote_hostname, remote_port, options = {})
+      super
+      @tls             = options[:tls]
+      @retry_limit     = options[:retry_limit] || 3
+      @retry_interval  = options[:retry_interval] || 0.5
+      @remote_hostname = remote_hostname
+      @remote_port     = remote_port
+      @ssl_method      = options[:ssl_method] || 'TLSv1_2'
+      @ca_file         = options[:ca_file]
+      @verify_mode     = options[:verify_mode]
+      @timeout         = options[:timeout] || 600
+      @timeout_exception   = !!options[:timeout_exception]
+      @exponential_backoff = !!options[:exponential_backoff]
+
+      @mutex = Mutex.new
+      @tcp_socket = nil
+
+      if [:SOL_SOCKET, :SO_KEEPALIVE, :IPPROTO_TCP, :TCP_KEEPIDLE].all? {|c| Socket.const_defined? c}
+        @keep_alive      = options[:keep_alive]
+      end
+      if Socket.const_defined?(:TCP_KEEPIDLE)
+        @keep_alive_idle = options[:keep_alive_idle]
+      end
+      if Socket.const_defined?(:TCP_KEEPCNT)
+        @keep_alive_cnt  = options[:keep_alive_cnt]
+      end
+      if Socket.const_defined?(:TCP_KEEPINTVL)
+        @keep_alive_intvl = options[:keep_alive_intvl]
+      end
+      connect
+    end
+
+    def close
+      @socket.close if @socket
+      @tcp_socket.close if @tcp_socket
+    end
+
+    private
+
+    def connect
+      connect_retry_count = 0
+      connect_retry_limit = 3
+      connect_retry_interval = 1
+      @mutex.synchronize do
+        begin
+          close
+
+          @tcp_socket = TCPSocket.new(@remote_hostname, @remote_port)
+
+          if @keep_alive
+            @tcp_socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
+            @tcp_socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_KEEPIDLE, @keep_alive_idle) if @keep_alive_idle
+            @tcp_socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_KEEPCNT, @keep_alive_cnt) if @keep_alive_cnt
+            @tcp_socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_KEEPINTVL, @keep_alive_intvl) if @keep_alive_intvl
+          end
+          if @tls
+            require 'openssl'
+            context = OpenSSL::SSL::SSLContext.new(@ssl_method)
+            context.ca_file = @ca_file if @ca_file
+            context.verify_mode = @verify_mode if @verify_mode
+
+            @socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, context)
+            @socket.connect
+            @socket.post_connection_check(@remote_hostname)
+            raise "verification error" if @socket.verify_result != OpenSSL::X509::V_OK
+          else
+            @socket = @tcp_socket
+          end
+        rescue
+          if connect_retry_count < connect_retry_limit
+            sleep connect_retry_interval
+            connect_retry_count += 1
+            retry
+          else
+            raise
+          end
+        end
+      end
+    end
+
+    def send_msg(payload)
+      if @timeout && @timeout >= 0
+        method = :write_nonblock
+      else
+        method = :write
+      end
+
+      retry_limit = @retry_limit.to_i
+      retry_interval = @retry_interval.to_f
+      retry_count = 0
+
+      payload << "\n"
+      payload.force_encoding(Encoding::ASCII_8BIT)
+      payload_size = payload.bytesize
+
+      until payload_size <= 0
+        start = get_time
+        begin
+          result = @mutex.synchronize { @socket.__send__(method, payload) }
+          payload_size -= result
+          payload.slice!(0, result) if payload_size > 0
+        rescue IO::WaitReadable
+          timeout_wait = @timeout - (get_time - start)
+          retry if IO.select([@socket], nil, nil, timeout_wait)
+
+          raise NonBlockingTimeout if @timeout_exception
+          break
+        rescue IO::WaitWritable
+          timeout_wait = @timeout - (get_time - start)
+          retry if IO.select(nil, [@socket], nil, timeout_wait)
+
+          raise NonBlockingTimeout if @timeout_exception
+          break
+        rescue
+          if retry_count < retry_limit
+            sleep retry_interval
+            retry_count += 1
+            retry_interval *= 2 if @exponential_backoff
+            connect
+            retry
+          else
+            raise
+          end
+        end
+      end
+    end
+
+    POSIX_CLOCK =
+      if defined?(Process::CLOCK_MONOTONIC_COARSE)
+        Process::CLOCK_MONOTONIC_COARSE
+      elsif defined?(Process::CLOCK_MONOTONIC)
+        Process::CLOCK_MONOTONIC
+      elsif defined?(Process::CLOCK_REALTIME_COARSE)
+        Process::CLOCK_REALTIME_COARSE
+      elsif defined?(Process::CLOCK_REALTIME)
+        Process::CLOCK_REALTIME
+      end
+
+    def get_time
+      if POSIX_CLOCK
+        Process.clock_gettime(POSIX_CLOCK)
+      else
+        Time.now.to_f
+      end
+    end
+  end
+end

--- a/fluentd/vendored_gem_src/remote_syslog_sender/lib/remote_syslog_sender/udp_sender.rb
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/lib/remote_syslog_sender/udp_sender.rb
@@ -1,0 +1,18 @@
+require 'socket'
+require 'syslog_protocol'
+require 'remote_syslog_sender/sender'
+
+module RemoteSyslogSender
+  class UdpSender < Sender
+    def initialize(remote_hostname, remote_port, options = {})
+      super
+      @socket = UDPSocket.new
+    end
+
+    private
+
+    def send_msg(payload)
+      @socket.send(payload, 0, @remote_hostname, @remote_port)
+    end
+  end
+end

--- a/fluentd/vendored_gem_src/remote_syslog_sender/remote_syslog_sender.gemspec
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/remote_syslog_sender.gemspec
@@ -1,0 +1,21 @@
+Gem::Specification.new do |s|
+  s.name              = 'remote_syslog_sender'
+  s.version           = '1.2.1'
+  s.summary     = "Message sender that sends directly to a remote syslog endpoint"
+  s.description = "Message sender that sends directly to a remote syslog endpoint (Support UDP, TCP, TCP+TLS)"
+
+  s.authors  = ["Tomohiro Hashidate", "Eric Lindvall"]
+  s.email    = 'kakyoin.hierophant@gmail.com'
+  s.homepage = 'https://github.com/reproio/remote_syslog_logger'
+
+  s.files         = `git ls-files -z`.split("\x0")
+  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  s.require_paths = %w[lib]
+
+  s.add_runtime_dependency 'syslog_protocol'
+
+  s.add_development_dependency "bundler", "~> 1.6"
+  s.add_development_dependency "rake"
+  s.add_development_dependency "test-unit"
+end

--- a/fluentd/vendored_gem_src/remote_syslog_sender/test/helper.rb
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/test/helper.rb
@@ -1,0 +1,12 @@
+$:.unshift File.expand_path('../../lib', __FILE__)
+
+unless ENV['BUNDLE_GEMFILE']
+  require 'rubygems'
+  require 'bundler'
+  Bundler.setup
+  Bundler.require
+end
+
+require 'remote_syslog_sender'
+
+require 'test/unit'

--- a/fluentd/vendored_gem_src/remote_syslog_sender/test/test_remote_syslog_logger.rb
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/test/test_remote_syslog_logger.rb
@@ -1,0 +1,66 @@
+require File.expand_path('../helper', __FILE__)
+
+class TestRemoteSyslogSender < Test::Unit::TestCase
+  def setup
+    @server_port = rand(50000) + 1024
+    @socket = UDPSocket.new
+    @socket.bind('127.0.0.1', @server_port)
+
+    @tcp_server = TCPServer.open('127.0.0.1', 0)
+    @tcp_server_port = @tcp_server.addr[1]
+
+    @tcp_server_wait_thread = Thread.start do
+      @tcp_server.accept
+    end
+  end
+
+  def teardown
+    @socket.close
+    @tcp_server.close
+  end
+
+  def test_sender
+    @sender = RemoteSyslogSender.new('127.0.0.1', @server_port)
+    @sender.write "This is a test"
+
+    message, _ = *@socket.recvfrom(1024)
+    assert_match(/This is a test/, message)
+  end
+
+  def test_sender_long_payload
+    @sender = RemoteSyslogSender.new('127.0.0.1', @server_port, packet_size: 10240)
+    @sender.write "abcdefgh" * 1000
+
+    message, _ = *@socket.recvfrom(10240)
+    assert_match(/#{"abcdefgh" * 1000}/, message)
+  end
+
+  def test_sender_tcp
+    @sender = RemoteSyslogSender.new('127.0.0.1', @tcp_server_port, protocol: :tcp)
+    @sender.write "This is a test"
+    sock = @tcp_server_wait_thread.value
+
+    message, _ = *sock.recvfrom(1024)
+    assert_match(/This is a test/, message)
+  end
+
+  def test_sender_tcp_nonblock
+    @sender = RemoteSyslogSender.new('127.0.0.1', @tcp_server_port, protocol: :tcp, timeout: 20)
+    @sender.write "This is a test"
+    sock = @tcp_server_wait_thread.value
+
+    message, _ = *sock.recvfrom(1024)
+    assert_match(/This is a test/, message)
+  end
+
+  def test_sender_multiline
+    @sender = RemoteSyslogSender.new('127.0.0.1', @server_port)
+    @sender.write "This is a test\nThis is the second line"
+
+    message, _ = *@socket.recvfrom(1024)
+    assert_match(/This is a test/, message)
+
+    message, _ = *@socket.recvfrom(1024)
+    assert_match(/This is the second line/, message)
+  end
+end


### PR DESCRIPTION
This PR adds [fluent-plugin-remote_syslog ](https://github.com/dlackty/fluent-plugin-remote_syslog) to the plugins for fluentd. As opposed to the current plugin we use for interacting with an external syslog server, this one supports both secure connections (see #1547 ) and contains the implementation of UDP, TCP and TCP+TLS within a single script.