### PR TITLE
Bug 2002671: Improve logging-dump.sh (backport of LOG-1733 to 3.11)

### DIFF
--- a/hack/README-dump.md
+++ b/hack/README-dump.md
@@ -47,29 +47,35 @@ Examples:
     │   └── <logging-kibana-ops-pod>-kibana-proxy
     ├── es
     │   ├── cluster-es
-    |   │   ├── aliases
-    |   │   ├── health
-    |   │   ├── indices
+    |   │   ├── aliases.cat
+    |   │   ├── health.cat
+    |   │   ├── hot_threads.txt
+    |   │   ├── indices.cat
+    |   │   ├── indices_size.cat
     |   │   ├── latest_documents.json
-    |   │   ├── nodes
-    |   │   ├── nodes_stats
-    |   │   ├── thread_pool    
-    |   │   ├── pending_tasks
-    |   │   ├── recovery
-    |   │   ├── shards
-    |   │   └── unassigned_shards
+    |   │   ├── nodes.cat
+    |   │   ├── nodes_state.json
+    |   │   ├── nodes_stats.json
+    |   │   ├── thread_pool.cat    
+    |   │   ├── pending_tasks.cat      (iff cluster health not green)
+    |   │   ├── recovery.cat           (iff cluster health not green)
+    |   │   ├── shards.cat             (iff cluster health not green)
+    |   │   └── unassigned_shards.cat  (iff cluster health not green)
     │   ├── cluster-es-ops
-    |   │   ├── aliases
-    |   │   ├── health
-    |   │   ├── indices
+    |   │   ├── aliases.cat
+    |   │   ├── health.cat
+    |   │   ├── hot_threads.txt
+    |   │   ├── indices.cat
+    |   │   ├── indices_size.cat
     |   │   ├── latest_documents.json
-    |   │   ├── nodes
-    |   │   ├── nodes_stats
-    |   │   ├── thread_pool
-    |   │   ├── pending_tasks
-    |   │   ├── recovery
-    |   │   ├── shards
-    |   │   └── unassigned_shards
+    |   │   ├── nodes.cat
+    |   │   ├── nodes_state.json
+    |   │   ├── nodes_stats.json
+    |   │   ├── thread_pool.cat
+    |   │   ├── pending_tasks.cat      (iff cluster health not green)
+    |   │   ├── recovery.cat           (iff cluster health not green)
+    |   │   ├── shards.cat             (iff cluster health not green)
+    |   │   └── unassigned_shards.cat  (iff cluster health not green)
     │   ├── logs
     │   │   ├── <logging-es-pod-1>/logging-es_deprecation.log.xz
     │   │   ├── <logging-es-pod-1>/logging-es_indexing_slowlog.log.xz


### PR DESCRIPTION
### Description

Adding new resources:

- Adding [_nodes](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cluster-nodes-info.html)
- Adding [hot_threads](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cluster-nodes-hot-threads.html)
- Adding indices_size log

Extending curl timout to 20 sec:

We are experiencing empty resource logs in must-gather archives. Instead of expected content they only contain message referencing to "timeout error code (28)".

Completing the documentation.

Adding suffix to each type of resource.
- .json is a json content (can be directly processed by jq)
- .cat is output of _cat endpoint (can be processed by awk or sed)
- .txt is non-structural text format

/cc @btaani
/assign @jcantrill 

### Links

- JIRA: https://issues.redhat.com/browse/LOG-1734
- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2002671