### PR TITLE
[fluentd] Fix Dockerfile.centos7 builds

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -14,6 +14,13 @@ ENV DATA_VERSION=1.6.0 \
 # iproute needed for ip command to get ip addresses
 # autoconf redhat-rpm-config for building jemalloc
 USER 0
+
+#
+# Replace community build service repo with actuall SCLO mirror
+#
+RUN yum-config-manager --disable cbs.centos.org_repos_sclo7-rh-ruby25-rh-candidate_x86_64_os_ && \
+    yum-config-manager --add-repo http://mirror.centos.org/centos/7/sclo/x86_64/rh/rh-ruby25/
+
 RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum install -y --setopt=tsflags=nodocs \
       make \


### PR DESCRIPTION
The centos8 base image for sclo-rf-ruby25 is unfortunately based on a community build service yum repo. This change attempts to pin in it to the actual release mirror.