### PR TITLE
update base image to registry.ci.openshift.org

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:ubi8.ruby.25 AS builder
+FROM registry.ci.openshift.org/ocp/builder:ubi8.ruby.25 AS builder
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 


### PR DESCRIPTION
### Description
Repository changed from registry.svc.ci.openshift.org to registry.ci.openshift.org

/cc @jcantrill 
/assign @jcantrill 


More info here

https://docs.google.com/document/d/1pWRtk7IbnfPo6cSDsopUMrxS22t3VJ2PuN39MJp9tHM/edit


```
Note (1-26-21): the registry url recently changed from registry.svc.ci.openshift.org to registry.ci.openshift.org, you can get the login cmd from the token/request link above and to visit the console, see https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/ 
Note: Here is a list of useful cluster links: https://docs.ci.openshift.org/docs/getting-started/useful-links/#clusters.
```
