### PR TITLE
Bug 1870063: Use sanitized kibana user name for index pattern ACL

### DIFF
--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -142,7 +142,7 @@ project_user:
       '*':
         - READ
       _dls_: "{\"bool\":{\"filter\":{\"script\":{\"script\":{\"lang\":\"painless\",\"params\":{\"param1\":\"${attr.proxy.ns}\"},\"source\":\"String namespace = doc['kubernetes.namespace_name'][0];StringTokenizer st = new StringTokenizer(params.param1,\\\",\\\");while (st.hasMoreTokens()){if (st.nextToken().equalsIgnoreCase(namespace)){return true;}}return false;\"}}}}}"
-    '?kibana_*_${user_name}':
+    '?kibana_*_${attr.proxy.kibanauser}':
       '*':
         - CRUD
 


### PR DESCRIPTION
This PR applies the logic implemented in openshift/elasticsearch-proxy/pull/43 in the OpenDistro configuration.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1870063

/cc @ewolinetz @blockloop