### PR TITLE
Fix license labels to Apache-2.0

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -45,7 +45,7 @@ USER 1001
 CMD ["sh", "run.sh"]
 
 LABEL \
-        License="GPLv2+" \
+        License="Apache-2.0" \
         io.k8s.description="Curator elasticsearch container for elasticsearch deletion/archival" \
         io.k8s.display-name="Curator 5" \
         io.openshift.tags="logging,elk,elasticsearch,curator" \

--- a/curator/Dockerfile.in
+++ b/curator/Dockerfile.in
@@ -58,7 +58,7 @@ USER 1001
 CMD ["sh", "run.sh"]
 
 LABEL \
-        License="GPLv2+" \
+        License="Apache-2.0" \
         io.k8s.description="Curator elasticsearch container for elasticsearch deletion/archival" \
         io.k8s.display-name="Curator 5" \
         io.openshift.tags="logging,elk,elasticsearch,curator" \

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -84,7 +84,7 @@ USER 1000
 CMD ["sh", "/opt/app-root/src/run.sh"]
 
 LABEL \
-        License="GPLv2+" \
+        License="Apache-2.0" \
         io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \
         io.k8s.display-name="Elasticsearch 6" \
         io.openshift.tags="logging,elk,elasticsearch" \

--- a/elasticsearch/Dockerfile.in
+++ b/elasticsearch/Dockerfile.in
@@ -100,7 +100,7 @@ USER 1000
 CMD ["sh", "/opt/app-root/src/run.sh"]
 
 LABEL \
-        License="GPLv2+" \
+        License="Apache-2.0" \
         io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \
         io.k8s.display-name="Elasticsearch 6" \
         io.openshift.tags="logging,elk,elasticsearch" \

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -94,7 +94,7 @@ WORKDIR ${HOME}
 CMD ["sh", "run.sh"]
 
 LABEL \
-        License="GPLv2+" \
+        License="Apache-2.0" \
         io.k8s.description="Fluentd container for collecting of container logs" \
         io.k8s.display-name="Fluentd" \
         io.openshift.tags="logging,elk,fluentd" \

--- a/fluentd/Dockerfile.in
+++ b/fluentd/Dockerfile.in
@@ -110,7 +110,7 @@ WORKDIR ${HOME}
 CMD ["sh", "run.sh"]
 
 LABEL \
-        License="GPLv2+" \
+        License="Apache-2.0" \
         io.k8s.description="Fluentd container for collecting of container logs" \
         io.k8s.display-name="Fluentd" \
         io.openshift.tags="logging,elk,fluentd" \

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR ${HOME}
 CMD ["./run.sh"]
 
 LABEL \
-        License="GPLv2+" \
+        License="Apache-2.0" \
         io.k8s.description="Kibana container for querying Elasticsearch for aggregated logs" \
         io.k8s.display-name="Kibana" \
         io.openshift.tags="logging,elk,kibana" \

--- a/kibana/Dockerfile.in
+++ b/kibana/Dockerfile.in
@@ -63,7 +63,7 @@ WORKDIR ${HOME}
 CMD ["./run.sh"]
 
 LABEL \
-        License="GPLv2+" \
+        License="Apache-2.0" \
         io.k8s.description="Kibana container for querying Elasticsearch for aggregated logs" \
         io.k8s.display-name="Kibana" \
         io.openshift.tags="logging,elk,kibana" \


### PR DESCRIPTION
### Description
This PR syncs the correct license labels from midstream to upstream.

To address: https://issues.redhat.com/browse/LOG-1750

/cc @igor-karpukhin 
/assign @igor-karpukhin 
