### PR TITLE
Add role for indexmanagement

### DIFF
--- a/elasticsearch/sgconfig/roles_mapping.yml
+++ b/elasticsearch/sgconfig/roles_mapping.yml
@@ -13,6 +13,8 @@ sg_role_rsyslog:
 sg_role_curator:
   users:
     - 'CN=system.logging.curator,OU=OpenShift,O=Logging'
+  backendroles:
+    - 'index-management'
 
 sg_role_admin:
   users:


### PR DESCRIPTION
This PR add a backend roled named "index-management" that is mapped to the curator role so the indexmanagment cronjobs can manage indices

cc @ewolinetz 