### PR TITLE
Bug 1918876: Uncommenting server.MaxPayloadBytes setting in the kibana.yml

### DIFF
--- a/kibana/kibana.yml
+++ b/kibana/kibana.yml
@@ -19,7 +19,9 @@
 #server.rewriteBasePath: false
 
 # The maximum payload size in bytes for incoming server requests.
-#server.maxPayloadBytes: 1048576
+# 1048576 is the default value, however with it commented out there was no way
+# for a customer to override it with an env var
+server.maxPayloadBytes: 1048576
 
 # The Kibana server's name.  This is used for display purposes.
 #server.name: "your-hostname"


### PR DESCRIPTION
### Description
Uncommenting server.MaxPayloadBytes setting in the kibana.yml file so that customers can override it with env vars if necessary

/cc @jcantrill 

/cherry-pick release-4.6

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1918876
