### PR TITLE
fix smoke test to use correct operator branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build-images:
 .PHONY: build-images
 
 test:
-	OPERATOR_LOGGING_IMAGE_STREAM=$(OPERATOR_LOGGING_IMAGE_STREAM) ./hack/test-e2e.sh
+	OPERATOR_LOGGING_IMAGE_STREAM=$(OPERATOR_LOGGING_IMAGE_STREAM) MASTER_VERSION=4.6 CLO_BRANCH=release-4.6 EO_BRANCH=release-4.6 ./hack/test-e2e.sh
 .PHONY: test
 
 .PHONY: test-pre-upgrade

--- a/test/unit/Dockerfile
+++ b/test/unit/Dockerfile
@@ -4,14 +4,15 @@ MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 ENV FLUENTD_VERSION=1.0 \
     WORKDIR=/fluentd/lib
 
+USER 0
 ENTRYPOINT /tmp/run.sh
+ENV GEM_HOME=/tmp/vendor
 RUN scl enable rh-ruby25 -- gem install bundler --no-ri --no-doc
 WORKDIR ${WORKDIR}
 COPY test/unit/run.sh /tmp/
 COPY fluentd/lib ${WORKDIR}
 RUN for d in $(ls $WORKDIR) ; do \
     pushd ${d} ; \
-        export GEM_HOME=vendor ; \
         scl enable rh-ruby25 -- bundle install ; \
     popd ; \
     done

--- a/test/unit/Dockerfile.rhel8
+++ b/test/unit/Dockerfile.rhel8
@@ -2,16 +2,17 @@ FROM registry.svc.ci.openshift.org/ocp/builder:ubi8.ruby.25
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
 ENV FLUENTD_VERSION=1.0 \
-    WORKDIR=/fluentd/lib
+    WORKDIR=/tmp/fluentd/lib
 
+USER 0
 ENTRYPOINT /tmp/run.sh
-RUN gem install bundler --no-ri --no-doc
+ENV GEM_HOME=/tmp/vendor
+RUN gem install rake bundler --no-ri --no-doc
 WORKDIR ${WORKDIR}
 COPY test/unit/run.sh /tmp/
 COPY fluentd/lib ${WORKDIR}
 RUN for d in $(ls $WORKDIR) ; do \
     pushd ${d} ; \
-        export GEM_HOME=vendor ; \
         bundle install ; \
     popd ; \
     done

--- a/test/unit/run.sh
+++ b/test/unit/run.sh
@@ -2,7 +2,6 @@
 failed="0"
 for d in $(ls $WORKDIR) ; do
     pushd ${WORKDIR}/${d}
-        export GEM_HOME=vendor
         bundle exec rake test
 	    if [ "$?" != "0" ] ; then
               failed="1"


### PR DESCRIPTION
This PR:
* fixes the smoke job to utilized the correct operator branches for 4.6 release
* backports the fix for https://github.com/openshift/origin-aggregated-logging/pull/2012