### PR TITLE
Bug 1868416: downstream elasticsearch version marked as SNAPSHOT

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -50,7 +50,8 @@ COPY utils/** /usr/local/bin/
 ARG PROMETHEUS_EXPORTER_URL=${MAVEN_REPO_URL}org/elasticsearch/plugin/prometheus/prometheus-exporter/${PROMETHEUS_EXPORTER_VER}/prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
 ARG OPENDISTRO_URL=${MAVEN_REPO_URL}com/amazon/opendistroforelasticsearch/opendistro_security/${OPENDISTRO_VER}/opendistro_security-${OPENDISTRO_VER}.zip
 
-RUN ${HOME}/install.sh && rm -rf /artifacts
+RUN ${HOME}/install.sh && rm -rf /artifacts && \
+    mv ${ES_HOME}/lib/elasticsearch-${ES_VER}.jar ${ES_HOME}/lib/elasticsearch-$(echo $ES_VER | cut -d'.' -f1-3).jar
 
 WORKDIR ${HOME}
 USER 1000


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1868416

With this PR version line:
```
$ oc logs -c elasticsearch elasticsearch-cdm-j07dr97n-1-568f57c889-x59hb | grep version
[2020-08-18T22:29:26,001][INFO ][o.e.n.Node               ] [elasticsearch-cdm-j07dr97n-1] version[6.8.1], pid[1], build[oss/zip/afa2809/2019-11-21T03:59:47.627424Z], OS[Linux/4.18.0-147.8.1.el8_1.x86_64/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_262/25.262-b10]
```

Within the Elasticsearch code there is a check whether or not the library used matches the naming convention
`file:/*elasticsearch-{maj,min,rev}.jar`
for downstream our jar file also had `.redhat-6` so it would never match this file pattern and since we did not have a specific system variable set we were defaulted to be `isSnapshot = true`.

This also prevented our build hash and build date from being correctly pulled from our jar manifest and would show up as
```
[oss/zip/Unknown/Unknown]
```
they now show up as 
```
[oss/zip/afa2809/2019-11-21T03:59:47.627424Z]
```