### PR TITLE
Setting python alternatives to python3

### DIFF
--- a/elasticsearch/Dockerfile.origin
+++ b/elasticsearch/Dockerfile.origin
@@ -35,6 +35,7 @@ RUN  yum install -y --nogpgcheck \
               unzip" && \
      yum install -y ${packages} && \
      rpm -V ${packages} && \
+     alternatives --set python /usr/bin/python3 && \
      yum clean all
 
 ADD extra-jvm.options ci-env.sh install-es.sh /var/tmp


### PR DESCRIPTION
Setting the alternatives to python3 so that local elasticsearch images can run correctly. Without this, the image will break down in `es_util_env` because the python command cannot be run. The rhe8 Dockerfile already has this command in it.

/cc @periklis 
/assign @jcantrill 