### PR TITLE
Pin ffi to 1.12.2, because newer versions require ruby >= 2.3

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -48,6 +48,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
      'elasticsearch-api:5.0.5' \
      'elasticsearch:5.0.5' \
      'prometheus-client:0.9.0' \
+     'ffi:1.12.2' \
       fluentd:${FLUENTD_VERSION} \
      'fluent-plugin-elasticsearch:1.17.2' \
      'fluent-plugin-record-modifier:0.6.2' \


### PR DESCRIPTION
We should pin ffi to 1.12.2, because newer versions requires ruby 2.3. CentOS ships with ruby 2.0.

Error without the fix:
```
...
Step 8/26 : RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin &&     gem install -N --conservative --minimal-deps --no-ri --no-doc      'minitest:5.10.3'      'activesupport:4.2.10'      'public_suffix:2.0.5'      'faraday:0.15.2'      'elasticsearch-transport:5.0.5'      'elasticsearch-api:5.0.5'      'elasticsearch:5.0.5'      'prometheus-client:0.9.0'       fluentd:${FLUENTD_VERSION}      'fluent-plugin-elasticsearch:1.17.2'      'fluent-plugin-record-modifier:0.6.2'      'fluent-plugin-rewrite-tag-filter:1.5.6'       fluent-plugin-secure-forward:0.4.5      'fluent-plugin-systemd:0.0.11'       fluent-plugin-viaq_data_model:0.0.18      'fluent-plugin-remote-syslog:1.1'      'fluent-plugin-kubernetes_metadata_filter:1.2.2'      'fluent-plugin-prometheus:0.4.0'
 ---> Running in c11d76dbfd6c

Successfully installed minitest-5.10.3
Successfully installed concurrent-ruby-1.1.6
Successfully installed i18n-0.9.5
Successfully installed thread_safe-0.3.6
Successfully installed tzinfo-1.2.7
Successfully installed activesupport-4.2.10
Successfully installed public_suffix-2.0.5
Successfully installed multipart-post-2.1.1
Successfully installed faraday-0.15.2
Successfully installed multi_json-1.14.1
Successfully installed elasticsearch-transport-5.0.5
Successfully installed elasticsearch-api-5.0.5
Successfully installed elasticsearch-5.0.5
Successfully installed quantile-0.2.1
Successfully installed prometheus-client-0.9.0
Building native extensions.  This could take a while...
Successfully installed msgpack-1.3.3
Building native extensions.  This could take a while...
Successfully installed yajl-ruby-1.4.1
Building native extensions.  This could take a while...
Successfully installed cool.io-1.6.0
Building native extensions.  This could take a while...
Successfully installed http_parser.rb-0.6.0
Successfully installed sigdump-0.2.4
Successfully installed tzinfo-data-1.2020.1
Building native extensions.  This could take a while...
ERROR:  Error installing fluent-plugin-systemd:
	ffi requires Ruby version >= 2.3.
Successfully installed string-scrub-0.0.5
Successfully installed fluentd-0.12.43
Successfully installed excon-0.73.0
Successfully installed fluent-plugin-elasticsearch-1.17.2
Successfully installed fluent-plugin-record-modifier-0.6.2
Successfully installed fluent-plugin-rewrite-tag-filter-1.5.6
Successfully installed resolve-hostname-0.1.0
Successfully installed proxifier-1.0.3
Successfully installed fluent-plugin-secure-forward-0.4.5
Successfully installed fluent-plugin-viaq_data_model-0.0.18
Successfully installed uuidtools-2.1.5
Successfully installed fluent-mixin-config-placeholders-0.4.0
Successfully installed syslog_protocol-0.9.2
Successfully installed fluent-plugin-remote-syslog-1.1
Successfully installed lru_redux-1.1.0
Successfully installed http-accept-1.7.0
Building native extensions.  This could take a while...
Successfully installed unf_ext-0.0.7.7
Successfully installed unf-0.1.4
Successfully installed domain_name-0.5.20190701
Successfully installed http-cookie-1.0.3
Successfully installed mime-types-data-3.2020.0512
Successfully installed mime-types-3.3.1
Successfully installed netrc-0.11.0
Successfully installed rest-client-2.1.0
Successfully installed recursive-open-struct-1.0.0
Successfully installed http-form_data-1.0.3
Successfully installed addressable-2.7.0
Successfully installed http-0.9.8
Successfully installed kubeclient-1.1.4
Successfully installed fluent-plugin-kubernetes_metadata_filter-1.2.2
Successfully installed fluent-plugin-prometheus-0.4.0
52 gems installed
Removing intermediate container c11d76dbfd6c
error: build error: The command '/bin/sh -c mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin &&     gem install -N --conservative --minimal-deps --no-ri --no-doc      'minitest:5.10.3'      'activesupport:4.2.10'      'public_suffix:2.0.5'      'faraday:0.15.2'      'elasticsearch-transport:5.0.5'      'elasticsearch-api:5.0.5'      'elasticsearch:5.0.5'      'prometheus-client:0.9.0'       fluentd:${FLUENTD_VERSION}      'fluent-plugin-elasticsearch:1.17.2'      'fluent-plugin-record-modifier:0.6.2'      'fluent-plugin-rewrite-tag-filter:1.5.6'       fluent-plugin-secure-forward:0.4.5      'fluent-plugin-systemd:0.0.11'       fluent-plugin-viaq_data_model:0.0.18      'fluent-plugin-remote-syslog:1.1'      'fluent-plugin-kubernetes_metadata_filter:1.2.2'      'fluent-plugin-prometheus:0.4.0'' returned a non-zero code: 1
```