### PR TITLE
LOG-1213: New plugin metric for inbound log data loss at the collector jira ticket log 1032

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -71,6 +71,7 @@ RUN bash -c '. /source.jemalloc; echo jemalloc $JEMALLOC_VER >> /contents'
 
 COPY  ${upstream_code}/vendored_gem_src/ ${HOME}/vendored_gem_src/
 COPY  ${upstream_code}/lib/fluent-plugin-remote_syslog/ ${HOME}/vendored_gem_src/fluent-plugin-remote_syslog/
+COPY  ${upstream_code}/lib/fluent-plugin-collected/ ${HOME}/vendored_gem_src/fluent-plugin-collected/
 COPY  ${upstream_code}/lib/remote_syslog_sender/ ${HOME}/vendored_gem_src/remote_syslog_sender/
 COPY  ${upstream_code}/lib/syslog_protocol/ ${HOME}/vendored_gem_src/syslog_protocol/
 COPY  ${upstream_code}/install-gems.sh ${HOME}/vendored_gem_src/

--- a/fluentd/Dockerfile.in
+++ b/fluentd/Dockerfile.in
@@ -87,6 +87,7 @@ RUN bash -c '. /source.jemalloc; echo jemalloc $JEMALLOC_VER >> /contents'
 
 COPY --from=builder ${upstream_code}/vendored_gem_src/ ${HOME}/vendored_gem_src/
 COPY --from=builder ${upstream_code}/lib/fluent-plugin-remote_syslog/ ${HOME}/vendored_gem_src/fluent-plugin-remote_syslog/
+COPY --from=builder ${upstream_code}/lib/fluent-plugin-collected/ ${HOME}/vendored_gem_src/fluent-plugin-collected/
 COPY --from=builder ${upstream_code}/lib/remote_syslog_sender/ ${HOME}/vendored_gem_src/remote_syslog_sender/
 COPY --from=builder ${upstream_code}/lib/syslog_protocol/ ${HOME}/vendored_gem_src/syslog_protocol/
 COPY --from=builder ${upstream_code}/install-gems.sh ${HOME}/vendored_gem_src/

--- a/fluentd/lib/fluent-plugin-collected/Gemfile
+++ b/fluentd/lib/fluent-plugin-collected/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in fluent-plugin-collected.gemspec
+gemspec

