### PR TITLE
Bug 1840274: Add script to let fluentd check ES version

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -105,7 +105,7 @@ COPY --from=builder /contents /contents
 RUN mkdir -p /etc/fluent/plugin
 ADD configs.d/ /etc/fluent/configs.d/
 ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb /etc/fluent/plugin/
-ADD run.sh generate_syslog_config.rb ${HOME}/
+ADD run.sh generate_syslog_config.rb wait_for_es_version.rb wait_for_es_version.sh ${HOME}/
 ADD lib/generate_throttle_configs/lib/*.rb ${HOME}/
 ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
 ADD lib/filter_elasticsearch_genid_ext/lib/filter_elasticsearch_genid_ext.rb /etc/fluent/plugin/

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -41,7 +41,7 @@ RUN cd ${HOME}/vendored_gem_src/ && ./install-gems.sh && cd / && rm -rf ${HOME}/
 RUN mkdir -p /etc/fluent/plugin
 ADD configs.d/ /etc/fluent/configs.d/
 ADD out_syslog_buffered.rb out_syslog.rb out_rawtcp.rb /etc/fluent/plugin/
-ADD run.sh generate_syslog_config.rb ${HOME}/
+ADD run.sh generate_syslog_config.rb wait_for_es_version.rb wait_for_es_version.sh ${HOME}/
 ADD lib/generate_throttle_configs/lib/*.rb ${HOME}/
 ADD lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
 ADD lib/filter_elasticsearch_genid_ext/lib/filter_elasticsearch_genid_ext.rb /etc/fluent/plugin/

--- a/fluentd/wait_for_es_version.rb
+++ b/fluentd/wait_for_es_version.rb
@@ -1,0 +1,38 @@
+#! /usr/bin/env ruby
+
+require 'net/https'
+require 'json'
+
+if ARGV.length != 2
+  abort "Usage: wait_for_es_version.rb <min_es_version> <es_url>"
+end
+
+min_version = ARGV[0]
+es_url = ARGV[1]
+
+uri = URI(es_url)
+
+cert_dir = "/etc/fluent/keys/"
+
+fluentd_ca_file = File.join(cert_dir, "ca-bundle.crt")
+
+client_file = File.join(cert_dir, "tls.crt")
+client_cert = OpenSSL::X509::Certificate.new File.read client_file
+
+key_file = File.join(cert_dir, "tls.key")
+client_key = OpenSSL::PKey::RSA.new File.read key_file
+
+
+Net::HTTP.start(uri.host, uri.port, :use_ssl => true, :ca_file => fluentd_ca_file, :cert => client_cert, :key => client_key) do |http|
+  request = Net::HTTP::Get.new uri
+  response = http.request request
+
+  hash = JSON.parse(response.body)
+
+  version = hash["version"]["number"]
+
+  if version.to_f < min_version.to_f
+    warn "Elasticsearch is currently version: #{version} - Expecting it to be at least: #{min_version}"
+    exit 1
+  end
+end

--- a/fluentd/wait_for_es_version.sh
+++ b/fluentd/wait_for_es_version.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+ruby wait_for_es_version.rb $@


### PR DESCRIPTION
This is part of addressing the concern where CLO upgrades before EO does.
With this script we can create an init container for Fluentd that will call this script (it will cause the main container to wait until the correct ES version is found) which can be passed via a command arg

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1840274