### PR TITLE
LOG-1131: Updating order for kibana index template

### DIFF
--- a/elasticsearch/index_templates/common.settings.kibana.template.json
+++ b/elasticsearch/index_templates/common.settings.kibana.template.json
@@ -1,5 +1,5 @@
 {
-  "order": 0,
+  "order": 5,
   "settings": {
     "index.number_of_replicas": $REPLICA_SHARDS,
     "index.number_of_shards": $PRIMARY_SHARDS


### PR DESCRIPTION
### Description
To not conflict with the order of the index template created by Kibana, which can lead to unpredictable outcomes, we are increasing the order of the index patter than we provide as part of seeding ES.

/cc @lukas-vlcek 

/cherry-pick release-5.0

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1131
