### PR TITLE
Add USER 0 to test/unit/Dockerfile to fix CI

### DIFF
--- a/test/unit/Dockerfile
+++ b/test/unit/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos/ruby-25-centos7:latest
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
+USER 0
 
 ENV FLUENTD_VERSION=1.0 \
     WORKDIR=/fluentd/lib


### PR DESCRIPTION
This PR:

Updates test/unit/Dockerfile to specify USER 0 to fix CI that is broken when the CI clusters moved to 4.6