### PR TITLE
Bug 1895581: Replace DLS rule script with more performant terms filter

### DIFF
--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -139,7 +139,7 @@ project_user:
     app:
       '*':
         - READ
-      _dls_: "{\"bool\":{\"filter\":{\"script\":{\"script\":{\"lang\":\"painless\",\"params\":{\"param1\":\"${attr.proxy.ns}\"},\"source\":\"String namespace = doc['kubernetes.namespace_name'][0];StringTokenizer st = new StringTokenizer(params.param1,\\\",\\\");while (st.hasMoreTokens()){if (st.nextToken().equalsIgnoreCase(namespace)){return true;}}return false;\"}}}}}"
+      _dls_: '{"bool":{"filter":{"terms":{"kubernetes.namespace_name":[${attr.proxy.ns}]}}}}'
     '?kibana_*_${user_name}':
       '*':
         - CRUD


### PR DESCRIPTION
### Description

Use terms query instead of painless scripting. This is much more performant
and uses a lot less resources.

Relevant ES docs:

- [Bool Query Filter](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-bool-query.html)
- [Terms Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-terms-query.html)

This PR assume that es-proxy provide list of projects in comma-delimited form
where every item is quoted.

Watch for associated PR in https://github.com/openshift/elasticsearch-proxy
before merging.

/cc @vimalk78 
/assign @jcantrill 

/cherry-pick release-4.5

### Links

- Depending on PR(s): https://github.com/openshift/elasticsearch-proxy/pull/68
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1895581
