### PR TITLE
Workaround COPY behavior in OCP4

### DIFF
--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -41,7 +41,9 @@ ADD extra-jvm.options install-es.sh ci-env.sh /var/tmp
 # Since artifacts does not exist during CI build, include README.MD
 # which will prevent the copy from raising an error.
 RUN mkdir /artifacts
-COPY README.md artifacts/* /artifacts
+# In an OSBS build, this will COPY artifacts from fetch-artifacts-koji.yaml. In a CI build, it will just
+# copy the README.MD.
+COPY artifacts/* /artifacts
 RUN /var/tmp/install-es.sh
 
 ADD sgconfig/ ${HOME}/sgconfig/

--- a/elasticsearch/artifacts/README.MD
+++ b/elasticsearch/artifacts/README.MD
@@ -1,0 +1,6 @@
+See Dockerfile.rhel8 for where this directory is copied into the
+image during a build. During an OSBS build, this directory will
+be populated from artifacts from within the Red Hat firewall.
+During a CI build, this is directory will not be used at all, but
+the Dockerfile still needs succeed in it's COPY statement.
+


### PR DESCRIPTION
The COPY behavior observed on OCP4 clusters is causing an error:
```
STEP 10: ADD extra-jvm.options install-es.sh ci-env.sh /var/tmp
STEP 11: RUN mkdir /artifacts
STEP 12: COPY README.md artifacts/* /artifacts
error: build error: error building at STEP "COPY README.md artifacts/* /artifacts": no files found matching "/tmp/build/inputs/artifacts/*": no such file or directory
```

This PR aims to ensure that *something* is available for the COPY.