### PR TITLE
Add indices:admin/mappings/get permission to READ group

### DIFF
--- a/elasticsearch/sgconfig/action_groups.yml
+++ b/elasticsearch/sgconfig/action_groups.yml
@@ -40,6 +40,7 @@ WRITE:
 READ:
   - "indices:data/read*"
   - "indices:admin/mappings/fields/get*"
+  - "indices:admin/mappings/get"
 
 DELETE:
   - "indices:data/write/delete*"
@@ -68,6 +69,7 @@ GET:
 
 INDEX_ANY_ADMIN:
   - indices:admin/mappings/fields/get*
+  - indices:admin/mappings/get
   - indices:admin/validate/query*
   - indices:admin/get*
   - "indices:data/read/field_stats"

--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -121,13 +121,11 @@ sg_project_operations:
     '?operations?*':
       '*':
         - READ
-        - indices:admin/mappings/fields/get*
         - indices:admin/validate/query*
         - indices:admin/get*
     '*?*?*':
       '*':
         - READ
-        - indices:admin/mappings/fields/get*
         - indices:admin/validate/query*
         - indices:admin/get*
 


### PR DESCRIPTION
### Description

The READ group already has the `indices:admin/mappings/fields/get*` permission but it does not have the generic `indices:admin/mappings/get` rule – and this PR adds it. It also enable cluster admin to pull index mappings in the dev console.

Right now the cluster admin can get mappings of individual index fields:
```
GET /infra-000001/_mapping/field/kubernetes.namespace_name
```

But is unable to get mapping of whole index:
```
GET /infra-000001/_mapping/
```
Instead it yields:
```JSON
{
  "error": {
    "root_cause": [
      {
        "type": "security_exception",
        "reason": "no permissions for [indices:admin/mappings/get] and User [name=kube:admin, roles=[admin_reader], requestedTenant=__user__]"
      }
    ],
    "type": "security_exception",
    "reason": "no permissions for [indices:admin/mappings/get] and User [name=kube:admin, roles=[admin_reader], requestedTenant=__user__]"
  },
  "status": 403
}
```

/cc @ewolinetz 
/assign @jcantrill 