### PR TITLE
Bump ES binary to 6.8.1.redhat-00013 to mitigate CVE-2021-45105

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -21,7 +21,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00012 \
+    ES_VER=6.8.1.redhat-00013 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \

--- a/elasticsearch/Dockerfile.in
+++ b/elasticsearch/Dockerfile.in
@@ -36,7 +36,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00012 \
+    ES_VER=6.8.1.redhat-00013 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \

--- a/elasticsearch/ci-env.sh
+++ b/elasticsearch/ci-env.sh
@@ -10,8 +10,8 @@ INGEST_PLUGIN_URL=${INGEST_PLUGIN_URL:-$MAVEN_REPO_URL/org/elasticsearch/plugin/
 if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
     # This flag is set during CI runs. If no ARG was passed in,
     # default to maven.org.
-    export ES_ARCHIVE_URL=https://github.com/openshift/origin-aggregated-logging/releases/download/elasticsearch-oss-$ES_VER/elasticsearch-oss-$ES_VER.zip
-    export OPENDISTRO_URL=https://github.com/openshift/origin-aggregated-logging/releases/download/opendistro_security-$OPENDISTRO_VER/opendistro_security-$OPENDISTRO_VER.zip
+    export ES_ARCHIVE_URL=https://github.com/ViaQ/elasticsearch/releases/download/elasticsearch-oss-$ES_VER/elasticsearch-oss-$ES_VER.zip
+    export OPENDISTRO_URL=https://github.com/ViaQ/security/releases/download/opendistro_security-$OPENDISTRO_VER/opendistro_security-$OPENDISTRO_VER.zip
 
     INGEST_PLUGIN_VER=$(echo $INGEST_PLUGIN_VER | cut -d'-' -f1)
     export INGEST_PLUGIN_URL=https://github.com/ViaQ/elasticsearch-openshift-ingest-plugin/releases/download/$INGEST_PLUGIN_VER/openshift-ingest-plugin-$INGEST_PLUGIN_VER.zip

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,4 +1,4 @@
-- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00012-1
+- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00013-1
 - nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.1.2_redhat_00006-1
 - nvr: org.elasticsearch.plugin.prometheus-prometheus-exporter-6.8.1.2_redhat_00001-1
 - nvr: org.elasticsearch.plugin.ingest-openshift-ingest-plugin-6.8.1.0_redhat_00003-1


### PR DESCRIPTION
### Description
This PR bumps the elasticsarch binary to 6.8.1.redhat-00013 to mitigate CVE-2021-45105

/cc @igor-karpukhin 

### Links
- JIRA:
  - 5.3.z: https://issues.redhat.com/browse/LOG-2080
  - 5.2.z: https://issues.redhat.com/browse/LOG-2081
  - 5.1.z: https://issues.redhat.com/browse/LOG-2082
  - 5.4.0: https://issues.redhat.com/browse/LOG-2086

