### PR TITLE
removed earlier prometheus exporter nvr

### DIFF
--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,4 +1,3 @@
 - nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00006-1
-- nvr: org.elasticsearch.plugin.prometheus-elasticsearch-prometheus-exporter-6.8.1.0_redhat_1-2
 - nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.0.4_redhat_00001-1
 - nvr: org.elasticsearch.plugin.prometheus-prometheus-exporter-6.8.1.0_redhat_00001-1


### PR DESCRIPTION
### Description
prometheus exporter plugin was recently updated, old nvr is still in the `fetch-artifacts-koji` file

/cc @jcantrill 
/assign @jcantrill 



### Links
