### PR TITLE
Bug 1852341: skip nil keys in json filter

### DIFF
--- a/fluentd/lib/filter_parse_json_field/lib/filter_parse_json_field.rb
+++ b/fluentd/lib/filter_parse_json_field/lib/filter_parse_json_field.rb
@@ -60,7 +60,7 @@ module Fluent::Plugin
     def do_merge_json_log(record)
       json_fields.each do |merge_json_log_key|
         if record.has_key?(merge_json_log_key)
-          value = record[merge_json_log_key].strip
+          value = (record[merge_json_log_key] || "").strip
           if value.start_with?('{') && value.end_with?('}')
             begin
               record = JSON.parse(value).merge(record)
@@ -80,7 +80,7 @@ module Fluent::Plugin
     def do_replace_json_log(record)
       json_fields.each do |merge_json_log_key|
         if record.has_key?(merge_json_log_key)
-          value = record[merge_json_log_key].strip
+          value = (record[merge_json_log_key] || "").strip
           if value.start_with?('{') && value.end_with?('}')
             begin
               parsed_value = JSON.parse(value)

--- a/fluentd/lib/filter_parse_json_field/test/filter_parse_json_field_test.rb
+++ b/fluentd/lib/filter_parse_json_field/test/filter_parse_json_field_test.rb
@@ -147,5 +147,16 @@ class ParseJsonFieldFilterTest < Test::Unit::TestCase
       debugit(@driver, 'in test')
       assert_match /\[debug\]: parse_json_field could not parse field \[skip1\] as JSON: value \[\{"bogusvalue\}\]/, @logs[0]
     end
+    test 'fallback if given field is nil' do
+      # test that - skip1 is skipped because it has a nil key
+      json_string_val2 = '{"k":{"b":"c"},"l":["e","f"],"m":97,"n":{"i":"j"}}'
+      orig_a_value = 'orig a value'
+      rec = emit_with_tag('tag', {'skip1'=>nil, 'a'=>orig_a_value, 'jsonfield'=>json_string_val2},'
+        merge_json_log true
+        json_fields skip1,jsonfield
+      ')
+      assert_equal({'skip1'=>nil, 'a'=>orig_a_value, 'jsonfield'=>json_string_val2}, rec)
+      debugit(@driver, 'in test')
+    end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1852341

During JSON parsing the code invalidly assumes that any key will
have a non-nil value. This fixes this issue by defaulting to an empty
string

/assign @jcantrill 
/cc @vimalk78 