### PR TITLE
Bug 1873493: reenabling info and warning messages in kibana logs

### DIFF
--- a/kibana/kibana.yml
+++ b/kibana/kibana.yml
@@ -102,7 +102,8 @@ pid.file: ${HOME}/kibana.pid
 #logging.silent: false
 
 # Set the value of this setting to true to suppress all logging output other than error messages.
-logging.quiet: true
+# if this is set to true and enabled we are unable to see warning messages such as ones indicating the migration of a kibana index failed
+#logging.quiet: true
 
 # Set the value of this setting to true to log all events, including system usage information
 # and all requests.


### PR DESCRIPTION
Addresses needing to do https://github.com/openshift/elasticsearch-operator/issues/457#issuecomment-673711157 in order to see logs that kibana index migration failed and the steps that can be taken to resolve it.

Would help to diagnose and address issues seen here: https://bugzilla.redhat.com/show_bug.cgi?id=1873493