### PR TITLE
Bug 1881445: Fixed 'time' type to be Fluent::EventTime

### DIFF
--- a/fluentd/lib/parser_viaq_host_audit/lib/parser_viaq_host_audit.rb
+++ b/fluentd/lib/parser_viaq_host_audit/lib/parser_viaq_host_audit.rb
@@ -15,7 +15,14 @@ module Fluent
     def parse(text)
       begin
         parsed_line = @audit_parser.parse_audit_line text
-        time = parsed_line.nil? ? Time.now.to_f : DateTime.parse(parsed_line['time']).to_time.to_f
+        
+        if parsed_line.nil?
+          t = Time.now
+          time = Fluent::EventTime.new(t.to_i, t.nsec)
+        else
+          t = DateTime.parse(parsed_line['time']).to_time
+          time = Fluent::EventTime.new(t.to_i, t.nsec)
+        end
 
         yield time, parsed_line
       rescue Fluent::ViaqHostAudit::ViaqHostAuditParserException => e

--- a/fluentd/lib/parser_viaq_host_audit/test/parser_viaq_host_audit_test.rb
+++ b/fluentd/lib/parser_viaq_host_audit/test/parser_viaq_host_audit_test.rb
@@ -25,6 +25,7 @@ class ParserViaqHostAuditTest < Test::Unit::TestCase
         assert_equal('296', record['audit.linux']['record_id'])
         assert_equal("2019-10-24T09:56:31.145999+00:00", record['time'])
         assert_equal(message, record['message'])
+        assert_true(time.instance_of? Fluent::EventTime)
       end
     end
     test 'AVC denial is detected' do
@@ -36,6 +37,7 @@ class ParserViaqHostAuditTest < Test::Unit::TestCase
         assert_equal('233', record['audit.linux']['record_id'])
         assert_equal("2019-10-24T09:56:31.145999+00:00", record['time'])
         assert_equal(message, record['message'])
+        assert_true(time.instance_of? Fluent::EventTime)
       end
     end
   end


### PR DESCRIPTION
### Description

  Copy of fix for Bug 1901505 on release-4.5. 
  Cherrypick of 8e381f0b5c422fdaf10bd797d386d723a1bafe19

  - changed the datatype of 'time'i from float to Fluent::EventTime
  - added assert on type in existing test case

/assign @jcantrill 


### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1881445
