### PR TITLE
Minor fix to print the reason for CSV creation not Succeeding.

### DIFF
--- a/hack/vendor/olm-test-script/e2e-olm.sh
+++ b/hack/vendor/olm-test-script/e2e-olm.sh
@@ -112,4 +112,4 @@ fi
 
 test::object_assert 100 subscriptions.operators.coreos.com/olm-testing${SUFFIX:-} "{.status.catalogHealth[?(@.catalogSourceRef.name=='openshift-olm-test${SUFFIX:-}')].healthy}" "true" "-n $TEST_NAMESPACE"
 # Need to change to match the name of the CSV with version.
-test::object_assert 50 clusterserviceversions.operators.coreos.com/${CURRENT_CSV} "{.status.phase}" Succeeded "-n $TEST_NAMESPACE"
+test::object_assert 50 clusterserviceversions.operators.coreos.com/${CURRENT_CSV} "{.status['phase','reason']}" "Succeeded InstallSucceeded" "-n $TEST_NAMESPACE"


### PR DESCRIPTION
Script output after this change: 
```
Waiting for Get clusterserviceversions.operators.coreos.com/elasticsearch-operator.v4.5.0 {.status['phase','reason']} -n openshift-operators-redhat: expected: Succeeded InstallSucceeded, got: Pending RequirementsNotMet
```

probably need updating in CLO and EO e2e-olm.sh also