### PR TITLE
Pin msgpack to version 1.3.3 for release 3.11

### DIFF
--- a/fluentd/Dockerfile.centos7
+++ b/fluentd/Dockerfile.centos7
@@ -49,6 +49,7 @@ RUN mkdir -p ${HOME} && mkdir -p /etc/fluent/plugin && \
      'elasticsearch-api:5.0.5' \
      'elasticsearch:5.0.5' \
      'prometheus-client:0.9.0' \
+     'msgpack:1.3.3' \
       fluentd:${FLUENTD_VERSION} \
      'fluent-plugin-elasticsearch:1.17.2' \
      'fluent-plugin-record-modifier:0.6.2' \


### PR DESCRIPTION
### Description
This PR fixes a bug in the Fluentd image build process with release 3.11.

/cc jcantrill
/assign jcantrill

Without this PR I get the following error during the build.
```
....
ERROR:  Error installing fluentd:
	msgpack requires Ruby version >= 2.4.
ERROR:  Error installing fluent-plugin-elasticsearch:
	bundler requires Ruby version >= 2.3.0.
ERROR:  Error installing fluent-plugin-record-modifier:
	bundler requires Ruby version >= 2.3.0.
ERROR:  Error installing fluent-plugin-rewrite-tag-filter:
	msgpack requires Ruby version >= 2.4.
ERROR:  Error installing fluent-plugin-secure-forward:
	bundler requires Ruby version >= 2.3.0.
ERROR:  Error installing fluent-plugin-systemd:
	msgpack requires Ruby version >= 2.4.
ERROR:  Error installing fluent-plugin-viaq_data_model:
	bundler requires Ruby version >= 2.3.0.
ERROR:  Error installing fluent-plugin-remote-syslog:
	bundler requires Ruby version >= 2.3.0.
ERROR:  Error installing fluent-plugin-kubernetes_metadata_filter:
	bundler requires Ruby version >= 2.3.0.
ERROR:  Error installing fluent-plugin-prometheus:
	msgpack requires Ruby version >= 2.4.
...
```
With this PR, image building works again.