### PR TITLE
[LOG-334] Setup cgroups path override to enable cgroups metrics

### DIFF
--- a/elasticsearch/run.sh
+++ b/elasticsearch/run.sh
@@ -93,10 +93,13 @@ GC_LOG_LOCATION=/elasticsearch/persistent/${CLUSTER_NAME}/logs/gc.log
 ERR_FILE_LOCATION=/elasticsearch/persistent/${CLUSTER_NAME}/logs/error.log
 
 export ES_JAVA_OPTS="${ES_JAVA_OPTS:-} -XX:HeapDumpPath=$HEAP_DUMP_LOCATION -Xlog:gc*,gc+age=trace,safepoint:file=${GC_LOG_LOCATION}:utctime,pid,tags:filecount=32,filesize=64m -XX:ErrorFile=$ERR_FILE_LOCATION"
-info "ES_JAVA_OPTS: '${ES_JAVA_OPTS}'"
 
 DHE_TMP_KEY_SIZE=${DHE_TMP_KEY_SIZE:-2048}
 export ES_JAVA_OPTS="${ES_JAVA_OPTS:-} -Djdk.tls.ephemeralDHKeySize=$DHE_TMP_KEY_SIZE"
+
+#LOG-334
+export ES_JAVA_OPTS="${ES_JAVA_OPTS:-} -Des.cgroups.hierarchy.override=/"
+info "ES_JAVA_OPTS: '${ES_JAVA_OPTS}'"
 
 if [ ! -d /elasticsearch/persistent/${CLUSTER_NAME}/logs ] ; then
     mkdir -p /elasticsearch/persistent/${CLUSTER_NAME}/logs


### PR DESCRIPTION
### Description
This system property override cgroups path statistics. Currently the statistics are searched according to paths defined in `/proc/self/cgroup` but they are actually not located there.

See <https://issues.redhat.com/browse/LOG-334> for more details.

/cc @jcaianirh 
/assign @ewolinetz 

### Links
- JIRA: [LOG-334](https://issues.redhat.com/browse/LOG-334)
