### PR TITLE
Correction to the fix for LOG-1315: place ua-parser-js-1.0.2 under node_modules/ua-parser-js

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -29,7 +29,7 @@ COPY  ${upstream_code}/vendored_tar_src/kibana-oss-6.8.1 ${HOME}/
 COPY  ${upstream_code}/vendored_tar_src/opendistro_security_kibana_plugin-0.10.0.4/ ${HOME}/plugins/opendistro_security_kibana_plugin-0.10.0.4/
 COPY  ${upstream_code}/vendored_tar_src/handlebars/ ${HOME}/node_modules/handlebars/
 COPY  ${upstream_code}/vendored_tar_src/minimist/ ${HOME}/node_modules/minimist/
-COPY  ${upstream_code}/vendored_tar_src/ua-parser-js-1.0.2/ ${HOME}/node_modules/ua-parser/
+COPY  ${upstream_code}/vendored_tar_src/ua-parser-js-1.0.2/ ${HOME}/node_modules/ua-parser-js/
 COPY  ${upstream_code}/vendored_tar_src/fbjs-0.8.18/ ${HOME}/node_modules/fbjs/
 
 RUN chmod -R og+w ${HOME}/

--- a/kibana/Dockerfile.in
+++ b/kibana/Dockerfile.in
@@ -48,7 +48,7 @@ COPY --from=builder ${upstream_code}/vendored_tar_src/kibana-oss-6.8.1 ${HOME}/
 COPY --from=builder ${upstream_code}/vendored_tar_src/opendistro_security_kibana_plugin-0.10.0.4/ ${HOME}/plugins/opendistro_security_kibana_plugin-0.10.0.4/
 COPY --from=builder ${upstream_code}/vendored_tar_src/handlebars/ ${HOME}/node_modules/handlebars/
 COPY --from=builder ${upstream_code}/vendored_tar_src/minimist/ ${HOME}/node_modules/minimist/
-COPY --from=builder ${upstream_code}/vendored_tar_src/ua-parser-js-1.0.2/ ${HOME}/node_modules/ua-parser/
+COPY --from=builder ${upstream_code}/vendored_tar_src/ua-parser-js-1.0.2/ ${HOME}/node_modules/ua-parser-js/
 COPY --from=builder ${upstream_code}/vendored_tar_src/fbjs-0.8.18/ ${HOME}/node_modules/fbjs/
 
 RUN chmod -R og+w ${HOME}/


### PR DESCRIPTION
Correction to the fix for [LOG-1315](https://issues.redhat.com/browse/LOG-1315)
Place ua-parser-js-1.0.2 under node_modules/ua-parser-js

### Description
The fix for [LOG-1315](https://issues.redhat.com/browse/LOG-1315) placed the updated ua-parser-js-1.0.2 under node_modules/ua-parser, which should have been node_modules/ua-parser-js.
/cc @jcantrill 
/assign @alanconway 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1315

