### PR TITLE
Fixed Fluentd unit tests on rhel8

### DIFF
--- a/fluentd/lib/syslog_protocol/Gemfile
+++ b/fluentd/lib/syslog_protocol/Gemfile
@@ -1,2 +1,3 @@
 source :rubygems
 gemspec
+gem 'rdoc'

--- a/test/unit/Dockerfile.rhel8
+++ b/test/unit/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder/ubi8.ruby.25
+FROM registry.svc.ci.openshift.org/ocp/builder:ubi8.ruby.25
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
 ENV FLUENTD_VERSION=1.0 \


### PR DESCRIPTION
To fix the tests in https://github.com/openshift/release/pull/10886

```
/fluentd/lib
/fluentd/lib/syslog_protocol /fluentd/lib
rake aborted!
LoadError: cannot load such file -- rdoc/task
/fluentd/lib/syslog_protocol/Rakefile:63:in `require'
/fluentd/lib/syslog_protocol/Rakefile:63:in `<top (required)>'
/fluentd/lib/syslog_protocol/vendor/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `load'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `kernel_load'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:28:in `run'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/cli.rb:424:in `exec'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/cli.rb:27:in `dispatch'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/cli.rb:18:in `start'
/usr/share/gems/gems/bundler-1.16.1/exe/bundle:30:in `block in <top (required)>'
/usr/share/gems/gems/bundler-1.16.1/lib/bundler/friendly_errors.rb:122:in `with_friendly_errors'
/usr/share/gems/gems/bundler-1.16.1/exe/bundle:22:in `<top (required)>'
/opt/app-root/src/bin/bundle:23:in `load'
/opt/app-root/src/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
```

/cc @jcantrill 