### PR TITLE
Bug 1925081: Updating kibana logs to censor use access token and email address

### DIFF
--- a/kibana/kibana.yml
+++ b/kibana/kibana.yml
@@ -106,6 +106,9 @@ pid.file: ${HOME}/kibana.pid
 # if this is set to true and enabled we are unable to see warning messages such as ones indicating the migration of a kibana index failed
 #logging.quiet: true
 
+logging.filter.x-forwarded-access-token: censor
+logging.filter.x-forwarded-email: censor
+
 # Set the value of this setting to true to log all events, including system usage information
 # and all requests.
 #logging.verbose: false


### PR DESCRIPTION
### Description
This censors sensitive information like the user's email address and access token, replacing it with `X`s to look like:
```
{... ,"x-forwarded-access-token":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX","x-forwarded-email":"XXXXXXXXXXXXXXXXXXXXXXXX", ...}
```

We are censoring rather than removing so that if necessary we can verify that the headers are being passed as part of requests.

/cc @blockloop 

/cherry-pick release-4.6

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1925081