### PR TITLE
Bug 1845517: limit ffi version

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -40,6 +40,7 @@ RUN cd ${HOME}/jemalloc && EXTRA_CFLAGS="$( rpm --eval '%{optflags}' )" ./autoge
 
 RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
     gem install -N --conservative --minimal-deps --no-ri --no-doc \
+     'ffi:<1.13' \
      'minitest:5.10.3' \
      'activesupport:4.2.10' \
      'public_suffix:2.0.5' \


### PR DESCRIPTION
Currently building of the Docker image is broken, due to new ffi gem releases.

```
ERROR:  Error installing fluent-plugin-systemd:
	ffi requires Ruby version >= 2.3.
```

This PR limits the ffi version below 1.13.

ref https://bugzilla.redhat.com/show_bug.cgi?id=1845517