### PR TITLE
Bug 1933978: Update OD security dependency to resolve kibana index migration issue

### DIFF
--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -24,14 +24,14 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00006 \
+    ES_VER=6.8.1.redhat-00007 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
     PROMETHEUS_EXPORTER_VER=6.8.1.0 \
-    OPENDISTRO_VER=0.10.0.4-redhat-00001 \
+    OPENDISTRO_VER=0.10.1.2-redhat-00006 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
     RECOVER_EXPECTED_NODES=1 \

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,4 +1,3 @@
-- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00006-1
-- nvr: org.elasticsearch.plugin.prometheus-elasticsearch-prometheus-exporter-6.8.1.0_redhat_1-2
-- nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.0.4_redhat_00001-1
+- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00007-1
+- nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.1.2_redhat_00006-1
 


### PR DESCRIPTION
### Description
This PR
* Updates the version of opendistro-security to pull-in a fix that addresses issues related to kibana index migration

/cc @ewolinetz @periklis @vimalk78 


/cherrypick release-5.0
/cherrypick release-5.1

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1933978
