### PR TITLE
LOG-2098 Remove bundler from logging fluentd image

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -66,7 +66,7 @@ RUN BUILD_PKGS="make gcc-c++ libffi-devel \
                 gcc gcc-gdb-plugin cpp \
                 nodejs \
                 autoconf automake libtool m4 \
-                redhat-rpm-config" && \
+                redhat-rpm-config rubygem-bundler" && \
     yum remove -y $BUILD_PKGS
 
 RUN mkdir -p /etc/fluent/plugin

--- a/fluentd/Dockerfile.in
+++ b/fluentd/Dockerfile.in
@@ -84,7 +84,7 @@ RUN BUILD_PKGS="make gcc-c++ libffi-devel \
                 gcc gcc-gdb-plugin cpp \
                 nodejs \
                 autoconf automake libtool m4 \
-                redhat-rpm-config" && \
+                redhat-rpm-config rubygem-bundler" && \
     yum remove -y $BUILD_PKGS
 
 RUN mkdir -p /etc/fluent/plugin


### PR DESCRIPTION
### Description
There is a CVE in bundler version used in fluentd. 
https://access.redhat.com/security/cve/cve-2020-36327

Since we dont need rubygem-bundler to run the fluentd, we can remove this rpm from the final image.

/cc 
/assign @jcantrill 



### Links
- JIRA: https://issues.redhat.com/browse/LOG-2098

