### PR TITLE
LOG-1927: Remove devel packages from final image (e.g gcc)

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -63,6 +63,8 @@ COPY  ${upstream_code}/*.patch ${HOME}/vendored_gem_src/
 RUN cd ${HOME}/vendored_gem_src/ && ./install-gems.sh && cd / && rm -rf ${HOME}/vendored_gem_src/
 
 RUN BUILD_PKGS="make gcc-c++ libffi-devel \
+                gcc gcc-gdb-plugin cpp \
+                nodejs \
                 autoconf automake libtool m4 \
                 redhat-rpm-config" && \
     yum remove -y $BUILD_PKGS

--- a/fluentd/Dockerfile.in
+++ b/fluentd/Dockerfile.in
@@ -81,6 +81,8 @@ COPY --from=builder ${upstream_code}/*.patch ${HOME}/vendored_gem_src/
 RUN cd ${HOME}/vendored_gem_src/ && ./install-gems.sh && cd / && rm -rf ${HOME}/vendored_gem_src/
 
 RUN BUILD_PKGS="make gcc-c++ libffi-devel \
+                gcc gcc-gdb-plugin cpp \
+                nodejs \
                 autoconf automake libtool m4 \
                 redhat-rpm-config" && \
     yum remove -y $BUILD_PKGS

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,7 +1,7 @@
 ### This is a generated file from Dockerfile.in ###
 
 #@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/ubi8-nodejs-10:latest)
-FROM registry.ci.openshift.org/ocp/builder:ubi8.nodejs.10
+FROM registry.ci.openshift.org/ocp/builder:rhel8.2.els.nodejs.10
 ENV BUILD_VERSION=6.8.1
 ENV SOURCE_GIT_COMMIT=${CI_ORIGIN_AGGREGATED_LOGGING_UPSTREAM_COMMIT:-}
 ENV SOURCE_GIT_URL=${CI_ORIGIN_AGGREGATED_LOGGING_UPSTREAM_URL:-}

--- a/kibana/origin-meta.yaml
+++ b/kibana/origin-meta.yaml
@@ -1,3 +1,3 @@
 from:
 - source: registry-proxy.engineering.redhat.com/rh-osbs/ubi8-nodejs-10:(\d)-(?:[\.0-9\-]*)
-  target: registry.ci.openshift.org/ocp/builder:ubi8.nodejs.10 
+  target: registry.ci.openshift.org/ocp/builder:rhel8.2.els.nodejs.10


### PR DESCRIPTION
### Description
This PR:
* Removes devel packages from fluent image (e.g. gcc, nodejs)

cc @syedriko The Dockerfile.in will need to be copied to midstream files once this merges
cc @vimalk78 

### Links
* https://issues.redhat.com/browse/LOG-1927
