### PR TITLE
Bug 1906765: Allow project users to view root endpoint

### DIFF
--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -134,6 +134,7 @@ project_user:
   readonly: true
   cluster:
     - CLUSTER_COMPOSITE_OPS_RO
+    - MONITOR
     - indices:data/write/bulk  #required for being able to let index mappings update... is this required still with multitenancy?
   indices:
     app:


### PR DESCRIPTION
### Description
This PR grants project_user roles the permission to MONITOR the cluster to see the root endpoint.  This restores the permissions that existed in 4.4 and earlier.

/cherrypick release-4.6

/cc @periklis @blockloop 

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1906765
