### PR TITLE
removing jq from ES images

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -30,8 +30,7 @@ RUN packages="java-${JAVA_VER}-openjdk-headless \
               hostname \
               openssl \
               zip \
-              unzip \
-              jq" && \
+              unzip" && \
     yum install -y --setopt=tsflags=nodocs ${packages} && \
     rpm -V ${packages} && \
     yum clean all

--- a/elasticsearch/Dockerfile.origin
+++ b/elasticsearch/Dockerfile.origin
@@ -32,8 +32,7 @@ RUN  yum install -y --setopt=tsflags=nodocs --nogpgcheck \
               hostname \
               openssl \
               zip \
-              unzip \
-              jq" && \
+              unzip" && \
      yum install -y --setopt=tsflags=nodocs ${packages} && \
      rpm -V ${packages} && \
      yum clean all

--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -30,8 +30,7 @@ RUN packages="java-${JAVA_VER}-openjdk-headless \
               hostname \
               openssl \
               zip \
-              unzip \
-              jq" && \
+              unzip" && \
     yum install -y --setopt=tsflags=nodocs ${packages} && \
     rpm -V ${packages} && \
     alternatives --set python /usr/bin/python3 &&

--- a/elasticsearch/utils/logging
+++ b/elasticsearch/utils/logging
@@ -69,33 +69,8 @@ get_kibana_index_name() {
     echo .kibana.$(get_hash "$1")
 }
 
-#es_util --query="_cluster/state/master_node?pretty"
-# {
-#  "cluster_name" : "elasticsearch",
-#  "master_node" : "xD9yX9NTRBCqM8YA0Nym6w"
-#}
-#
-#es_util --query="_cluster/state/nodes?pretty"
-# {
-#  "cluster_name" : "elasticsearch",
-#  "nodes" : {
-#    "xD9yX9NTRBCqM8YA0Nym6w" : {
-#      "name" : "elasticsearch-cdm-h5el9dsq-1",
-#      "ephemeral_id" : "JDAmX2H9S5akj4bEcCjZ2w",
-#      "transport_address" : "10.128.2.19:9300",
-#      "attributes" : { }
-#    },
-#    "PWJlWf-PSvKMYy5J5Khacg" : {
-#      "name" : "elasticsearch-cdm-h5el9dsq-2",
-#      "ephemeral_id" : "zWCXff-eQwi2YLMpZ9qbqA",
-#      "transport_address" : "10.131.0.17:9300",
-#      "attributes" : { }
-#    }
-#  }
-#}
 get_master_node() {
-    local master=$(es_util --query="_cluster/state/master_node?pretty" | jq -r .master_node)
-    echo $(es_util --query="_cluster/state/nodes?pretty" | jq -r .nodes[\"${master}\"].name)
+    echo $(es_util --query="_cat/master?h=node")
 }
 
 check_index_exists() {

--- a/hack/build-component-image.sh
+++ b/hack/build-component-image.sh
@@ -6,7 +6,7 @@ dir=$1
 fullimagename=$2
 
 tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin-"}"
-docker_suffix='.centos7'
+docker_suffix='.origin'
 
 if [ "${RELEASE_STREAM:-}" = 'prod' ] ; then
   docker_suffix=''


### PR DESCRIPTION
follow up from https://github.com/openshift/origin-aggregated-logging/pull/1893#discussion_r430913185

also fixes `hack/build-component-images.sh`