### PR TITLE
Update bundler version 1.17.3 to 2.1.4

### DIFF
--- a/fluentd/Gemfile.lock
+++ b/fluentd/Gemfile.lock
@@ -162,4 +162,4 @@ DEPENDENCIES
   uuidtools (= 2.1.5)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/fluentd/lib/remote_syslog_sender/Gemfile.lock
+++ b/fluentd/lib/remote_syslog_sender/Gemfile.lock
@@ -28,4 +28,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/fluentd/lib/syslog_protocol/Gemfile.lock
+++ b/fluentd/lib/syslog_protocol/Gemfile.lock
@@ -18,4 +18,4 @@ DEPENDENCIES
   syslog_protocol!
 
 BUNDLED WITH
-   1.17.2
+   2.1.4


### PR DESCRIPTION
### Description
This PR updates the pinned version of bundler in `fluentd/Gemfile.lock` from `1.17.3` to `2.1.4`. This resolves the current image build failures on UBI8-ruby2.5 base image.

/cc @jcantrill 
/assign @jcantrill 