### PR TITLE
Bug 1913952: Reenabling info and warning messages in kibana logs

### DIFF
--- a/kibana/kibana.yml
+++ b/kibana/kibana.yml
@@ -103,7 +103,8 @@ pid.file: ${HOME}/kibana.pid
 #logging.silent: false
 
 # Set the value of this setting to true to suppress all logging output other than error messages.
-logging.quiet: true
+# if this is set to true and enabled we are unable to see warning messages such as ones indicating the migration of a kibana index failed
+#logging.quiet: true
 
 # Set the value of this setting to true to log all events, including system usage information
 # and all requests.


### PR DESCRIPTION
### Description
Manual cherry-pick of #1980 to address bz

Per the [Kibana source code](https://github.com/elastic/kibana/blob/6.8/src/server/saved_objects/migrations/core/migration_coordinator.ts#L26-L34), it is up to the Kibana admin to address issues of migrations manually. This change enables them to know which indices are in question regarding migration failures.

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->

### Links
- Depending on PR(s): https://github.com/openshift/origin-aggregated-logging/pull/1980
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1913952