### PR TITLE
Elasticsearch image build: remove elasticsearch installer after installation

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -62,7 +62,7 @@ COPY  ${upstream_code}/extra-jvm.options /var/tmp
 COPY  ${upstream_code}/ci-env.sh /var/tmp
 COPY  ${upstream_code}/install-es.sh /var/tmp
 COPY artifacts /artifacts
-RUN /var/tmp/install-es.sh
+RUN /var/tmp/install-es.sh && rm -rf /var/tmp/*
 
 COPY  ${upstream_code}/sgconfig/ ${HOME}/sgconfig/
 COPY  ${upstream_code}/index_templates/ ${ES_HOME}/index_templates/

--- a/elasticsearch/Dockerfile.in
+++ b/elasticsearch/Dockerfile.in
@@ -80,7 +80,7 @@ COPY --from=builder ${upstream_code}/extra-jvm.options /var/tmp
 COPY --from=builder ${upstream_code}/ci-env.sh /var/tmp
 COPY --from=builder ${upstream_code}/install-es.sh /var/tmp
 COPY artifacts /artifacts
-RUN /var/tmp/install-es.sh
+RUN /var/tmp/install-es.sh && rm -rf /var/tmp/*
 
 COPY --from=builder ${upstream_code}/sgconfig/ ${HOME}/sgconfig/
 COPY --from=builder ${upstream_code}/index_templates/ ${ES_HOME}/index_templates/


### PR DESCRIPTION
### Description
Remove elasticsearch installer after installation, trim 100MB off the resulting image.

/cc @vimalk78
/assign @jcantrill