### PR TITLE
fix: memory detection for ES on cgroupv2

### DIFF
--- a/elasticsearch/run.sh
+++ b/elasticsearch/run.sh
@@ -51,9 +51,21 @@ if [[ "$CONTAINER_MEM_LIMIT" =~ $regex ]]; then
         warn "Downgrading the CONTAINER_MEM_LIMIT to $(($num / BYTES_PER_MEG))m because ${CONTAINER_MEM_LIMIT} will result in a larger heap then recommended."
     fi
 
+
+    #check cgroup version
+    info "Inspecting cgroup version..."
+    if [ -r "/sys/fs/cgroup/cgroup.controllers" ]; then
+        #cgroup v2
+        info "Detected cgroup v2"
+        mem_file="/sys/fs/cgroup/memory.max"
+    else
+        #cgroup v1
+        info "Detected cgroup v1"
+        mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+    fi
+
     #determine max allowable memory
     info "Inspecting the maximum RAM available..."
-    mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
     if [ -r "${mem_file}" ]; then
         max_mem="$(cat ${mem_file})"
         if [ ${max_mem} -lt ${num} ]; then


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
Elasticsearch pods can not start on systems with cgroup v2 enabled, since its hierarchy is different from cgroup v1 and the memory limit file is at `/sys/fs/cgroup/memory.max` instead of `/sys/fs/cgroup/memory/memory.limit_in_bytes`.

For full description of the bug see this issue: https://github.com/openshift/origin-aggregated-logging/issues/2181

/cc @lukas-vlcek @jcantrill  <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Github issue: Closes https://github.com/openshift/origin-aggregated-logging/issues/2181
