### PR TITLE
Bug 1835903: Add guard script for kibana to wait for index migration

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -25,7 +25,7 @@ COPY vendored_tar_src/opendistro_security_kibana_plugin-0.10.0.4/ ${HOME}/plugin
 RUN chmod -R og+w ${HOME}/
 ADD probe/ /usr/share/kibana/probe/
 ADD kibana.yml ${KIBANA_CONF_DIR}/
-ADD run.sh utils ${HOME}/
+ADD run.sh utils wait_for_alias.sh ${HOME}/
 RUN sed -i -e 's/"node":.*/"node": "'$(${NODE_PATH}/node --version | sed 's/v//')'"/' package.json && \
     mkdir -p node && \
     ln -s ${NODE_PATH} node/bin

--- a/kibana/Dockerfile.centos7
+++ b/kibana/Dockerfile.centos7
@@ -25,7 +25,7 @@ COPY vendored_tar_src/opendistro_security_kibana_plugin-0.10.0.4/ ${HOME}/plugin
 RUN chmod -R og+w ${HOME}/
 ADD probe/ /usr/share/kibana/probe/
 ADD kibana.yml ${KIBANA_CONF_DIR}/
-ADD run.sh utils ${HOME}/
+ADD run.sh utils wait_for_alias.sh ${HOME}/
 RUN sed -i -e 's/"node":.*/"node": "'$(${NODE_PATH}/node --version | sed 's/v//')'"/' package.json && \
     mkdir -p node && \
     ln -s ${NODE_PATH} node/bin

--- a/kibana/kibana.yml
+++ b/kibana/kibana.yml
@@ -34,7 +34,6 @@ elasticsearch.hosts: ["https://elasticsearch.openshift-logging.svc.cluster.local
 
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations and
 # dashboards. Kibana creates a new index if the index doesn't already exist.
-#kibana.index: ".kibana"
 
 # The default application to load.
 kibana.defaultAppId: "discover"

--- a/kibana/wait_for_alias.sh
+++ b/kibana/wait_for_alias.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+required_alias=$1
+required_index=$2
+
+cat <<EOF >> js_script
+const fss =require('fs');
+const index = process.argv[2];
+const data = fss.readFileSync('/dev/stdin').toString()
+var indices = {};
+try {
+  indices = JSON.parse(data)
+} catch(err) {
+  console.error(err)
+}
+console.info(Object.keys(indices).some(e => e === index))
+EOF
+
+while [ true ]; do
+
+  valid=$(curl -s --cacert /etc/kibana/keys/ca --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert https://elasticsearch.openshift-logging.svc:9200/_alias/"$required_alias" | node/bin/node js_script "$required_index")
+
+  if [[ "$valid" == "true" ]]; then
+    echo "Required alias $required_alias for index $required_index valid"
+    exit 0
+  fi
+
+  echo "Required alias $required_alias for index $required_index not valid"
+  sleep 10s
+done


### PR DESCRIPTION
This PR adds an helper utility for init containers to check if the required alias-to-index mapping is matching before starting kibana >=6.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1835903