### PR TITLE
Bug 1875487: downgrade fluent-plugin-kubernetes_metadata_filter

### DIFF
--- a/fluentd/Gemfile
+++ b/fluentd/Gemfile
@@ -3,7 +3,7 @@ gem 'fluentd', ENV['FLUENTD_VERSION'], :source=>"https://rubygems.org"
 gem 'elasticsearch-transport'
 gem 'elasticsearch-api'
 gem 'elasticsearch'
-gem 'fluent-plugin-kubernetes_metadata_filter'
+gem 'fluent-plugin-kubernetes_metadata_filter', '2.4.1'
 gem 'fluent-plugin-concat'
 gem 'fluent-plugin-elasticsearch'
 gem 'fluent-plugin-kafka'


### PR DESCRIPTION
- Downgrade fluent-plugin-kubernetes_metadata_filter from version 2.4.2 to version 2.4.1
- #1974

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1875487