### PR TITLE
add delete by query permissions to index-management role

### DIFF
--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -71,6 +71,7 @@ sg_role_curator:
       '*':
         - READ
         - MANAGE
+        - DELETE
 
 sg_role_admin:
   indices:


### PR DESCRIPTION
### Description
Elasticsearch Operator's index management needs permissions to execute delete-by-query.
This PR adds DELETE permissions to `sg-role-curator`, which in turns adds it to the index-management role.

/cc @lukas-vlcek @periklis 
/assign @igor-karpukhin 

### Links
- Depending on PR(s): https://github.com/openshift/elasticsearch-operator/pull/797
