### PR TITLE
Bug 1883902: Updating kibana Dockerfile.rhel8 being out of sync

### DIFF
--- a/kibana/Dockerfile.rhel8
+++ b/kibana/Dockerfile.rhel8
@@ -20,6 +20,7 @@ USER 0
 
 COPY vendored_tar_src/kibana-oss-6.8.1 ${HOME}/
 COPY vendored_tar_src/opendistro_security_kibana_plugin-0.10.0.4/ ${HOME}/plugins/opendistro_security_kibana_plugin-0.10.0.4/
+COPY vendored_tar_src/handlebars/ ${HOME}/node_modules/handlebars/
 COPY lib/openshift_logging_plugin/ ${HOME}/plugins/openshift_logging_plugin/
 
 RUN chmod -R og+w ${HOME}/


### PR DESCRIPTION
### Description
To address issue where kibana's `Dockerfile.rhel8` is out of sync from `Dockerfile`

/cc @jcantrill 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1883902
