### PR TITLE
fix for https://issues.redhat.com/browse/LOG-1647

### DIFF
--- a/fluentd/lib/fluent-plugin-collected/lib/fluent/plugin/in_collected_tail_monitor.rb
+++ b/fluentd/lib/fluent-plugin-collected/lib/fluent/plugin/in_collected_tail_monitor.rb
@@ -114,15 +114,15 @@ module Fluent::Plugin
         namespace = path_match_data['namespace'],
         containername = path_match_data['container_name'],
         dockerid = path_match_data['docker_id']
-
-        @log.debug "path #{path}, namespace #{namespace}, podname #{podname},containername #{containername}"
+        
+        @log.debug "path #{path}, namespace #{namespace}, podname #{podname[0]},containername #{containername}"
 
         @base_labels.merge(
         plugin_id: plugin_info["plugin_id"],
         type: plugin_info["type"],
         path: path,
         namespace: namespace,
-        podname: podname,
+        podname: podname[0],
         containername: containername,
       )
       else
@@ -130,6 +130,9 @@ module Fluent::Plugin
         plugin_id: plugin_info["plugin_id"],
         type: plugin_info["type"],
         path: path,
+        namespace: "notfound",
+        podname: "notfound",
+        containername: "notfound",
         )
       end
     end


### PR DESCRIPTION
### Description
Fixes the below reported issue  **"error_class=Prometheus::Client::LabelSetValidator::InvalidLabelSetError error="labels must have the same signature (keys given: [:hostname, :path, :plugin_id, :type] vs. keys expected: [:containername, :hostname, :namespace, :path, :plugin_id, :podname, :type]"**

/cc @jcantrill 
/assign @jcantrill 


### Links

- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: fix for https://issues.redhat.com/browse/LOG-1647
- Enhancement proposal:
