### PR TITLE
Use elasticsearch pnc build with netty 4.1.63.Final

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -21,7 +21,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00007 \
+    ES_VER=6.8.1.redhat-00011 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \

--- a/elasticsearch/Dockerfile.in
+++ b/elasticsearch/Dockerfile.in
@@ -36,7 +36,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00007 \
+    ES_VER=6.8.1.redhat-00011 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,4 +1,4 @@
-- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00007-1
+- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00011-1
 - nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.1.2_redhat_00006-1
 - nvr: org.elasticsearch.plugin.prometheus-prometheus-exporter-6.8.1.1_redhat_00001-1
 - nvr: org.elasticsearch.plugin.ingest-openshift-ingest-plugin-6.8.1.0_redhat_00003-1


### PR DESCRIPTION
### Description
This PR provides a bump of the elasticsearch package to fix the following CVEs:
- https://issues.redhat.com/browse/LOG-1317
- https://issues.redhat.com/browse/LOG-1817
- https://issues.redhat.com/browse/LOG-1818

Requires backport: release-5.0 and release-4.6

/cc @jcantrill 
/assign @jcantrill 
