### PR TITLE
Fix multitenancy check of project users to infra indices

### DIFF
--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -232,7 +232,7 @@ EOF
 function get_test_user_token() {
     local current_project; current_project="$( oc project -q )"
     create_users ${1:-${LOG_ADMIN_USER:-admin}} ${2:-${LOG_ADMIN_PW:-admin}} ${3:-true}
-    oc login --username=${1:-${LOG_ADMIN_USER:-admin}} --password=${2:-${LOG_ADMIN_PW:-admin}} > /dev/null
+    oc login --username="${1:-${LOG_ADMIN_USER:-admin}}" --password="${2:-${LOG_ADMIN_PW:-admin}}" > /dev/null
     test_token="$(oc whoami -t)"
     test_name="$(oc whoami)"
     test_ip="127.0.0.1"

--- a/test/multi_tenancy.sh
+++ b/test/multi_tenancy.sh
@@ -156,14 +156,14 @@ function test_user_has_proper_access() {
         exit 1
     fi
 
-    # verify normal user has no access to .operations
-    os::log::info See if user $user is denied /.operations.*
+    # verify normal user has no access to infra
+    os::log::info See if user $user is denied /infra*
     get_test_user_token $user $pw false
-    nrecs=$( curl_es_pod_from_kibana_with_token $kpod $eshost "/.operations.*/_count" $test_token -XPOST | \
+    nrecs=$( curl_es_pod_from_kibana_with_token $kpod $eshost "/infra*/_count" $test_token -XPOST | \
                  get_count_from_json )
     if ! os::cmd::expect_success "test $nrecs = 0" ; then
-        os::log::error $LOG_NORMAL_USER has improper access to .operations.* indices
-        curl_es_pod_from_kibana_with_token $kpod $eshost "/.operations.*/_count" $test_token -XPOST | python -mjson.tool
+        os::log::error $LOG_NORMAL_USER has improper access to infra* indices
+        curl_es_pod_from_kibana_with_token $kpod $eshost "/infra*/_count" $test_token -XPOST | python -mjson.tool
         exit 1
     fi
 }


### PR DESCRIPTION
### Description
The following change set address a hindsight in checking access for project users to infra indices through Kibana. Project users are not allowed to access these indices. The fix changes the test to use the assert denied access against the new `infra*` indices from the old data model `.operations.*` indices.

/cc @jcantrill 
/assign @jcantrill 
