### PR TITLE
Log 1870: Removing deprecated map values

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -60,3 +60,13 @@ Example to find unassigned shards:
 ```
 $ oc exec -c elasticsearch $POD -- shards | grep UNASSIGNED
 ```
+
+## Image Templates
+
+### Updating Openshift Logging Templates
+
+The Logging team directly manages the ViaQ and Kibana templates. To update the ViaQ models, follow the instructions listed in the [elasticsearch-templates](https://github.com/ViaQ/elasticsearch-templates) repository's README. To update the Kibana templates, change the file and create a PR.
+
+### Updating Jaeger Templates
+
+The Jaeger templates are managed by the Jaeger team and can be updated via the same methodology as the Kibana templates.

--- a/elasticsearch/index_templates/common.settings.kibana.template.json
+++ b/elasticsearch/index_templates/common.settings.kibana.template.json
@@ -4,5 +4,5 @@
     "index.number_of_replicas": $REPLICA_SHARDS,
     "index.number_of_shards": $PRIMARY_SHARDS
   },
-  "index_patterns": ".kibana*"
+  "index_patterns": [ ".kibana*" ]
 }

--- a/elasticsearch/index_templates/jaeger-service.json
+++ b/elasticsearch/index_templates/jaeger-service.json
@@ -1,17 +1,13 @@
 {
-  "index_patterns": "*jaeger-service-*",
+  "index_patterns": [ "*jaeger-service-*" ],
   "settings":{
     "index.number_of_shards": $PRIMARY_SHARDS,
     "index.number_of_replicas": $REPLICA_SHARDS,
     "index.mapping.nested_fields.limit":50,
-    "index.requests.cache.enable":true,
-    "index.mapper.dynamic":false
+    "index.requests.cache.enable":true
   },
   "mappings":{
-    "_default_":{
-      "_all":{
-        "enabled":false
-      },
+    "_doc":{
       "dynamic_templates":[
         {
           "span_tags_map":{
@@ -31,9 +27,7 @@
             "path_match":"process.tag.*"
           }
         }
-      ]
-    },
-    "service":{
+      ],
       "properties":{
         "serviceName":{
           "type":"keyword",

--- a/elasticsearch/index_templates/jaeger-span.json
+++ b/elasticsearch/index_templates/jaeger-span.json
@@ -1,17 +1,13 @@
 {
-  "index_patterns": "*jaeger-span-*",
+  "index_patterns": [ "*jaeger-span-*" ],
   "settings":{
     "index.number_of_shards": $PRIMARY_SHARDS,
     "index.number_of_replicas": $REPLICA_SHARDS,
     "index.mapping.nested_fields.limit":50,
-    "index.requests.cache.enable":true,
-    "index.mapper.dynamic":false
+    "index.requests.cache.enable":true
   },
   "mappings":{
-    "_default_":{
-      "_all":{
-        "enabled":false
-      },
+    "_doc":{
       "dynamic_templates":[
         {
           "span_tags_map":{
@@ -31,9 +27,7 @@
             "path_match":"process.tag.*"
           }
         }
-      ]
-    },
-    "span":{
+      ],
       "properties":{
         "traceID":{
           "type":"keyword",


### PR DESCRIPTION
Removes deprecated values from the jaeger file jsons and some formatting. The `elasticsearch_deprecation.log` now looks like this with the current EO:

```
[2021-10-21T18:59:15,295][WARN ][o.e.d.r.a.a.i.RestGetIndicesAction] [elasticsearch-cdm-s2haufij-1] [types removal] The parameter include_type_name should be explicitly specified in get indices requests to prepare for 7.0. In 7.0 include_type_name will default to 'false', which means responses will omit the type name in mapping definitions.
[2021-10-21T18:59:20,379][WARN ][o.e.d.r.a.a.i.RestGetIndexTemplateAction] [elasticsearch-cdm-s2haufij-1] [types removal] The parameter include_type_name should be explicitly specified in get template requests to prepare for 7.0. In 7.0 include_type_name will default to 'false', which means responses will omit the type name in mapping definitions.
[2021-10-21T18:59:24,352][WARN ][o.e.d.r.a.a.i.RestPutIndexTemplateAction] [elasticsearch-cdm-s2haufij-1] [types removal] The parameter include_type_name should be explicitly specified in put template requests to prepare for 7.0. In 7.0 include_type_name will default to 'false', and requests are expected to omit the type name in mapping definitions.
[2021-10-21T18:59:24,372][WARN ][o.e.d.c.j.Joda           ] [elasticsearch-cdm-s2haufij-1] 'y' year should be replaced with 'u'. Use 'y' for year-of-era.; 'Z' time zone offset/id fails when parsing 'Z' for Zulu timezone. Consider using 'X'. Prefix your date format with '8' to use the new specifier.
[2021-10-21T18:59:33,825][WARN ][o.e.d.r.a.a.i.RestRolloverIndexAction] [elasticsearch-cdm-s2haufij-1] [types removal] The parameter include_type_name should be explicitly specified in rollover requests to prepare for 7.0. In 7.0 include_type_name will default to 'false', which means requests must omit the type name in mapping definitions.
```

It should be noted that in ES 7:

>The include_type_name parameter in the index creation, index template, and mapping APIs will default to false. Setting the parameter at all will result in a deprecation warning. 

/cc @lukas-vlcek 
/assign @igor-karpukhin 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1870
