### PR TITLE
fix storage class to match GCP

### DIFF
--- a/openshift/ci-operator/build-image/cr.yaml
+++ b/openshift/ci-operator/build-image/cr.yaml
@@ -9,7 +9,6 @@ spec:
     elasticsearch:
       nodeCount: 3
       storage:
-        storageClassName: gp2
         size: 32G
       redundancyPolicy: "ZeroRedundancy"
       resources:


### PR DESCRIPTION
### Description
This PR fixes the smoke test to use a storage class that is valid for GCP

cc @ewolinetz 