### PR TITLE
Disable fips mode to deploy elasticsearch on a fips enabled cluster

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -26,6 +26,7 @@ ENV ES_PATH_CONF=/etc/elasticsearch/ \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \
     JAVA_HOME=/usr/lib/jvm/jre \
+    _JAVA_OPTIONS="-Dcom.redhat.fips=false" \
     NODE_QUORUM=1 \
     PROMETHEUS_EXPORTER_VER=6.8.1.2-redhat-00001 \
     INGEST_PLUGIN_VER=6.8.1.0-redhat-00003 \

--- a/elasticsearch/Dockerfile.in
+++ b/elasticsearch/Dockerfile.in
@@ -41,6 +41,7 @@ ENV ES_PATH_CONF=/etc/elasticsearch/ \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \
     JAVA_HOME=/usr/lib/jvm/jre \
+    _JAVA_OPTIONS="-Dcom.redhat.fips=false" \
     NODE_QUORUM=1 \
     PROMETHEUS_EXPORTER_VER=6.8.1.2-redhat-00001 \
     INGEST_PLUGIN_VER=6.8.1.0-redhat-00003 \


### PR DESCRIPTION
Signed-off-by: Shweta Padubidri <spadubid@redhat.com>

### Description
Disable fips mode to enable elasticsearch deployment on a fips enabled cluster

/cc
/assign @jcantrill

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-1974

