### PR TITLE
Fix elasticsearch6 rhel8 build

### DIFF
--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -40,6 +40,7 @@ ADD extra-jvm.options install-es.sh ci-env.sh /var/tmp
 
 # Since artifacts does not exist during CI build, include README.MD
 # which will prevent the copy from raising an error.
+RUN mkdir /artifacts
 COPY README.md artifacts/* /artifacts
 RUN /var/tmp/install-es.sh
 


### PR DESCRIPTION
Added a step to create `/artifacts` directory to fix the error
```
STEP 11: COPY README.md artifacts/* /artifacts
error: build error: error building at STEP "COPY README.md artifacts/* /artifacts": destination "/var/lib/containers/storage/overlay/63474113ec6ce7ab6265d0ad5ab54d1e8fdb8549e6d1648179e09eb4d77e8100/merged/artifacts" is not a directory
```
https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/10886/rehearse-10886-pull-ci-openshift-origin-aggregated-logging-master-images/1304088431109869568/build-log.txt