### PR TITLE
Bug 1838929: Remove module/ingest-geoip

### DIFF
--- a/elasticsearch/install.sh
+++ b/elasticsearch/install.sh
@@ -6,6 +6,9 @@ ln -s /usr/local/bin/logging ${HOME}/logging
 
 source ${HOME}/prep-install.${RELEASE_STREAM}
 
+echo "removing module: ingest-geoip"
+rm -rf ${ES_HOME}/modules/ingest-geoip
+
 echo "ES plugins: ${es_plugins[@]}"
 for es_plugin in ${es_plugins[@]}
 do


### PR DESCRIPTION
This PR:

* Removes the module/ingest-geoip from the elasticsearch distribution

Indicators this is fixed in later 6.x release but we have significant productization work in order for us to be able to pull in later releases

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1838929