### PR TITLE
Bug 1882232: Enable admin_reader to monitor cluster

### DIFF
--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -149,12 +149,14 @@ project_user:
 admin_user:
   readonly: true
   cluster:
+    - CLUSTER_MONITOR
     - CLUSTER_COMPOSITE_OPS_RO
     - indices:data/write/bulk  #required for being able to let index mappings update... is this required still with multitenancy?
   indices:
     '*':
       '*':
         - READ
+        - INDICES_MONITOR
     '?kibana_*':
       '*':
         - CRUD


### PR DESCRIPTION
This PR allows requests that map to the 'admin_reader' role to access the `_cat` endpoint to monitor the cluster

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1882232