### PR TITLE
Bump ES binary to 6.8.1.redhat-00012 to mitigate CVE-2021-44228

### DIFF
--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -24,7 +24,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00007 \
+    ES_VER=6.8.1.redhat-00012 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,3 +1,3 @@
-- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00007-1
+- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00012-1
 - nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.1.2_redhat_00006-1
 - nvr: org.elasticsearch.plugin.prometheus-prometheus-exporter-6.8.1.0_redhat_00001-1


### PR DESCRIPTION
### Description
This PR provides a fix that references an Elasticsearch binary build with Project Newcastle that includes the following upstream PR: https://github.com/elastic/elasticsearch/pull/81632

It addresses OpenShift Logging releases 5.0.z
/cc @igor-karpukhin @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2064
