### PR TITLE
[release-5.0] Bump ES binary to 6.8.1.redhat-00013 to mitigate CVE-2021-45105

### DIFF
--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -24,7 +24,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00012 \
+    ES_VER=6.8.1.redhat-00013 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \

--- a/elasticsearch/ci-env.sh
+++ b/elasticsearch/ci-env.sh
@@ -8,8 +8,8 @@ OPENDISTRO_URL=${OPENDISTRO_URL:-$MAVEN_REPO_URL/com/amazon/opendistroforelastic
 if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
     # This flag is set during CI runs. If no ARG was passed in,
     # default to maven.org.
-    export ES_ARCHIVE_URL=https://github.com/openshift/origin-aggregated-logging/releases/download/elasticsearch-oss-$ES_VER/elasticsearch-oss-$ES_VER.zip
-    export OPENDISTRO_URL=https://github.com/openshift/origin-aggregated-logging/releases/download/opendistro_security-$OPENDISTRO_VER/opendistro_security-$OPENDISTRO_VER.zip
+    export ES_ARCHIVE_URL=https://github.com/ViaQ/elasticsearch/releases/download/elasticsearch-oss-$ES_VER/elasticsearch-oss-$ES_VER.zip
+    export OPENDISTRO_URL=https://github.com/ViaQ/security/releases/download/opendistro_security-$OPENDISTRO_VER/opendistro_security-$OPENDISTRO_VER.zip
 
     PROMETHEUS_EXPORTER_VER=$(echo $PROMETHEUS_EXPORTER_VER | cut -d'-' -f1)
     export PROMETHEUS_EXPORTER_URL=https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/$PROMETHEUS_EXPORTER_VER/prometheus-exporter-$PROMETHEUS_EXPORTER_VER.zip

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,3 +1,3 @@
-- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00012-1
+- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00013-1
 - nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.1.2_redhat_00006-1
 - nvr: org.elasticsearch.plugin.prometheus-prometheus-exporter-6.8.1.0_redhat_00001-1


### PR DESCRIPTION
### Description
This PR bumps the elasticsarch binary to 6.8.1.redhat-00013 to mitigate CVE-2021-45105

/cc @igor-karpukhin 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2083
