### PR TITLE
Fixed typo in out_syslog, TCP & UDP. Global @facilty should be @facility

### DIFF
--- a/fluentd/out_syslog.rb
+++ b/fluentd/out_syslog.rb
@@ -39,7 +39,7 @@ module Fluent
       if remove_tag_prefix = conf['remove_tag_prefix']
           @remove_tag_prefix = Regexp.new('^' + Regexp.escape(remove_tag_prefix))
       end
-      @facilty = conf['facility']
+      @facility = conf['facility']
       @severity = conf['severity']
       @use_record = conf['use_record']
       @payload_key = conf['payload_key']
@@ -97,7 +97,7 @@ module Fluent
           end
         else
           @packet.hostname = hostname
-          @packet.facility = @facilty
+          @packet.facility = @facility
           @packet.severity = @severity
         end
         time = if record['time']

--- a/fluentd/out_syslog_buffered.rb
+++ b/fluentd/out_syslog_buffered.rb
@@ -39,7 +39,7 @@ module Fluent
       if remove_tag_prefix = conf['remove_tag_prefix']
         @remove_tag_prefix = Regexp.new('^' + Regexp.escape(remove_tag_prefix))
       end
-      @facilty = conf['facility']
+      @facility = conf['facility']
       @severity = conf['severity']
       @use_record = conf['use_record']
       @payload_key = conf['payload_key']
@@ -121,7 +121,7 @@ module Fluent
         end
       else
         @packet.hostname = hostname
-        @packet.facility = @facilty
+        @packet.facility = @facility
         @packet.severity = @severity
       end
       time = if record['time']


### PR DESCRIPTION
### Description
Setting `use_record true` will affect the `facility` of you configuration.
If you set it to something like `tag_key systemd.u.SYSLOG_FACILITY` it would set some further facility configurations by it self.
However, if you break the conditional it’ll move to setting `@packet.facility = @facility` which is never set in the first place because the global is called `@facilty`

And if you completely break it by setting an invalid value it’ll also try to set it to `@facility` which again does not exist.
So, `use_record true` only works if you set the `tag_key` to what's defined in the conditional.

Or have I misunderstood this?
