### PR TITLE
add bulk permissions to sg_role_curator

### DIFF
--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -72,7 +72,8 @@ sg_role_curator:
         - READ
         - MANAGE
         - DELETE
-
+        - "indices:data/write/bulk*"
+        
 sg_role_admin:
   indices:
     '*':


### PR DESCRIPTION
### Description
Elasticsearch Operator's index management needs `bulk` permissions to execute delete-by-query.
This PR adds `"indices:data/write/bulk*"` permissions to sg-role-curator, which in turns adds it to the index-management role.
/cc @lukas-vlcek @periklis 
/assign @igor-karpukhin  

### Links
- Depending on PR(s): https://github.com/openshift/elasticsearch-operator/pull/797
