### PR TITLE
LOG-1071: CloudWatch fluentd plugin posts all logs it forwards to AWS to its own log

### DIFF
--- a/fluentd/aws-sdk-core.source0001.patch
+++ b/fluentd/aws-sdk-core.source0001.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/aws-sdk-core/plugins/logging.rb b/lib/aws-sdk-core/plugins/logging.rb
+index 1680232a9..c91a3a1fb 100644
+--- a/lib/aws-sdk-core/plugins/logging.rb
++++ b/lib/aws-sdk-core/plugins/logging.rb
+@@ -50,7 +50,7 @@ is not set, logging will be disabled.
+         # @param [Response] response
+         # @return [void]
+         def log(config, response)
+-          config.logger.send(config.log_level, format(config, response))
++          config.logger.send(:debug, format(config, response))
+         end
+ 
+         # @param [Configuration] config


### PR DESCRIPTION
### Description

The issue is here: https://github.com/aws/aws-sdk-ruby/blob/92338358970bc776baab082b670c7c5031842402/gems/aws-sdk-core/lib/aws-sdk-core/plugins/logging.rb#L53

This line
```
config.logger.send(config.log_level, format(config, response))
```
always logs at the current log level, so whatever it logs, always ends up in the fluentd's log. There're more details at https://issues.redhat.com/browse/LOG-1071?focusedCommentId=16502229&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16502229

/cc @igor-karpukhin 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1071