### PR TITLE
LOG-1557: Update kibana base image to nodejs-14

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,7 +1,7 @@
 ### This is a generated file from Dockerfile.in ###
 
 #@follow_tag(openshift-ose-base:ubi8.nodejs.10)
-FROM registry.ci.openshift.org/ocp/builder:ubi8.nodejs.10
+FROM registry.ci.openshift.org/ocp/builder:ubi8.nodejs.14
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION:-}
 ENV OS_GIT_MAJOR=${CI_X_VERSION:-}

--- a/kibana/origin-meta.yaml
+++ b/kibana/origin-meta.yaml
@@ -1,3 +1,3 @@
 from:
 - source: openshift-ose-base\:v(?:[\.0-9\-]*)
-  target: registry.ci.openshift.org/ocp/builder:ubi8.nodejs.10 
+  target: registry.ci.openshift.org/ocp/builder:ubi8.nodejs.14 


### PR DESCRIPTION
### Description
NodeJS-10 image is deprecated, so need to use the LTS NodeJS-14 image.

Updated the base kibana NodeJS image from nodejs-10 to nodejs-14

/cc @jcantrill 
/assign @igor-karpukhin 

/cherry-pick 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
