### PR TITLE
LOG-1657: Fixed admin_reader indices permissions

### DIFF
--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -130,7 +130,7 @@ sg_project_operations:
         - indices:admin/validate/query*
         - indices:admin/get*
 
-# To support multi-tenancy. User's access to indices is restricted to indices belonging to the user's projects, enforced by DLS.    
+# To support multi-tenancy. User's access to indices is restricted to indices belonging to the user's projects, enforced by DLS.
 project_user:
   readonly: true
   cluster:
@@ -155,8 +155,7 @@ admin_user:
   indices:
     '*':
       '*':
-        - READ
-        - INDICES_MONITOR
+        - INDICES_ALL
     '?kibana_*':
       '*':
         - CRUD


### PR DESCRIPTION
### Description
This PR allows the admin user to perform any actions on indices and aliases

/cc @jcantrill 
/assign @jcantrill 

/cherry-pick release-5.0
/cherry-pick release-5.1
/cherry-pick release-5.2

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1657
