### PR TITLE
Bug 2036043: Fix CVE-2021-44832 to upgrade log4j version to 2.17.1

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/ose-base:elasticsearch
+FROM rhel7:7-released
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
@@ -14,6 +14,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_VER=1.8.0 \
     NODE_QUORUM=1 \
     OSE_ES_VER=5.6.16.4-redhat-00001 \
+    ES_VER_REDHAT=5.6.16.redhat-00004 \
     PROMETHEUS_EXPORTER_VER=5.6.16.0-redhat-1 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -23,12 +24,22 @@ ENV ES_CONF=/etc/elasticsearch/ \
     DHE_TMP_KEY_SIZE=2048 \
     container=oci
 
-ARG OSE_ES_VER=5.6.16.4-redhat-00001
-ARG OSE_ES_URL
+ARG ES_ARCHIVE_URL
 ARG PROMETHEUS_EXPORTER_VER=5.6.16.0-redhat-1
 ARG PROMETHEUS_EXPORTER_URL
 ARG MAVEN_REPO_URL=file:///artifacts/
 
+RUN yum-config-manager -q --enable rhel-7-server-extras-rpms && \
+    packages="java-${JAVA_VER}-openjdk-headless \
+              PyYAML  \
+              hostname \
+              openssl \
+              zip \
+              unzip" && \
+    yum install -y --setopt=tsflags=nodocs ${packages} && \
+    yum clean all
+
+ADD extra-jvm.options ${ES_CONF}/
 ADD sgconfig/ ${HOME}/sgconfig/
 ADD index_templates/ ${ES_HOME}/index_templates/
 ADD index_patterns/ ${ES_HOME}/index_patterns/
