### PR TITLE
Restrict access to ES from localhost only

### DIFF
--- a/elasticsearch/sgconfig/config.yml
+++ b/elasticsearch/sgconfig/config.yml
@@ -4,8 +4,8 @@ opendistro_security:
       xff:
         enabled: true
         remoteIpHeader: 'x-forwarded-for'
+        internalProxies: '0\:0\:0\:0\:0\:0\:0\:1|127\.0\.0\.1'
         trustedProxies: '.*'
-        internalProxies: '.*'
     authc:
       openshift_domain:
         enabled: true


### PR DESCRIPTION

`trustedProxies` is regex pattern which is matched against the remote address in the http request. 

configure `trustedProxies` to match only localhost ipv4 and ipv6 addesses
