### PR TITLE
Bug 1836230: Remove fluent centos dependency

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -1,4 +1,4 @@
-FROM centos/ruby-25-centos7:latest
+FROM ubi7/ruby-25
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
@@ -14,8 +14,7 @@ ENV DATA_VERSION=1.6.0 \
 # iproute needed for ip command to get ip addresses
 # autoconf redhat-rpm-config for building jemalloc
 USER 0
-RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
-    yum install -y --setopt=tsflags=nodocs \
+RUN yum install -y --setopt=tsflags=nodocs \
       make \
       bc \
       git \

--- a/hack/testing/test-010-smoke-test-logging.sh
+++ b/hack/testing/test-010-smoke-test-logging.sh
@@ -57,8 +57,7 @@ done
 log::info "Checking deployment of kibana..."
 #HACK there should only be one
 try_until_text "oc -n $LOGGING_NS get pods -l component=kibana --no-headers | wc -l" "1" "$(( 3*$minute ))"
-#expect head to redirect to the 'kibana' app running with kibana as opposed to 'timelion'
-try_until_text "oc -n $LOGGING_NS exec $( oc -n $LOGGING_NS get pods -l component=kibana -o jsonpath={.items[0].metadata.name} ) -c kibana -- curl --silent --request HEAD --head --output /dev/null --write-out %{response_code} http://localhost:5601/" "302" "$(( 1*$minute ))"
+try_until_text "oc -n $LOGGING_NS get pod $(oc -n $LOGGING_NS get pods -l component=kibana -o jsonpath={.items[0].metadata.name}) -o jsonpath='{.status.conditions[?(@.type==\"ContainersReady\")].status}'" "True" "$(( 1*$minute ))"
 
 log::info "Check to see if we have expected indices..."
 pod=$(oc -n $LOGGING_NS get pods -l component=elasticsearch -o jsonpath={.items[0].metadata.name})


### PR DESCRIPTION
This PR:

removes dependency on centos to mitigate issue with changing repo mirrors

https://bugzilla.redhat.com/show_bug.cgi?id=1836230

blocks https://github.com/openshift/origin-aggregated-logging/pull/1895