--- a/fluentd/lib/fluent-plugin-collected/LICENSE
+++ b/fluentd/lib/fluent-plugin-collected/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/fluentd/lib/fluent-plugin-collected/README.md
+++ b/fluentd/lib/fluent-plugin-collected/README.md
@@ -1,0 +1,91 @@
+# fluent-plugin-collected, a plugin for publishing collected_bytes_total metric via prometheus
+
+
+## Requirements
+
+| fluent-plugin-collected | fluentd    | ruby   |
+|--------------------------|------------|--------|
+| 1.x.y                    | >= v0.14.8 | >= 2.1 |
+| 0.x.y                    | >= v0.12.0 | >= 1.9 |
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'fluent-plugin-collected'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install fluent-plugin-collected
+
+## Usage
+
+fluentd-plugin-collected includes 1 new plugin.
+
+- `collected_tail_monitor` input plugin
+
+See [sample configuration]
+  @type collected_tail_monitor
+  <metric>
+    name log_collected_bytes_total
+    type counter
+    desc Total bytes collected from file
+    <labels>
+      tag ${tag}
+      hostname ${hostname}
+    </labels>
+  </metric>
+
+### collected_tail_monitor plugin as input plugin
+
+You have to configure this plugin to expose metrics collected by other Prometheus plugins.
+This plugin provides a metrics HTTP endpoint to be scraped by a Prometheus server on 24231/tcp(default).
+With following configuration, you can access http://localhost:24231/metrics on a server where fluentd running.
+
+```
+<source>
+  @type collected_tail_monitor
+  <labels>
+    host ${hostname}
+  </labels>
+</source>
+```
+
+More configuration parameters:
+
+- `bind`: binding interface (default: '0.0.0.0')
+- `port`: listen port (default: 24231)
+- `metrics_path`: metrics HTTP endpoint (default: /metrics)
+- `aggregated_metrics_path`: metrics HTTP endpoint (default: /aggregated_metrics)
+
+When using multiple workers, each worker binds to port + `fluent_worker_id`.
+To scrape metrics from all workers at once, you can access http://localhost:24231/aggregated_metrics.
+
+
+
+#### Exposed metrics
+
+- `log_collected_bytes_total`
+    - collected total bytes for a given log file
+
+Default labels:
+
+- `plugin_id`: a value set for a plugin in configuration.
+- `type`: plugin name. 
+- `path`: file path
+- `namespace: namespace`
+- `podname`: pod name`
+- `containername: container name`
+
+
+Start fluentd with sample configuration. It listens on 24231.
+
+```
+$ bundle exec fluentd -c misc/fluentd_sample.conf -v
+```

--- a/fluentd/lib/fluent-plugin-collected/Rakefile
+++ b/fluentd/lib/fluent-plugin-collected/Rakefile
@@ -1,0 +1,10 @@
+require "bundler/gem_tasks"
+
+require 'rake/testtask'
+Rake::TestTask.new(:test) do |test|
+  test.libs << "lib" << "test"
+  test.pattern = "test/plugin/*.rb"
+  test.verbose = true
+end
+
+task :default => :test

--- a/fluentd/lib/fluent-plugin-collected/fluent-plugin-collected.gemspec
+++ b/fluentd/lib/fluent-plugin-collected/fluent-plugin-collected.gemspec
@@ -1,0 +1,24 @@
+Gem::Specification.new do |spec|
+  spec.name          = "fluent-plugin-collected"
+  spec.version       = "1.0.0"
+  spec.authors       = ["RedHat"]
+  spec.email         = ["team-logging@redhat.com"]
+  spec.homepage      = "https://github.com/openshift/origin-aggregated-logging/tree/master/fluentd/lib/fluent-plugin-collected"
+  spec.summary       = %q{A fluent plugin that collects metrics on total bytes collected by fluentd.}
+  spec.description   = %q{A fluent plugin that collects metrics on total bytes collected by fluentd and exposes that for Prometheus.}
+  spec.license       = "Apache-2.0"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "fluentd", ">= 0.14.20", "< 2"
+  spec.add_dependency "prometheus-client", "< 0.10"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "test-unit", "~> 3.0"
+  spec.add_development_dependency "test-unit-rr", "~> 1.0"
+  spec.add_development_dependency "fluent-plugin-prometheus", "~> 1.8.5"
+
+
+end

--- a/fluentd/lib/fluent-plugin-collected/lib/fluent/plugin/in_collected_tail_monitor.rb
+++ b/fluentd/lib/fluent-plugin-collected/lib/fluent/plugin/in_collected_tail_monitor.rb
@@ -1,0 +1,146 @@
+require 'fluent/plugin/input'
+require 'fluent/plugin/in_monitor_agent'
+require 'fluent/plugin/prometheus'
+
+module Fluent::Plugin
+  # Collect log_collected_bytes_total metric from in_tail plugin.
+  class CollectedTailMonitorInput < Fluent::Plugin::Input
+    Fluent::Plugin.register_input('collected_tail_monitor', self)
+    include Fluent::Plugin::PrometheusLabelParser
+
+    helpers :timer
+
+    #ideally interval must be rotatewait > 0 ? rotatewait/2 : 1.0 
+    #and if interval >= rotate_wait we should log a warning. 
+    #For rotatewait = 5 sec, interval can be set to 2 sec
+
+
+    config_param :interval, :time, default: 2
+    attr_reader :registry
+
+    MONITOR_IVARS = [
+      :tails,
+    ]
+
+    def initialize
+      super
+      @registry = ::Prometheus::Client.registry
+      # As per k8 regex for container logfile symlink ref :  
+      # https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/blob/master/lib/fluent/plugin/filter_kubernetes_metadata.rb#L56
+
+      @tag_to_kubernetes_filename_regexp_compiled = Regexp.new('var.log.containers.(?<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$')
+
+    end
+
+    def multi_workers_ready?
+      true
+    end
+
+    def configure(conf)
+      super
+      hostname = Socket.gethostname
+      expander_builder = Fluent::Plugin::Prometheus.placeholder_expander(log)
+      expander = expander_builder.build({ 'hostname' => hostname, 'worker_id' => fluentd_worker_id })
+      @base_labels = parse_labels_elements(conf)
+      @base_labels.each do |key, value|
+        unless value.is_a?(String)
+          raise Fluent::ConfigError, "record accessor syntax is not available in collected_tail_monitor"
+        end
+        @base_labels[key] = expander.expand(value)
+      end
+
+      if defined?(Fluent::Plugin) && defined?(Fluent::Plugin::MonitorAgentInput)
+        # from v0.14.6
+        @monitor_agent = Fluent::Plugin::MonitorAgentInput.new
+      else
+        @monitor_agent = Fluent::MonitorAgentInput.new
+      end
+    end
+
+    def start
+      super
+
+      @metrics = {
+        total_bytes_collected: get_counter(
+          :log_collected_bytes_total,
+          'Total bytes collected from file.'),
+      }
+      timer_execute(:in_collected_tail_monitor, @interval, &method(:update_monitor_info))
+    end
+
+
+    def update_monitor_info
+      opts = {
+        ivars: MONITOR_IVARS,
+      }
+
+     agent_info = @monitor_agent.plugins_info_all(opts).select do |info|
+        info['type'] == 'tail'.freeze
+     end
+      agent_info.each do |info|
+        tails = info['instance_variables'][:tails]
+        next if tails.nil?
+
+        tails.clone.each do |_, watcher|
+          # Access to internal variable of internal class...
+          # Very fragile implementation, borrowed from the standard prometheus_tail_monitor
+          pe = watcher.instance_variable_get(:@pe)
+          label = labels(info, watcher.path)
+
+          # Compare pos/inode with the last time we saw this tail
+          old_pos = pe.instance_variable_get(:@_old_pos) || 0.0
+          pe.instance_variable_set(:@_old_pos, pe.read_pos)
+          old_inode = pe.instance_variable_get(:@_old_inode)
+          pe.instance_variable_set(:@_old_inode, pe.read_inode)
+          if pe.read_inode == old_inode && pe.read_pos >= old_pos
+            # Same file, has not been truncated since last we looked. Add the delta.
+            @log.debug "delta bytes #{pe.read_pos}  #{old_pos}"
+            @metrics[:total_bytes_collected].increment(label, pe.read_pos - old_pos)
+          else
+            # Changed file or truncated the existing file. Add the initial content.
+            @log.debug "delta bytes #{pe.read_pos}"
+            @metrics[:total_bytes_collected].increment(label, pe.read_pos)
+          end
+        end
+      end
+    end
+
+    def labels(plugin_info, path)
+      #taking out dirname and .log from the full pathname e.g. /var/log/containers/xxx.log --> xxx
+      #k8 regexp for parsing container generated logfile pathname into namespace, podname, containername
+      path_match_data = path.match(@tag_to_kubernetes_filename_regexp_compiled)
+      if path_match_data
+        podname = path_match_data['pod_name'],
+        namespace = path_match_data['namespace'],
+        containername = path_match_data['container_name'],
+        dockerid = path_match_data['docker_id']
+
+        @log.debug "path #{path}, namespace #{namespace}, podname #{podname},containername #{containername}"
+
+        @base_labels.merge(
+        plugin_id: plugin_info["plugin_id"],
+        type: plugin_info["type"],
+        path: path,
+        namespace: namespace,
+        podname: podname,
+        containername: containername,
+      )
+      else
+        @base_labels.merge(
+        plugin_id: plugin_info["plugin_id"],
+        type: plugin_info["type"],
+        path: path,
+        )
+      end
+    end
+
+    def get_counter(name, docstring)
+      if @registry.exist?(name)
+        @registry.get(name)
+      else
+        @registry.counter(name, docstring)
+      end
+    end
+
+  end
+end

--- a/fluentd/lib/fluent-plugin-collected/test/plugin/test_in_collected_tail_monitor.rb
+++ b/fluentd/lib/fluent-plugin-collected/test/plugin/test_in_collected_tail_monitor.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+require "fluent/plugin/in_collected_tail_monitor"
+
+class CollectedTailMonitorInputTest < Test::Unit::TestCase
+  include Fluent
+
+  def setup
+    Fluent::Test.setup
+  end
+
+  MONITOR_CONFIG = %[
+  @type collected_tail_monitor
+  <metric>
+    name log_collected_bytes_total
+    type counter
+    desc Total bytes collected from file
+    <labels>
+      tag ${tag}
+      hostname ${hostname}
+    </labels>
+  </metric>
+]
+
+  INVALID_MONITOR_CONFIG = %[
+  @type collected_tail_monitor
+
+  <labels>
+    host ${hostname}
+    foo bar
+    invalid_use1 $.foo.bar
+    invalid_use2 $[0][1]
+  </labels>
+  ]
+
+  def create_driver(conf = MONITOR_CONFIG)
+    Fluent::Test::Driver::Input.new(Fluent::Plugin::CollectedTailMonitorInput).configure(conf)
+  end
+
+  def test_configure
+    d = create_driver(MONITOR_CONFIG)
+  end
+
+  def test_invalid_configure
+      assert_raise(Fluent::ConfigError) {
+        d = create_driver(INVALID_MONITOR_CONFIG)
+      }
+  end
+
+
+end

--- a/fluentd/lib/fluent-plugin-collected/test/test_helper.rb
+++ b/fluentd/lib/fluent-plugin-collected/test/test_helper.rb
@@ -1,0 +1,10 @@
+require 'bundler/setup'
+require 'test/unit'
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+
+require "fluent/test"
+require 'fluent/test/driver/input'
+
+require 'test/unit/rr'

--- a/hack/build-component-image.sh
+++ b/hack/build-component-image.sh
@@ -33,4 +33,4 @@ if [ "$dir" = "elasticsearch" ] ; then
   buildargs="--build-arg OPENSHIFT_CI=true"
 fi
 
-podman build $buildargs -f $dfpath -t "$fullimagename" $dir
+podman --cgroup-manager=cgroupfs build $buildargs -f $dfpath -t "$fullimagename" $dir


### PR DESCRIPTION
Description

Currently plugin implementations - fluentd/lib/fluent/plugin/in_tail.rb, and fluent-plugin-prometheus/lib/fluent/plugin/in_prometheus_tail_monitor.rb  don't support publishing of inbound logloss - i.e. difference between total bytes written to disk (logfile) and total bytes collected or read by fluentd. This PR proposes a new fluent plugin to publish total bytes collected to disk.  This is done to avoid any changes required in in_tail.rb and fluent-plugin-prometheus/lib/fluent/plugin/in_prometheus_tail_monitor.rb.  Note total bytes logged will get published by a separate go file watcher PR:  https://github.com/openshift/cluster-logging-operator/pull/979

log_collected_bytes_total (read or collected by fluentd per container process)

/cc @alanconway @jcantrill
/assign @alanconway

/cherry-pick

Links

Depending on PR(s):

Bugzilla:

Github issue:

JIRA: https://issues.redhat.com/browse/LOG-1213

Enhancement proposal: many rotations getting missed by fluentd, next enhancement proposal is to get fluentd know about all actual rotations done by CRIO/conmon process by reading extra meta data such as . Based on what rotations fluentd could track and which one got missed computing log-loss as [no-of-rotations-those-missed * maxsizeoflogfile + sum over all tracked rotations by fluentd as [totalbytes_logged_in_disk - totalbytes_collected_from_disk]
