### PR TITLE
LOG-1494: Added Formatter single_json_value

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -100,6 +100,7 @@ COPY  ${upstream_code}/lib/filter_parse_json_field/lib/*.rb /etc/fluent/plugin/
 COPY  ${upstream_code}/lib/filter_elasticsearch_genid_ext/lib/filter_elasticsearch_genid_ext.rb /etc/fluent/plugin/
 COPY  ${upstream_code}/lib/parser_viaq_host_audit/lib/*.rb /etc/fluent/plugin/
 COPY  ${upstream_code}/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/*.rb /etc/fluent/plugin/
+COPY  ${upstream_code}/lib/formatter-single-json-value/lib/*.rb /etc/fluent/plugin/
 COPY  ${upstream_code}/utils/ /usr/local/bin/
 
 RUN mkdir -p /etc/fluent/configs.d/user && \    

--- a/fluentd/Dockerfile.in
+++ b/fluentd/Dockerfile.in
@@ -116,6 +116,7 @@ COPY --from=builder ${upstream_code}/lib/filter_parse_json_field/lib/*.rb /etc/f
 COPY --from=builder ${upstream_code}/lib/filter_elasticsearch_genid_ext/lib/filter_elasticsearch_genid_ext.rb /etc/fluent/plugin/
 COPY --from=builder ${upstream_code}/lib/parser_viaq_host_audit/lib/*.rb /etc/fluent/plugin/
 COPY --from=builder ${upstream_code}/lib/fluent-plugin-viaq_data_model/lib/fluent/plugin/*.rb /etc/fluent/plugin/
+COPY --from=builder ${upstream_code}/lib/formatter-single-json-value/lib/*.rb /etc/fluent/plugin/
 COPY --from=builder ${upstream_code}/utils/ /usr/local/bin/
 
 RUN mkdir -p /etc/fluent/configs.d/user && \    

--- a/fluentd/lib/formatter-single-json-value/Gemfile
+++ b/fluentd/lib/formatter-single-json-value/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in formatter-single-json-value.gemspec
+gemspec

--- a/fluentd/lib/formatter-single-json-value/LICENSE.txt
+++ b/fluentd/lib/formatter-single-json-value/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 Vimal Kumar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/fluentd/lib/formatter-single-json-value/README.md
+++ b/fluentd/lib/formatter-single-json-value/README.md
@@ -1,0 +1,39 @@
+# Formatter::Single::Json::Value
+
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/formatter/single/json/value`. To experiment with that code, run `bin/console` for an interactive prompt.
+
+TODO: Delete this and the text above, and describe your gem
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'formatter-single-json-value'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install formatter-single-json-value
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/formatter-single-json-value.
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/fluentd/lib/formatter-single-json-value/Rakefile
+++ b/fluentd/lib/formatter-single-json-value/Rakefile
@@ -1,0 +1,11 @@
+#require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+    t.test_files = FileList['test/**/*_test.rb']
+    t.warning = false
+    #t.verbose = true
+end
+desc "Run tests"
+
+task default: :test

--- a/fluentd/lib/formatter-single-json-value/formatter-single-json-value.gemspec
+++ b/fluentd/lib/formatter-single-json-value/formatter-single-json-value.gemspec
@@ -1,0 +1,32 @@
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+
+# can override for testing
+FLUENTD_VERSION = ENV['FLUENTD_VERSION'] || "0.12.0"
+
+Gem::Specification.new do |gem|
+  gem.name          = "formatter-single-json-value"
+  gem.version       = "0.0.1"
+  gem.authors       = ["Vimal Kumar"]
+  gem.email         = ["vimal78@gmail.com"]
+
+  gem.summary       = %q{Formatter to extract a single value as string of json string}
+  gem.description   = %q{Formatter to extract a single value as string of json string}
+  gem.license       = "MIT"
+
+  gem.required_ruby_version = '>= 2.0.0'
+
+  gem.add_runtime_dependency "fluentd", "~> #{FLUENTD_VERSION}"
+
+  gem.add_development_dependency "bundler"
+  gem.add_development_dependency("fluentd", "~> #{FLUENTD_VERSION}")
+  gem.add_development_dependency("rake", ["~> 11.0"])
+  gem.add_development_dependency("rr", ["~> 1.0"])
+  gem.add_development_dependency("test-unit", ["~> 3.2"])
+  gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
+
+
+end
+

