### PR TITLE
remove unused cert domain. fix operators ability to fetch templates

### DIFF
--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -110,6 +110,7 @@ sg_role_admin:
         - ALL
   cluster:
     - CLUSTER_ALL
+    - ALL
 
 sg_role_jaeger:
   cluster:


### PR DESCRIPTION
This PR:
* Removes the cert domain config which is unused when traffic comes through the elasticsearch-proxy
* Adds permissions for admin roles to manipulate tempaltes

cc @ewolinetz 