### PR TITLE
LOG-1835: Move elasticsearch files from /etc/elasticsearch to /var/run/elasticsearch

### DIFF
--- a/docs/proposals/generate-jks-certs-on-container-start.md
+++ b/docs/proposals/generate-jks-certs-on-container-start.md
@@ -19,11 +19,11 @@ Elasticsearch is configured such that it will utilize the keystore and truststor
 ### Container Resource Definition:
 Generated client certificates will be mounted as:
 ```
-/etc/elasticsearch/secrets/client-cert/<ALIAS>/tls.{cert,key}
+/var/run/elasticsearch/secrets/client-cert/<ALIAS>/tls.{cert,key}
 ```
 For example:
 ```
-/etc/elasticsearch/secrets/client-cert
+/var/run/elasticsearch/secrets/client-cert
   |- elasticsearch
   |    |- tls.cert
   |    |- tls.key
@@ -44,11 +44,11 @@ For example:
 
 Generated client CAs will be mounted as:
 ```
-/etc/elasticsearch/secrets/client-ca/<ALIAS>/ca.crt
+/var/run/elasticsearch/secrets/client-ca/<ALIAS>/ca.crt
 ```
 For example:
 ```
-/etc/elasticsearch/secrets/client-ca
+/var/run/elasticsearch/secrets/client-ca
   |- elasticsearch
   |    |- ca.crt
   |

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -19,7 +19,7 @@ ARG OPENDISTRO_URL
 ARG OPENSHIFT_CI
 
 
-ENV ES_PATH_CONF=/etc/elasticsearch/ \
+ENV ES_PATH_CONF=/var/run/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
     ES_VER=6.8.1.redhat-00011 \
     HOME=/opt/app-root/src \

--- a/elasticsearch/Dockerfile.in
+++ b/elasticsearch/Dockerfile.in
@@ -34,7 +34,7 @@ ARG OPENDISTRO_URL
 ARG OPENSHIFT_CI
 
 
-ENV ES_PATH_CONF=/etc/elasticsearch/ \
+ENV ES_PATH_CONF=/var/run/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
     ES_VER=6.8.1.redhat-00011 \
     HOME=/opt/app-root/src \

--- a/hack/templates/logging.yml
+++ b/hack/templates/logging.yml
@@ -73,7 +73,7 @@ items:
               name: "transport"
             volumeMounts:
               - name: certs
-                mountPath: /etc/elasticsearch/keys
+                mountPath: /var/run/elasticsearch/keys
                 readOnly: true
               - name: pvc
                 mountPath: /elasticsearch/persistent

--- a/hack/templates/ops-logging.yml
+++ b/hack/templates/ops-logging.yml
@@ -106,7 +106,7 @@ items:
               name: "transport"
             volumeMounts:
               - name: certs
-                mountPath: /etc/elasticsearch/keys
+                mountPath: /var/run/elasticsearch/keys
                 readOnly: true
               - name: pvc
                 mountPath: /elasticsearch
@@ -157,7 +157,7 @@ items:
               name: "transport"
             volumeMounts:
               - name: certs
-                mountPath: /etc/elasticsearch/keys
+                mountPath: /var/run/elasticsearch/keys
                 readOnly: true
               - name: pvc
                 mountPath: /elasticsearch

--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -274,7 +274,7 @@ function curl_es_pod() {
     shift; shift
     local args=( "${@:-}" )
 
-    local secret_dir="/etc/elasticsearch/secret/"
+    local secret_dir="/var/run/elasticsearch/secret/"
     oc -n $LOGGING_NS exec -c elasticsearch "${pod}" -- curl --silent --insecure "${args[@]}" \
                              --key "${secret_dir}admin-key"   \
                              --cert "${secret_dir}admin-cert" \


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- Updates the elasticsearch `ES_PATH_CONF` env variable to store elasticsearch files at `/var/run/elasticsearch`.
- This resolves the issue of copying to /etc because it is generally considered as read-only.
- Original Bug here - https://bugzilla.redhat.com/show_bug.cgi?id=1944313

/cc @Red-GV @igor-karpukhin <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @periklis <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-1835
