### PR TITLE
LOG-2103: Update ES to resolve CVE-2021-44832

### DIFF
--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -24,7 +24,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00013 \
+    ES_VER=6.8.1.redhat-00016 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,3 +1,3 @@
-- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00013-1
+- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00016-1
 - nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.1.2_redhat_00006-1
 - nvr: org.elasticsearch.plugin.prometheus-prometheus-exporter-6.8.1.0_redhat_00001-1


### PR DESCRIPTION
### Description
This PR:

Fixes CVE-2021-44832 by bumping log4j to v2.17.1 for logging 5.0

### Links
* https://issues.redhat.com/browse/LOG-2103