### PR TITLE
Bug 1794085:  [fluentd] 3.11 remote syslog message is incomplete/truncated

### DIFF
--- a/fluentd/generate_syslog_config.rb
+++ b/fluentd/generate_syslog_config.rb
@@ -23,6 +23,7 @@ def init_environment_vars()
       ['SEVERITY', 'severity', "debug", nil],
       ['USE_RECORD', 'use_record', nil, nil],
       ['PAYLOAD_KEY', 'payload_key', nil, nil],
+      ['MAX_SIZE', 'max_size', nil, nil],
       # TYPE must be vars[-1]
       ['TYPE', 'type', "syslog_buffered", ['syslog_buffered', 'syslog']]
     ]

--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -19,7 +19,7 @@ module Fluent
     config_param :severity, :string, :default => 'debug'
     config_param :use_record, :string, :default => nil
     config_param :payload_key, :string, :default => 'message'
-
+    config_param :max_size, :integer, :default => 1024
 
     def initialize
       super
@@ -44,6 +44,9 @@ module Fluent
       @payload_key = conf['payload_key']
       if not @payload_key
         @payload_key = "message"
+      end
+      if conf['max_size']
+        @max_size = conf['max_size'].to_i
       end
       @random_string = SecureRandom.hex
     end
@@ -135,7 +138,7 @@ module Fluent
         else
           record[@payload_key]
         end
-        @socket.send(packet.assemble, 0, @remote_syslog, @port)
+        @socket.send(packet.assemble(@max_size), 0, @remote_syslog, @port)
     }
     end
   end

--- a/fluentd/out_syslog_buffered.rb
+++ b/fluentd/out_syslog_buffered.rb
@@ -19,7 +19,7 @@ module Fluent
     config_param :severity, :string, :default => 'debug'
     config_param :use_record, :string, :default => nil
     config_param :payload_key, :string, :default => 'message'
-
+    config_param :max_size, :integer, :default => 1024
 
     def initialize
       super
@@ -45,6 +45,9 @@ module Fluent
       @payload_key = conf['payload_key']
       if not @payload_key
         @payload_key = "message"
+      end
+      if conf['max_size']
+        @max_size = conf['max_size'].to_i
       end
       @random_string = SecureRandom.hex
     end
@@ -166,7 +169,7 @@ module Fluent
         end
         if @socket
           begin
-            @socket.write packet.assemble + "\n"
+            @socket.write packet.assemble(@max_size) + "\n"
             @socket.flush
           rescue SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EPIPE, Timeout::Error, OpenSSL::SSL::SSLError => e
             log.warn "out:syslog: connection error by #{@remote_syslog}:#{@port} :#{e}"


### PR DESCRIPTION
This fix makes maximum size of syslog messages sent by Fluentd configurable,
for both the syslog (UDP) and syslog_buffered (TCP) plugins.
Previously, the maximum message size was hardcoded to 1024 bytes. This fix
keeps that limit as the default.

A new environment variable is now recognized:
* REMOTE_SYSLOG_MAX_SIZE, which specifies the maximum size of syslog messages, in bytes.