### PR TITLE
Bug 1872080: elasticsearch: fix prod plugin URLs

### DIFF
--- a/elasticsearch/prep-install.prod
+++ b/elasticsearch/prep-install.prod
@@ -2,6 +2,6 @@
 source $(dirname "$0")/ci-env.sh
 
 es_plugins=(
-    ${MAVEN_REPO_URL}io/fabric8/elasticsearch/openshift-elasticsearch-plugin/$OSE_ES_VER/openshift-elasticsearch-plugin-$OSE_ES_VER.zip
-    ${MAVEN_REPO_URL}org/elasticsearch/plugin/prometheus/elasticsearch-prometheus-exporter/$PROMETHEUS_EXPORTER_VER/elasticsearch-prometheus-exporter-$PROMETHEUS_EXPORTER_VER.zip
+    ${MAVEN_REPO_URL}com/amazon/opendistroforelasticsearch/opendistro_security/${OPENDISTRO_VER}/opendistro_security-${OPENDISTRO_VER}.zip
+    ${MAVEN_REPO_URL}org/elasticsearch/plugin/prometheus/prometheus-exporter/$PROMETHEUS_EXPORTER_VER/prometheus-exporter-$PROMETHEUS_EXPORTER_VER.zip
 )


### PR DESCRIPTION
This fixes the downstream builds of logging-elasticsearch6 following the 
unification of CI and downstream Dockerfiles.