### PR TITLE
Bug 1840274: Enable ruby from scl if exists

### DIFF
--- a/fluentd/wait_for_es_version.sh
+++ b/fluentd/wait_for_es_version.sh
@@ -1,3 +1,7 @@
 #! /bin/bash
 
+if [ -f /opt/rh/rh-ruby25/enable ] ; then
+  source /opt/rh/rh-ruby25/enable
+fi
+
 ruby wait_for_es_version.rb $@


### PR DESCRIPTION
This PR enables scl ruby if exists in the image.  Ref:
https://bugzilla.redhat.com/show_bug.cgi?id=1840274