### PR TITLE
In fluentd-plugin-cloudwatch-logs, added support for passing the ssl_verify_peer flag to the AWS SDK

### DIFF
--- a/fluentd/fluent-plugin-cloudwatch-logs.source0001.patch
+++ b/fluentd/fluent-plugin-cloudwatch-logs.source0001.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/fluent/plugin/out_cloudwatch_logs.rb b/lib/fluent/plugin/out_cloudwatch_logs.rb
+index fb5077919..5a57ba985 100644
+--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
++++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
+@@ -19,6 +19,7 @@ module Fluent::Plugin
+     config_param :aws_sts_session_name, :string, default: 'fluentd'
+     config_param :region, :string, :default => nil
+     config_param :endpoint, :string, :default => nil
++    config_param :ssl_verify_peer, :bool, :default => true
+     config_param :log_group_name, :string, :default => nil
+     config_param :log_stream_name, :string, :default => nil
+     config_param :auto_create_stream, :bool, default: false
+@@ -88,6 +89,7 @@ module Fluent::Plugin
+       options[:log_level] = ({0 => :trace, 1 => :debug, 2 => :info, 3 => :warn, 4 => :error, 5 => :fatal}[log.level] || :info) if log
+       options[:region] = @region if @region
+       options[:endpoint] = @endpoint if @endpoint
++      options[:ssl_verify_peer] = @ssl_verify_peer
+       options[:instance_profile_credentials_retries] = @aws_instance_profile_credentials_retries if @aws_instance_profile_credentials_retries
+ 
+       if @aws_use_sts


### PR DESCRIPTION
### Description
ssl_verify_peer boolean flag is needed for testing the CloudWatch log forwarder against the moto AWS mock server https://github.com/spulec/moto , which by default runs with a self-signed certificate
Not intended for production, so no doc impact.

/cc @jcantrill 
/assign @igor-karpukhin 

### Links
- PR depending on this one: https://github.com/openshift/cluster-logging-operator/pull/1162
- JIRA: https://issues.redhat.com/browse/LOG-1479
- Upstream PR: https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/pull/239
