### PR TITLE
Adding Makefile targets for building and deploying each component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 OPERATOR_LOGGING_IMAGE_STREAM?=stable
+
+FLUENTD_IMAGE?="openshift/origin-logging-fluentd"
+KIBANA_IMAGE?="openshift/origin-logging-kibana6"
+ELASTICSEARCH_IMAGE?="openshift/origin-logging-elasticsearch6"
+CURATOR_IMAGE?="openshift/origin-logging-curator5"
+
 # Build the Docker images for Origin Aggregated Logging
 build-images:
 	hack/build-images.sh
@@ -9,3 +15,49 @@ test:
 .PHONY: test
 
 .PHONY: test-pre-upgrade
+
+build-fluentd-image:
+	hack/build-component-image.sh "fluentd" $(FLUENTD_IMAGE)
+.PHONY: build-fluentd-image
+
+build-kibana-image:
+	hack/build-component-image.sh "kibana" $(KIBANA_IMAGE)
+.PHONY: build-kibana-image
+
+build-elasticsearch-image:
+	hack/build-component-image.sh "elasticsearch" $(ELASTICSEARCH_IMAGE)
+.PHONY: build-elasticsearch-image
+
+build-curator-image:
+	hack/build-component-image.sh "curator" $(CURATOR_IMAGE)
+.PHONY: build-curator-image
+
+build-all-images:
+	build-fluentd-image
+	build-kibana-image
+	build-elasticsearch-image
+	build-curator-image
+.PHONY: build-all-images
+
+deploy-fluentd-image: build-fluentd-image
+	hack/deploy-component-image.sh $(FLUENTD_IMAGE)
+.PHONY: deploy-fluentd-image
+
+deploy-kibana-image: build-kibana-image
+	hack/deploy-component-image.sh $(KIBANA_IMAGE)
+.PHONY: deploy-kibana-image
+
+deploy-elasticsearch-image: build-elasticsearch-image
+	hack/deploy-component-image.sh $(ELASTICSEARCH_IMAGE)
+.PHONY: deploy-elasticsearch-image
+
+deploy-curator-image: build-curator-image
+	hack/deploy-component-image.sh $(CURATOR_IMAGE)
+.PHONY: deploy-curator-image
+
+deploy-all-images:
+	deploy-fluentd-image
+	deploy-kibana-image
+	deploy-elasticsearch-image
+	deploy-curator-image
+.PHONY: deploy-all-images

--- a/hack/build-component-image.sh
+++ b/hack/build-component-image.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+set -euo pipefail
+
+dir=$1
+fullimagename=$2
+
+tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin-"}"
+docker_suffix='.centos7'
+
+if [ "${RELEASE_STREAM:-}" = 'prod' ] ; then
+  docker_suffix=''
+fi
+dockerfile="Dockerfile${docker_suffix}"
+
+dfpath=${dir}/${dockerfile}
+
+podman build -f $dfpath -t "$fullimagename" $dir

--- a/hack/deploy-component-image.sh
+++ b/hack/deploy-component-image.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IMAGE_TAG=$1
+
+echo "Setting up port-forwarding to remote registry ..."
+coproc oc -n openshift-image-registry port-forward service/image-registry 5000:5000
+trap "kill -15 $COPROC_PID" EXIT
+read PORT_FORWARD_STDOUT <&"${COPROC[0]}"
+if [[ "$PORT_FORWARD_STDOUT" =~ ^Forwarding.*5000$ ]] ; then
+    user=$(oc whoami | sed s/://)
+    echo "Login to registry..."
+    podman login --tls-verify=false -u ${user} -p $(oc whoami -t) 127.0.0.1:5000
+
+    echo "Pushing image ${IMAGE_TAG} ..."
+    if podman push --tls-verify=false ${IMAGE_TAG} 127.0.0.1:5000/${IMAGE_TAG}; then
+        oc -n openshift get imagestreams | grep $IMAGE_TAG
+    fi
+else
+    echo "Unexpected message from oc port-forward: $PORT_FORWARD_STDOUT"
+fi


### PR DESCRIPTION
To simplify building and deploying individual component images when testing fixes locally vs original make target that builds and pushes every image