--- a/fluentd/lib/formatter-single-json-value/lib/formatter_single_json_value.rb
+++ b/fluentd/lib/formatter-single-json-value/lib/formatter_single_json_value.rb
@@ -1,0 +1,40 @@
+#
+# Fluentd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'fluent/plugin/formatter'
+require 'json'
+
+module Fluent
+  module Plugin
+    class SingleJsonValueFormatter < Formatter
+      Plugin.register_formatter('single_json_value', self)
+
+      config_param :message_key, :string, default: 'message'
+      config_param :add_newline, :bool, default: true
+
+      def format(tag, time, record)
+        m = record[@message_key]
+        if m.is_a?(Hash)
+          text = m.to_json.dup
+        else
+          text = m.to_s.dup
+        end
+        text << "\n" if @add_newline
+        text
+      end
+    end
+  end
+end

--- a/fluentd/lib/formatter-single-json-value/test/formatter_single_json_value_test.rb
+++ b/fluentd/lib/formatter-single-json-value/test/formatter_single_json_value_test.rb
@@ -1,0 +1,50 @@
+require_relative 'test_helper'
+require 'fluent/test/driver/formatter'
+require File.join(File.dirname(__FILE__), '..', 'lib/formatter_single_json_value')
+
+class SingleValueFormatterTest < ::Test::Unit::TestCase
+  def create_driver(conf = "")
+    Fluent::Test::Driver::Formatter.new(Fluent::Plugin::SingleJsonValueFormatter).configure(conf)
+  end
+
+  def test_config_params
+    d = create_driver
+    assert_equal "message", d.instance.message_key
+  end
+
+  def test_config_params_message_key
+    d = create_driver('message_key' => 'foobar')
+    assert_equal "foobar", d.instance.message_key
+  end
+
+  def test_format
+    d = create_driver
+    formatted = d.instance.format('tag', event_time, {'message' => 'awesome'})
+    assert_equal("awesome\n", formatted)
+  end
+
+  def test_format_json
+    d = create_driver
+    formatted = d.instance.format('tag', event_time, {'message' => {'key' => 'value'}})
+    assert_equal("{\"key\":\"value\"}\n", formatted)
+  end
+
+  def test_format_nested_json
+    d = create_driver
+    formatted = d.instance.format('tag', event_time, {'message' => {'nestedkey' => {'key' => 'value'}}})
+    assert_equal("{\"nestedkey\":{\"key\":\"value\"}}\n", formatted)
+  end
+
+  def test_format_without_newline
+    d = create_driver('add_newline' => 'false')
+    formatted = d.instance.format('tag', event_time, {'message' => 'awesome'})
+    assert_equal("awesome", formatted)
+  end
+
+  def test_format_with_message_key
+    d = create_driver('message_key' => 'foobar')
+    formatted = d.instance.format('tag', event_time, {'foobar' => 'foo'})
+
+    assert_equal("foo\n", formatted)
+  end
+end

--- a/fluentd/lib/formatter-single-json-value/test/test_helper.rb
+++ b/fluentd/lib/formatter-single-json-value/test/test_helper.rb
@@ -1,0 +1,7 @@
+require 'serverengine' # or test will throw error missing method windows?
+require "fluent/test"
+require 'test/unit/rr'
+require "fluent/test/helpers"
+require "fluent/test/driver/filter"
+
+Test::Unit::TestCase.include(Fluent::Test::Helpers)


### PR DESCRIPTION
### Description
As part of fix for issue 1494,. this PR adds a new formatter called `single_json_value` formatter, to be used with syslog plugin.

This formatter is similar to `single_value` formatter except that it formats the value of the configured key (default value `message`)  in record to json if the value is a Ruby hash. else it formats to a string.

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
