### PR TITLE
Bug 1847275: Allow cluster-admin to retrieve metrics

### DIFF
--- a/elasticsearch/sgconfig/roles_mapping.yml
+++ b/elasticsearch/sgconfig/roles_mapping.yml
@@ -25,6 +25,7 @@ sg_role_admin:
 sg_role_prometheus:
   backendroles:
     - 'prometheus'
+    - 'admin_reader'
 
 sg_role_jaeger:
   users:


### PR DESCRIPTION
This PR adds the admin_reader backend role to retrieve metrics

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1847275