### PR TITLE
Bump ES binary to 6.8.1.redhat-00012 to mitigate CVE-2021-44228

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -21,7 +21,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00011 \
+    ES_VER=6.8.1.redhat-00012 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \

--- a/elasticsearch/Dockerfile.in
+++ b/elasticsearch/Dockerfile.in
@@ -36,7 +36,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00011 \
+    ES_VER=6.8.1.redhat-00012 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,4 +1,4 @@
-- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00011-1
+- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00012-1
 - nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.1.2_redhat_00006-1
 - nvr: org.elasticsearch.plugin.prometheus-prometheus-exporter-6.8.1.2_redhat_00001-1
 - nvr: org.elasticsearch.plugin.ingest-openshift-ingest-plugin-6.8.1.0_redhat_00003-1


### PR DESCRIPTION
### Description
This PR provides a fix that references an Elasticsearch binary build with Project Newcastle that includes the following upstream PR: https://github.com/elastic/elasticsearch/pull/81632

It addresses OpenShift Logging releases 5.4.0, 5.3.z, 5.2.z, 5.1.z.

Requires backport for: release-5.0 and release-4.6

/cc @igor-karpukhin @jcantrill 

### Links
- JIRA:
  - https://issues.redhat.com/browse/LOG-2060
  - https://issues.redhat.com/browse/LOG-2059
  - https://issues.redhat.com/browse/LOG-2058
