### PR TITLE
LOG-1680: Update roles in sgconfig

### DIFF
--- a/elasticsearch/sgconfig/action_groups.yml
+++ b/elasticsearch/sgconfig/action_groups.yml
@@ -41,6 +41,7 @@ READ:
   - "indices:data/read*"
   - "indices:admin/mappings/fields/get*"
   - "indices:admin/mappings/get"
+  - "indices:data/read/search"
 
 DELETE:
   - "indices:data/write/delete*"
@@ -96,6 +97,7 @@ INDEX_PROJECT:
 
 METRICS:
   - CLUSTER_MONITOR
+  - SEARCH
 USER_ALL_INDEX_OPS:
   - "indices:data/read/field_caps"
 USER_CLUSTER_OPERATIONS:
@@ -124,6 +126,7 @@ CLUSTER_COMPOSITE_OPS_RO:
   - "indices:data/read/coordinate-msearch*"
   - "indices:data/read/field_caps"
   - "indices:data/read/mget"
+  - "indices:data/read/search"
   - "indices:data/read/msearch"
   - "indices:data/read/mtv"
   - "indices:data/read/scroll*"

--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -40,6 +40,7 @@ sg_role_prometheus:
     '*':
       '*':
         - indices:monitor*
+        - indices:data/read/search
 
 sg_role_fluentd:
   cluster:


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- Update roles in sgconfig to include `SEARCH` for `project_user` and `prometheus`.
- This is done to remove the `ElasticsearchSecurityException` which comes when search request is sent for Metrics.

`org.elasticsearch.ElasticsearchException: Search request failed
Caused by: org.elasticsearch.ElasticsearchSecurityException: no permissions for [indices:data/read/search] and User [name=system:serviceaccount:openshift-monitoring:prometheus-k8s, roles=[project_user, prometheus], requestedTenant=null]`

/cc @lukas-vlcek @igor-karpukhin <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @igor-karpukhin <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-1680