### PR TITLE
Support syslog rfc5424

### DIFF
--- a/fluentd/vendored_gem_src/fluent-plugin-remote_syslog/lib/fluent/plugin/out_remote_syslog.rb
+++ b/fluentd/vendored_gem_src/fluent-plugin-remote_syslog/lib/fluent/plugin/out_remote_syslog.rb
@@ -16,6 +16,7 @@ module Fluent
       config_param :facility, :string, :default => "user"
       config_param :severity, :string, :default => "notice"
       config_param :program, :string, :default => "fluentd"
+      config_param :rfc, :enum, list: [:rfc3164, :rfc5424], :default => :rfc5424
 
       config_param :protocol, :enum, list: [:udp, :tcp], :default => :udp
       config_param :tls, :bool, :default => false
@@ -98,6 +99,7 @@ module Fluent
 
         packet_options = {facility: facility, severity: severity, program: program}
         packet_options[:hostname] = hostname unless hostname.empty?
+        packet_options[:rfc] = @rfc
 
         begin
           chunk.open do |io|

--- a/fluentd/vendored_gem_src/remote_syslog_sender/lib/remote_syslog_sender/sender.rb
+++ b/fluentd/vendored_gem_src/remote_syslog_sender/lib/remote_syslog_sender/sender.rb
@@ -29,6 +29,7 @@ module RemoteSyslogSender
       @packet.facility = options[:facility] || 'user'
       @packet.severity = options[:severity] || 'notice'
       @packet.tag      = options[:tag] || options[:program]  || "#{File.basename($0)}[#{$$}]"
+      @packet.rfc      = options[:rfc] || :rfc5424
 
       @socket = nil
     end
@@ -40,6 +41,7 @@ module RemoteSyslogSender
           packet = @packet.dup
           if packet_options
             packet.tag = packet_options[:program] if packet_options[:program]
+            packet.rfc = packet_options[:rfc] if packet_options[:rfc]
             packet.hostname = packet_options[:local_hostname] if packet_options[:local_hostname]
             %i(hostname facility severity tag).each do |key|
               packet.send("#{key}=", packet_options[key]) if packet_options[key]

--- a/fluentd/vendored_gem_src/syslog_protocol/lib/syslog_protocol/packet.rb
+++ b/fluentd/vendored_gem_src/syslog_protocol/lib/syslog_protocol/packet.rb
@@ -1,17 +1,34 @@
 module SyslogProtocol
   class Packet
-    attr_reader :facility, :severity, :hostname, :tag
+    attr_reader :facility, :severity, :hostname, :tag, :rfc, :appname, :procid, :msgid
     attr_accessor :time, :content
+
+    NILVALUE = '-'
+
+    def initialize
+      @rfc = :rfc3164
+      @procid = NILVALUE
+      @msgid = NILVALUE
+    end
 
     def to_s
       assemble
     end
 
     def assemble(max_size = 1024)
-      unless @hostname and @facility and @severity and @tag
+      if @rfc == :rfc5424
+        @appname = @tag
+        assemble_rfc5424
+      else
+        assemble_rfc3164(max_size)
+      end
+    end
+
+    def assemble_rfc3164(max_size = 1024)
+      unless @hostname && @facility && @severity && @tag
         raise "Could not assemble packet without hostname, tag, facility, and severity"
       end
-      data = "<#{pri}>#{generate_timestamp} #{@hostname} #{@tag}: #{@content}"
+      data = "<#{pri}>#{generate_timestamp_rfc3164} #{@hostname} #{@tag}: #{@content}"
 
       if string_bytesize(data) > max_size
         data = data.slice(0, max_size)
@@ -19,8 +36,14 @@ module SyslogProtocol
           data = data.slice(0, data.length - 1)
         end
       end
-
       data
+    end
+
+    def assemble_rfc5424
+      unless @hostname && @facility && @severity && @appname
+        raise "Could not assemble packet without hostname, appname, facility, and severity"
+      end
+      data = "<#{pri}>1 #{generate_timestamp_rfc5424} #{@hostname} #{@appname} #{@procid} #{@msgid} #{structured_data} #{@content}"
     end
 
     def facility=(f)
@@ -109,13 +132,29 @@ module SyslogProtocol
       @severity = p - (@facility * 8)
     end
 
-    def generate_timestamp
+    def rfc=(r)
+      unless r == :rfc5424 or r == :rfc3164
+        raise ArgumentError.new "rfc must be rfc5424 or rfc3164"
+      end
+      @rfc = r
+    end
+
+    def generate_timestamp_rfc3164
       time = @time || Time.now
       # The timestamp format requires that a day with fewer than 2 digits have
       # what would normally be a preceding zero, be instead an extra space.
       day = time.strftime("%d")
       day = day.sub(/^0/, ' ') if day =~ /^0\d/
       time.strftime("%b #{day} %H:%M:%S")
+    end
+
+    def generate_timestamp_rfc5424
+      time = @time || Time.now
+      time.strftime("%Y-%m-%dT%H:%M:%S.%6N%:z")
+    end
+
+    def structured_data
+      NILVALUE
     end
 
     if "".respond_to?(:bytesize)


### PR DESCRIPTION
Support syslog rfc5424
  - added support for rfc5424 in `syslog_protocol` gem, default is rfc3164 so old behavior remains same
  - updated `fluent-plugin-remote_syslog` to accept rfc configuration
  - updated `remote_syslog_sender` to pass the rfc value