### PR TITLE
Bug 1877906: remove unwanted flag "--setopt=tsflags=nodocs"

### DIFF
--- a/elasticsearch/Dockerfile.origin
+++ b/elasticsearch/Dockerfile.origin
@@ -25,7 +25,7 @@ ENV ES_PATH_CONF=/etc/elasticsearch/ \
 
 ARG MAVEN_REPO_URL=https://repo1.maven.org/maven2/
 
-RUN  yum install -y --setopt=tsflags=nodocs --nogpgcheck \
+RUN  yum install -y --nogpgcheck \
          https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
      packages="java-${JAVA_VER}-openjdk-headless \
               python36 python3-pyyaml  \
@@ -33,7 +33,7 @@ RUN  yum install -y --setopt=tsflags=nodocs --nogpgcheck \
               openssl \
               zip \
               unzip" && \
-     yum install -y --setopt=tsflags=nodocs ${packages} && \
+     yum install -y ${packages} && \
      rpm -V ${packages} && \
      yum clean all
 

--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -31,7 +31,7 @@ RUN packages="java-${JAVA_VER}-openjdk-headless \
               openssl \
               zip \
               unzip" && \
-    yum install -y --setopt=tsflags=nodocs ${packages} && \
+    yum install -y ${packages} && \
     rpm -V ${packages} && \
     alternatives --set python /usr/bin/python3 && \
     yum clean all

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -31,7 +31,7 @@ RUN BUILD_PKGS="make gcc-c++ libffi-devel \
   RUNTIME_PKGS="hostname \
                 bc \
                 iproute" && \
-  yum install -y --setopt=tsflags=nodocs $BUILD_PKGS $RUNTIME_PKGS && \
+  yum install -y $BUILD_PKGS $RUNTIME_PKGS && \
   rpm -V $BUILD_PKGS && \
   rpm -V $RUNTIME_PKGS && \
   yum clean all


### PR DESCRIPTION
From many discussions and references , redhat based system container
images are built using yum's nodocs option, which helps reduce the size
of the image.

The discussions , references and best practices can be found at

https://github.com/CentOS/sig-cloud-instance-images/issues/21

http://docs.projectatomic.io/container-best-practices/

https://github.com/jumanjiman/docker-tsflags/blob/master/Dockerfile

https://bugzilla.redhat.com/show_bug.cgi?id=1512663

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>