@@ -37,11 +48,23 @@ ADD kibana_ui_objects/ ${ES_HOME}/kibana_ui_objects/
 ADD probe/ ${ES_HOME}/probe/
 ADD init.sh run.sh prep-install* install.sh ${HOME}/
 COPY utils/** /usr/local/bin/
-RUN ln -s /usr/local/bin/logging ${HOME}/logging
-
 COPY artifacts /artifacts
-RUN ${HOME}/install.sh && rm -rf /artifacts
+RUN ln -s /usr/local/bin/logging ${HOME}/logging && \
+    ${HOME}/install.sh && \ 
+    rm -rf /artifacts
 
 WORKDIR ${HOME}
 USER 1000
 CMD ["sh", "/opt/app-root/src/run.sh"]
+
+LABEL \
+        License="GPLv2+" \
+        io.k8s.description="Elasticsearch container for EFK aggregated logging storage" \
+        io.k8s.display-name="Elasticsearch 5" \
+        io.openshift.tags="logging,elk,elasticsearch" \
+        vendor="Red Hat" \
+        name="openshift3/ose-logging-elasticsearch5" \
+        com.redhat.component="logging-elasticsearch5-container" \
+        io.openshift.maintainer.product="OpenShift Container Platform" \
+        io.openshift.maintainer.component="Logging" \
+        version="v3.11"

--- a/elasticsearch/Dockerfile.centos7
+++ b/elasticsearch/Dockerfile.centos7
@@ -15,6 +15,7 @@ ENV ES_CONF=/etc/elasticsearch/ \
     JAVA_HOME=/usr/lib/jvm/jre \
     NODE_QUORUM=1 \
     OSE_ES_VER=5.6.16.4 \
+    ES_VER_REDHAT=5.6.16.redhat-00004 \
     PROMETHEUS_EXPORTER_VER=5.6.16.0 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
@@ -33,16 +34,18 @@ LABEL io.k8s.description="Elasticsearch container for EFK aggregated logging sto
       architecture=x86_64 \
       name="openshift3/logging-elasticsearch"
 
-ADD elasticsearch.repo /etc/yum.repos.d/elasticsearch.repo
+
 # install the RPMs in a separate step so it can be cached
 RUN rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch && \
     yum install -y --setopt=tsflags=nodocs --nogpgcheck \
                 java-${JAVA_VER}-openjdk-headless \
-                elasticsearch-${ES_VER} \
                 openssl \
-                PyYAML && \
+                PyYAML \
+                zip \ 
+                unzip && \
     yum clean all
 
+ADD extra-jvm.options ${ES_CONF}/
 ADD sgconfig/ ${HOME}/sgconfig/
 ADD index_templates/ ${ES_HOME}/index_templates/
 ADD index_patterns/ ${ES_HOME}/index_patterns/
@@ -51,10 +54,6 @@ ADD kibana_ui_objects/ ${ES_HOME}/kibana_ui_objects/
 ADD probe/ ${ES_HOME}/probe/
 ADD init.sh run.sh prep-install* install.sh ${HOME}/
 COPY utils/** /usr/local/bin/
-
-ARG OSE_ES_URL
-ARG PROMETHEUS_EXPORTER_URL=https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/${PROMETHEUS_EXPORTER_VER}/prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
-ARG SG_URL
 
 RUN ln -s /usr/local/bin/logging ${HOME}/logging && \
     ${HOME}/install.sh && \

--- a/elasticsearch/elasticsearch.repo
+++ b/elasticsearch/elasticsearch.repo
@@ -1,8 +1,0 @@
-[elasticsearch-5.x]
-name=Elasticsearch repository for 5.x packages
-baseurl=https://artifacts.elastic.co/packages/5.x/yum
-gpgcheck=1
-gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
-enabled=1
-autorefresh=1
-type=rpm-md

--- a/elasticsearch/extra-jvm.options
+++ b/elasticsearch/extra-jvm.options
@@ -1,0 +1,4 @@
+-XX:+UnlockExperimentalVMOptions
+-XX:MaxRAMFraction=2
+-XX:InitialRAMFraction=2
+-XX:MinRAMFraction=2

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,2 +1,3 @@
 - nvr: org.elasticsearch.plugin.prometheus-elasticsearch-prometheus-exporter-5.6.16.0_redhat_1-1
 - nvr: io.fabric8.elasticsearch-openshift-elasticsearch-plugin-5.6.16.4_redhat_00001-1
+- nvr: org.elasticsearch-elasticsearch-5.6.16.redhat_00004-1

--- a/elasticsearch/prep-install.origin
+++ b/elasticsearch/prep-install.origin
@@ -3,6 +3,8 @@ if [ -z "${OSE_ES_URL:-}" ] ; then
    OSE_ES_URL=https://github.com/fabric8io/openshift-elasticsearch-plugin/releases/download/openshift-elasticsearch-plugin-${OSE_ES_VER}/openshift-elasticsearch-plugin-${OSE_ES_VER}.zip
 fi
 if [ -z "${PROMETHEUS_EXPORTER_URL:-}" ] ; then
-    PROMETHEUS_EXPORTER_URL=https://github.com/lukas-vlcek/elasticsearch-prometheus-exporter/releases/download/${PROMETHEUS_EXPORTER_VER}/prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
+    PROMETHEUS_EXPORTER_URL=https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/${PROMETHEUS_EXPORTER_VER}/prometheus-exporter-${PROMETHEUS_EXPORTER_VER}.zip
 fi
 es_plugins=($OSE_ES_URL $PROMETHEUS_EXPORTER_URL)
+
+ES_ARCHIVE_URL=https://github.com/ViaQ/elasticsearch/releases/download/elasticsearch-${ES_VER_REDHAT}/elasticsearch-${ES_VER_REDHAT}.zip

--- a/elasticsearch/prep-install.prod
+++ b/elasticsearch/prep-install.prod
@@ -2,3 +2,4 @@ es_plugins=(
     ${MAVEN_REPO_URL}io/fabric8/elasticsearch/openshift-elasticsearch-plugin/$OSE_ES_VER/openshift-elasticsearch-plugin-$OSE_ES_VER.zip
     ${MAVEN_REPO_URL}org/elasticsearch/plugin/prometheus/elasticsearch-prometheus-exporter/$PROMETHEUS_EXPORTER_VER/elasticsearch-prometheus-exporter-$PROMETHEUS_EXPORTER_VER.zip
 )
+ES_ARCHIVE_URL=file:///artifacts/org/elasticsearch/distribution/zip/elasticsearch/${ES_VER_REDHAT}/elasticsearch-${ES_VER_REDHAT}.zip


### PR DESCRIPTION
### Description
This PR:
* Fixes the issue by upgrading the log4j library to v2.17.1

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=2036043