### PR TITLE
Bug 1822686: Require python2-pip in vendoring and removing python-thrift

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.k8s.description="Curator elasticsearch container for elasticsearch dele
 
 
 RUN yum install -y --setopt=tsflags=nodocs \
-        python-pip \
+        python2-pip \
         python2-ruamel-yaml && \
     yum clean all
 

--- a/curator/Dockerfile.centos7
+++ b/curator/Dockerfile.centos7
@@ -23,7 +23,7 @@ LABEL io.k8s.description="Curator elasticsearch container for elasticsearch dele
 
 RUN yum install -y epel-release
 RUN yum install -y --setopt=tsflags=nodocs \
-        python-pip \
+        python2-pip \
         python2-ruamel-yaml && \
     yum clean all
 


### PR DESCRIPTION
Additional change to support https://issues.redhat.com/browse/LOG-690 for downstream