### PR TITLE
[kibana] Fix config options override per env variable

### DIFF
--- a/kibana/utils
+++ b/kibana/utils
@@ -57,21 +57,6 @@ update_config_from_env_vars() {
       server.ssl.certificate
       server.ssl.enabled
       server.ssl.key
-      xpack.apm.enabled
-      xpack.ccr.enabled
-      xpack.graph.enabled
-      xpack.grokdebugger.enabled
-      xpack.ilm.enabled
-      xpack.infra.enabled
-      xpack.infra.sources.default.logAlias
-      xpack.maps.enabled
-      xpack.ml.enabled
-      xpack.monitoring.enabled
-      xpack.remote_clusters.enabled
-      xpack.reporting.enabled
-      xpack.searchprofiler.enabled
-      xpack.spaces.enabled
-      xpack.uptime.enabled
   )
   conf_file=${conf_dir}/kibana.yml
   echo "#The following values dynamically added from environment variable overrides:"

--- a/kibana/utils
+++ b/kibana/utils
@@ -85,7 +85,12 @@ update_config_from_env_vars() {
         if [ -n "${DEBUG:-}" ] ; then
           echo "updating ${conf_file} - '${kibana_var}: ${value}'"
         fi
-        echo "${kibana_var}: ${value}" >> ${conf_file}
+
+        if grep -q ${kibana_var} ${conf_file} ; then
+          sed -i "s,${kibana_var}:.*,${kibana_var}:\ ${value}," "${conf_file}"
+        else
+          echo -e "\n${kibana_var}: ${value}" >> "${conf_file}"
+        fi
       fi
   done
 }


### PR DESCRIPTION
### Description
This PR addresses a hindsight in the `kibana/utils` script that is responsible to override the kibana configuration options from environment variables. However, this script was broken per se because it appended the updates at the end of the yaml file resulting in yaml parser exceptions.

### Background
To address kibana NS fixes for E2E testing on random NS: openshift/elasticsearch-operator#305