### PR TITLE
[release-5.0] mainline fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build-images: build-all-images
 .PHONY: build-images
 
 test:
-	OPERATOR_LOGGING_IMAGE_STREAM=$(OPERATOR_LOGGING_IMAGE_STREAM) ./hack/test-e2e.sh
+	OPERATOR_LOGGING_IMAGE_STREAM=$(OPERATOR_LOGGING_IMAGE_STREAM) MASTER_VERSION=5.0 CLO_BRANCH=release-5.0 EO_BRANCH=release-5.0 ./hack/test-e2e.sh
 .PHONY: test
 
 .PHONY: test-pre-upgrade

--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:ubi8.python.36
+FROM registry.ci.openshift.org/ocp/builder:ubi8.python.36
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 

--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:ubi8.ruby.25 AS builder
+FROM registry.ci.openshift.org/ocp/builder:ubi8.ruby.25 AS builder
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -25,19 +25,19 @@ function image_is_ubi() {
   if [ -f $1 ] ; then
     # if $1 is a file, assume a Dockerfile with a FROM - otherwise,
     # it is an image name
-    grep -q "^FROM registry.svc.ci.openshift.org/ocp/[1-9].[0-9][0-9]*" $1
+    grep -q "^FROM registry.ci.openshift.org/ocp/[1-9].[0-9][0-9]*" $1
   else
-    echo "$1" | grep -q "registry.svc.ci.openshift.org/ocp/[1-9].[0-9][0-9]*"
+    echo "$1" | grep -q "registry.ci.openshift.org/ocp/[1-9].[0-9][0-9]*"
   fi
 }
 
 function image_needs_private_repo() {
   # dockerfile is arg $1
   image_is_ubi $1 || \
-    grep -q "^FROM registry.svc.ci.openshift.org/openshift/origin-v4.[0-9][0-9]*:base" $1
+    grep -q "^FROM registry.ci.openshift.org/openshift/origin-v4.[0-9][0-9]*:base" $1
 }
 
-CI_REGISTRY=${CI_REGISTRY:-registry.svc.ci.openshift.org}
+CI_REGISTRY=${CI_REGISTRY:-registry.ci.openshift.org}
 CI_CLUSTER_NAME=${CI_CLUSTER_NAME:-api-ci-openshift-org:443}
 CUSTOM_IMAGE_TAG=${CUSTOM_IMAGE_TAG:-latest}
 

--- a/hack/deploy-logging.sh
+++ b/hack/deploy-logging.sh
@@ -168,29 +168,35 @@ get_cluster_version_maj_min() {
     fi
 }
 
-MASTER_RELEASE_VERSION=${MASTER_RELEASE_VERSION:-4.6}
+MASTER_RELEASE_VERSION=${MASTER_RELEASE_VERSION:-4.7}
 get_cluster_version_maj_min
 # what numeric version does master correspond to?
-MASTER_VERSION=${MASTER_VERSION:-${CLUSTER_MAJ_MIN:-4.6}}
+MASTER_VERSION=${MASTER_VERSION:-${CLUSTER_MAJ_MIN:-4.7}}
 # what namespace to use for operator images?
-EXTERNAL_REGISTRY=${EXTERNAL_REGISTRY:-registry.svc.ci.openshift.org}
+EXTERNAL_REGISTRY=${EXTERNAL_REGISTRY:-registry.ci.openshift.org}
 EXT_REG_IMAGE_NS=${EXT_REG_IMAGE_NS:-origin}
 # for dev purposes, image builds will typically be pushed to this namespace
 OPENSHIFT_BUILD_NAMESPACE=${OPENSHIFT_BUILD_NAMESPACE:-openshift}
 
-CLO_BRANCH="release-${MASTER_VERSION}"
-EO_BRANCH="release-${MASTER_VERSION}"
+LOGGING_IS=${LOGGING_IS:-logging}
+LOGGING_VERSION=${LOGGING_VERSION:-5.0}
+export IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:logging-elasticsearch6}
+export IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:logging-kibana6}
+export IMAGE_LOGGING_CURATOR5=${IMAGE_LOGGING_CURATOR5:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:logging-curator5}
+export IMAGE_LOGGING_FLUENTD=${IMAGE_LOGGING_FLUENTD:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:logging-fluentd}
+export IMAGE_ELASTICSEARCH_PROXY=${IMAGE_ELASTICSEARCH_PROXY:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:elasticsearch-proxy}
+export IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY=${IMAGE_ELASTICSEARCH_OPERATOR_REGISTRY:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:elasticsearch-operator-registry}
+export IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=${IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:cluster-logging-operator-registry}
+export IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-registry.ci.openshift.org/ocp/${MASTER_VERSION}:oauth-proxy}
 
