### PR TITLE
Fix "elasticsearch version marked as SNAPSHOT" in rhel8

### DIFF
--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -55,7 +55,8 @@ COPY utils/** /usr/local/bin/
 ARG PROMETHEUS_EXPORTER_URL=${MAVEN_REPO_URL}org/elasticsearch/plugin/prometheus/prometheus-exporter/${PROMETHEUS_EXPORTER_VER}/prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
 ARG OPENDISTRO_URL=${MAVEN_REPO_URL}com/amazon/opendistroforelasticsearch/opendistro_security/${OPENDISTRO_VER}/opendistro_security-${OPENDISTRO_VER}.zip
 
-RUN ${HOME}/install.sh && rm -rf /artifacts
+RUN ${HOME}/install.sh && rm -rf /artifacts && \
+    mv ${ES_HOME}/lib/elasticsearch-${ES_VER}.jar ${ES_HOME}/lib/elasticsearch-$(echo $ES_VER | cut -d'.' -f1-3).jar
 
 WORKDIR ${HOME}
 USER 1000


### PR DESCRIPTION
Copy of PR https://github.com/openshift/origin-aggregated-logging/pull/1966
This was fixed in `Dockerfile` but not fixed in `Dockerfile.rhel8`

/cc @ewolinetz 
/assign @jcantrill 