### PR TITLE
Ingest plugin install path

### DIFF
--- a/elasticsearch/ci-env.sh
+++ b/elasticsearch/ci-env.sh
@@ -4,7 +4,7 @@ set -o xtrace
 
 PROMETHEUS_EXPORTER_URL=${PROMETHEUS_EXPORTER_URL:-$MAVEN_REPO_URL/org/elasticsearch/plugin/prometheus/prometheus-exporter/$PROMETHEUS_EXPORTER_VER/prometheus-exporter-$PROMETHEUS_EXPORTER_VER.zip}
 OPENDISTRO_URL=${OPENDISTRO_URL:-$MAVEN_REPO_URL/com/amazon/opendistroforelasticsearch/opendistro_security/$OPENDISTRO_VER/opendistro_security-$OPENDISTRO_VER.zip}
-INGEST_PLUGIN_URL=${INGEST_PLUGIN_URL:-$MAVEN_REPO_URL/org/elasticsearch/ingest/openshift/$INGEST_PLUGIN_VER/openshift-ingest-plugin-$INGEST_PLUGIN_VER.zip}
+INGEST_PLUGIN_URL=${INGEST_PLUGIN_URL:-$MAVEN_REPO_URL/org/elasticsearch/plugin/ingest/openshift-ingest-plugin/$INGEST_PLUGIN_VER/openshift-ingest-plugin-$INGEST_PLUGIN_VER.zip}
 #INGEST_PLUGIN_URL=${INGEST_PLUGIN_URL:-https://github.com/ViaQ/elasticsearch-openshift-ingest-plugin/releases/download/$INGEST_PLUGIN_VER/openshift-ingest-plugin-$INGEST_PLUGIN_VER.zip}
 
 if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then


### PR DESCRIPTION
### Description
Fixes ingest plugin install path for downstream builds.

this is a manual cherry-pick of https://github.com/openshift/origin-aggregated-logging/pull/2144

/cc @periklis 
/assign @igor-karpukhin 

