### PR TITLE
Bug 2031028: Bump ES binary to 6.8.1.redhat-00012 to mitigate CVE-2021-44228

### DIFF
--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -24,7 +24,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00007 \
+    ES_VER=6.8.1.redhat-00012 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \


### PR DESCRIPTION
### Description
This PR provides a fix that references an Elasticsearch binary build with Project Newcastle that includes the following upstream PR: https://github.com/elastic/elasticsearch/pull/81632

It addresses OpenShift Logging releases 4.6.z
/cc @igor-karpukhin @jcantrill 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2031028
