### PR TITLE
Bug 1835396: Disable http/2 for kubernetes-client

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -13,7 +13,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     INSTANCE_RAM=512G \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.16.2-redhat-1 \
+    OSE_ES_VER=5.6.16.3-redhat-1 \
     PROMETHEUS_EXPORTER_VER=5.6.16.0-redhat-1 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     container=oci
 
-ARG OSE_ES_VER=5.6.16.2-redhat-1
+ARG OSE_ES_VER=5.6.16.3-redhat-1
 ARG OSE_ES_URL
 ARG PROMETHEUS_EXPORTER_VER=5.6.16.0-redhat-1
 ARG PROMETHEUS_EXPORTER_URL

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -14,7 +14,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_VER=1.8.0 \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
-    OSE_ES_VER=5.6.16.2 \
+    OSE_ES_VER=5.6.16.3 \
     PROMETHEUS_EXPORTER_VER=5.6.16.0 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,7 +23,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     RELEASE_STREAM=origin
 
-ARG OSE_ES_VER=5.6.16.2
+ARG OSE_ES_VER=5.6.16.3
 ARG SG_VER=5.6.16-19.3
 
 LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,3 +1,3 @@
 - nvr: org.elasticsearch.plugin.prometheus-elasticsearch-prometheus-exporter-5.6.16.0_redhat_1-1
-- nvr: io.fabric8.elasticsearch-openshift-elasticsearch-plugin-5.6.16.2_redhat_1-1
+- nvr: io.fabric8.elasticsearch-openshift-elasticsearch-plugin-5.6.16.3_redhat_1-1
 


### PR DESCRIPTION
This PR bumps the openshift-elasticsearch-plugin dependency to pull in a change to disable the http/2 client.  This is to resolve an issue on an IBM cluster where the client was not able to communicate with the api server

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1835396