### PR TITLE
[release-3.11] Bug 1889385: Fetch the artifact that is used later

### DIFF
--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,2 +1,2 @@
 - nvr: org.elasticsearch.plugin.prometheus-elasticsearch-prometheus-exporter-5.6.16.0_redhat_1-1
-- nvr: io.fabric8.elasticsearch-openshift-elasticsearch-plugin-5.6.16.1_redhat_1-1
+- nvr: io.fabric8.elasticsearch-openshift-elasticsearch-plugin-5.6.16.4_redhat_00001-1


### PR DESCRIPTION
Follow-up of https://github.com/openshift/origin-aggregated-logging/pull/2006

Please note that as of yet, this does not work. Build [io.fabric8.elasticsearch-openshift-elasticsearch-plugin-5.6.16.4-redhat-00001-1](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1369849) does not yet exist in tag `lpc-rhel-7-maven-released`.