### PR TITLE
Cleanup centos7 references

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -21,11 +21,6 @@ ENV HOME=/opt/app-root/src \
 USER 0
 COPY . ${HOME}
 
-#
-# TODO Remove after openshift/release provides ubi7/python36 base image
-#
-RUN ${HOME}/install-centos7-deps.sh
-
 RUN mkdir -p $(dirname "$CURATOR_CONF_LOCATION") && \
     touch ${CURATOR_CONF_LOCATION} && \
     chmod -R u+x ${HOME} && \

--- a/curator/Dockerfile.centos7
+++ b/curator/Dockerfile.centos7
@@ -1,1 +1,0 @@
-Dockerfile

--- a/curator/install-centos7-deps.sh
+++ b/curator/install-centos7-deps.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-if [ -f /etc/centos-release ] ; then
-    echo "Installing temporarily centos 7 deps for CI"
-    yum install -y python3
-    yum clean all
-    ln -sf /usr/bin/python3 /usr/bin/python
-    ln -sf /usr/bin/pip3 /usr/bin/pip
-fi

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -1,1 +1,0 @@
-Dockerfile.origin

--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -1,1 +1,0 @@
-Dockerfile

--- a/kibana/Dockerfile.centos7
+++ b/kibana/Dockerfile.centos7
@@ -1,1 +1,0 @@
-Dockerfile

--- a/test/Dockerfile.centos7
+++ b/test/Dockerfile.centos7
@@ -1,1 +1,0 @@
-Dockerfile


### PR DESCRIPTION
This PR addresses follow-up cleanups for #1892 on the aftermath that the upstream CI is using UBI7 base images (See openshift/release/pull/9136)

/cc @jcantrill 