### PR TITLE
Bug 1847542: Rely on koji to get maven dependencies

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -27,7 +27,7 @@ ARG OSE_ES_VER=5.6.16.1-redhat-1
 ARG OSE_ES_URL
 ARG PROMETHEUS_EXPORTER_VER=5.6.16.0-redhat-1
 ARG PROMETHEUS_EXPORTER_URL
-ARG MAVEN_REPO_URL=http://download-node-02.eng.bos.redhat.com/brewroot/repos/lpc-rhel-7-maven-build/latest/maven/
+ARG MAVEN_REPO_URL=file:///artifacts/
 
 ADD sgconfig/ ${HOME}/sgconfig/
 ADD index_templates/ ${ES_HOME}/index_templates/
@@ -39,7 +39,8 @@ ADD init.sh run.sh prep-install* install.sh ${HOME}/
 COPY utils/** /usr/local/bin/
 RUN ln -s /usr/local/bin/logging ${HOME}/logging
 
-RUN ${HOME}/install.sh
+COPY artifacts /artifacts
+RUN ${HOME}/install.sh && rm -rf /artifacts
 
 WORKDIR ${HOME}
 USER 1000

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,0 +1,3 @@
+- nvr: org.elasticsearch.plugin.prometheus-elasticsearch-prometheus-exporter-5.6.16.0_redhat_1-1
+- nvr: io.fabric8.elasticsearch-openshift-elasticsearch-plugin-5.6.16.2_redhat_1-1
+


### PR DESCRIPTION

4.2 Backport of #1917

https://bugzilla.redhat.com/show_bug.cgi?id=1847542