-if [ "${MASTER_VERSION}" == "${MASTER_RELEASE_VERSION}" ]; then
-  CLO_BRANCH="master"
-  EO_BRANCH="master"
-fi
+CLO_BRANCH="${CLO_BRANCH:-master}"
+EO_BRANCH="${EO_BRANCH:-master}"
 
 construct_image_name() {
     local component="$1"
     local tagsuffix="${2:-latest}"
     # if running in CI environment, IMAGE_FORMAT will look like this:
-    # IMAGE_FORMAT=registry.svc.ci.openshift.org/ci-op-xxx/stable:${component}
+    # IMAGE_FORMAT=registry.ci.openshift.org/ci-op-xxx/stable:${component}
     # stable is the imagestream containing the images built for this PR, or
     # otherwise the most recent image
     if [ -n "${IMAGE_FORMAT:-}" ] ; then
@@ -198,7 +204,6 @@ construct_image_name() {
             local match=/stable:
             local replace="/${LOGGING_IMAGE_STREAM}:"
             IMAGE_FORMAT=${IMAGE_FORMAT/$match/$replace}
-
             if [ -n "${LOGGING_IMAGE_STREAM_NS:-}" -a "${LOGGING_IMAGE_STREAM_NS:-}" != 'ocp' ] ; then
                 local ns=$(echo ${IMAGE_FORMAT} | cut -d '/' -f 2)
                 IMAGE_FORMAT=${IMAGE_FORMAT/$ns/$LOGGING_IMAGE_STREAM_NS}
@@ -218,23 +223,19 @@ construct_image_name() {
 update_images_in_clo_yaml() {
     local yamlfile=$1
     local clo_img=${2:-} #unused.  leaving for compatibility
-    local version=${3:-latest}
+    local version=${3:-latest} #unused. leaving for compatibility
     local filearg
     if [ "$yamlfile" = "-" ] ; then
         filearg=""
     else
         filearg="-i $yamlfile"
     fi
-    local es_img=$( construct_image_name logging-elasticsearch6 $version )
-    local k_img=$( construct_image_name logging-kibana6 $version )
-    local c_img=$( construct_image_name logging-curator5 $version )
-    local f_img=$( construct_image_name logging-fluentd $version )
-    local op_img=$( construct_image_name oauth-proxy $version )
-    sed -e "/name: ELASTICSEARCH_IMAGE/,/value:/s,value:.*\$,value: ${es_img}," \
-        -e "/name: KIBANA_IMAGE/,/value:/s,value:.*\$,value: ${k_img}," \
-        -e "/name: CURATOR_IMAGE/,/value:/s,value:.*\$,value: ${c_img}," \
-        -e "/name: FLUENTD_IMAGE/,/value:/s,value:.*\$,value: ${f_img}," \
-        -e "/name: OAUTH_PROXY_IMAGE/,/value:/s,value:.*\$,value: ${op_img}," \
+    sed -e "/name: ELASTICSEARCH_IMAGE/,/value:/s,value:.*\$,value: ${IMAGE_ELASTICSEARCH6}," \
+        -e "/name: KIBANA_IMAGE/,/value:/s,value:.*\$,value: ${IMAGE_LOGGING_KIBANA6}," \
+        -e "/name: CURATOR_IMAGE/,/value:/s,value:.*\$,value: ${IMAGE_LOGGING_CURATOR5}," \
+        -e "/name: FLUENTD_IMAGE/,/value:/s,value:.*\$,value: ${IMAGE_LOGGING_FLUENTD}," \
+        -e "/name: OAUTH_PROXY_IMAGE/,/value:/s,value:.*\$,value: ${IMAGE_OAUTH_PROXY}," \
+        -e "/name: ELASTICSEARCH_PROXY/,/value:/s,value:.*\$,value: ${IMAGE_ELASTICSEARCH_PROXY}," \
         $filearg
 }
 
@@ -339,21 +340,15 @@ deploy_logging_using_olm() {
 deploy_logging_using_clo_make() {
     # edit the deployment manifest - use the images provided by CI or from api.ci registry
     pushd $EO_DIR > /dev/null
-        make elasticsearch-catalog-deploy \
-            IMAGE_ELASTICSEARCH6=$( construct_image_name logging-elasticsearch6 $MASTER_VERSION ) \
-            IMAGE_ELASTICSEARCH_PROXY=$( construct_image_name elasticsearch-proxy $MASTER_VERSION ) \
-            IMAGE_LOGGING_KIBANA6=$( construct_image_name logging-kibana6 $MASTER_VERSION ) \
-            IMAGE_OAUTH_PROXY=$( construct_image_name oauth-proxy $MASTER_VERSION )
+        make elasticsearch-catalog-deploy
         make elasticsearch-operator-install
     popd > /dev/null
     pushd $CLO_DIR > /dev/null
-        update_images_in_clo_yaml ./manifests/${MASTER_VERSION}/cluster-logging.*.clusterserviceversion.yaml 
-        make cluster-logging-catalog-deploy \
-            IMAGE_LOGGING_CURATOR5=$( construct_image_name logging-curator5 $MASTER_VERSION ) \
-            IMAGE_LOGGING_FLUENTD=$( construct_image_name logging-fluentd $MASTER_VERSION )
+        make cluster-logging-catalog-deploy
         make cluster-logging-operator-install
     popd > /dev/null
 }
+
 
 disable_cvo() {
     local cvopod=$( oc -n openshift-cluster-version get pods | awk '/^cluster-version-operator-.* Running / {print $1}' ) || :
@@ -427,18 +422,20 @@ if [ "${LOGGING_DEPLOY_MODE:-install}" = install ] ; then
     pushd $GOPATH/src/github.com/openshift
         if [ ! -d cluster-logging-operator ] ; then
             git clone https://github.com/openshift/cluster-logging-operator
+            pushd cluster-logging-operator
+             git checkout ${CLO_BRANCH}
+            popd
         fi
         if [ ! -d elasticsearch-operator ] ; then
             git clone https://github.com/openshift/elasticsearch-operator
+            pushd elasticsearch-operator
+              git checkout ${EO_BRANCH}
+            popd
         fi
     popd
-    # get clo version from manifests directory
-    CLO_MANIFEST_VER=$( get_latest_ver_from_manifest_dir $CLO_DIR/manifests )
 
-    # get eo version from manifests directory
-    EO_MANIFEST_VER=$( get_latest_ver_from_manifest_dir $EO_DIR/manifests )
     deploy_logging_using_clo_make
-    
+
     wait_func() {
         oc -n $ESO_NS get pods 2> /dev/null | grep -q 'elasticsearch-operator.*Running' && \
         oc -n $LOGGING_NS get pods 2> /dev/null | grep -q 'cluster-logging-operator.*Running'

--- a/kibana/Dockerfile.rhel8
+++ b/kibana/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:ubi8.nodejs.10 AS build
+FROM registry.ci.openshift.org/ocp/builder:ubi8.nodejs.10 AS build
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 

--- a/test/eventrouter.sh
+++ b/test/eventrouter.sh
@@ -5,7 +5,7 @@
 source "$(dirname "${BASH_SOURCE[0]}" )/../hack/lib/init.sh"
 source "${OS_O_A_L_DIR}/hack/testing/util.sh"
 
-EXTERNAL_REGISTRY=${EXTERNAL_REGISTRY:-registry.svc.ci.openshift.org}
+EXTERNAL_REGISTRY=${EXTERNAL_REGISTRY:-registry.ci.openshift.org}
 EXT_REG_IMAGE_NS=${EXT_REG_IMAGE_NS:-origin}
 MASTER_VERSION=${MASTER_VERSION:-4.3}
 get_eventrouter_image() {

--- a/test/unit/Dockerfile.rhel8
+++ b/test/unit/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:ubi8.ruby.25
+FROM registry.ci.openshift.org/ocp/builder:ubi8.ruby.25
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
 ENV FLUENTD_VERSION=1.0 \


### PR DESCRIPTION
### Description
These are cherry-picked commits from the master branch that separate version numbering of Logging from OpenShift and switch to registry.ci.openshift.org as the CI images registry. Intended to fix CI tests on the release-5.0 branch.

It turns out this PR inadvertently covered most of the ground of https://github.com/openshift/origin-aggregated-logging/pull/2075, but the latter didn't fix the smoke test. The smoke test is broken because we try to deploy 5.1 EO and CLO on top of 5.0 everything else, because of https://github.com/syedriko/origin-aggregated-logging/blob/dd20e497fea64cc9ddbfd427f3322975fb6e77d3/hack/deploy-logging.sh#L426 and https://github.com/syedriko/origin-aggregated-logging/blob/dd20e497fea64cc9ddbfd427f3322975fb6e77d3/hack/deploy-logging.sh#L432

/cc @ewolinetz 
/assign @alanconway 

