### PR TITLE
Bug 1795897: curator/Dockerfile: don't be picky about where pip installs curator

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR ${HOME}/vendor
 RUN pip install -q $(ls . | grep -v curator) --no-index --find-links . && \
     pip install -q --no-index elasticsearch-curator*  && \
     rm -rf $HOME/vendor && \
-    ls /usr/local/bin/curator
+    command -v curator
 
 WORKDIR ${HOME}
 USER 1001


### PR DESCRIPTION
Apparently in this environment pip doesn't put curator in `/usr/local/bin` - note that the `ls` check was removed in master. This checks that it's in the path somewhere and leaves it at that.