### PR TITLE
Bug 1908900: enable SCL ruby

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -55,4 +55,4 @@ RUN mkdir -p /etc/fluent/configs.d/{dynamic,user} && \
 
 WORKDIR ${HOME}
 USER 0
-CMD ["sh", "run.sh"]
+CMD ["scl", "enable", "rh-ruby25", "--", "sh", "run.sh"]


### PR DESCRIPTION
### Description
This PR enables scl ruby so the entryprocess can find it

/cc @alanconway 
/assign @periklis 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
https://bugzilla.redhat.com/show_bug.cgi?id=1908900 
