### PR TITLE
fix smoke test to rely on make target to confirm deployment

### DIFF
--- a/openshift/ci-operator/build-image/cr.yaml
+++ b/openshift/ci-operator/build-image/cr.yaml
@@ -7,14 +7,14 @@ spec:
   logStore:
     type: "elasticsearch"
     elasticsearch:
-      nodeCount: 3
+      nodeCount: 1
       storage:
         storageClassName: gp2
         size: 32G
       redundancyPolicy: "ZeroRedundancy"
       resources:
         limits:
-          memory: 2Gi
+          memory: 3Gi
         requests:
           cpu: 100m
           memory: 2Gi


### PR DESCRIPTION
### Description
This PR removes the wait functions and relies on the make targets to confirm successful deployment of the operators.  

cc @vimalk78 @igor-karpukhin 

Side note: the smoke test continued to fail without larger machines.  which I believe to be fixed with  https://github.com/openshift/release/pull/14429/files
