### PR TITLE
LOG-2357: Update Dockerfile to use public base images

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,7 +1,7 @@
 ### This is a generated file from Dockerfile.in ###
 
 #@follow_tag(registry.redhat.io/ubi8:latest)
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
+FROM registry.access.redhat.com/ubi8
 ENV BUILD_VERSION=6.8.1
 ENV SOURCE_GIT_COMMIT=${CI_ORIGIN_AGGREGATED_LOGGING_UPSTREAM_COMMIT:-}
 ENV SOURCE_GIT_URL=${CI_ORIGIN_AGGREGATED_LOGGING_UPSTREAM_URL:-}

--- a/elasticsearch/origin-meta.yaml
+++ b/elasticsearch/origin-meta.yaml
@@ -1,3 +1,3 @@
 from:
 - source: registry.redhat.io/ubi8:(\d).(\d)-(?:[\.0-9\-]*)
-  target: registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7 
+  target: registry.access.redhat.com/ubi8

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,7 +1,7 @@
 ### This is a generated file from Dockerfile.in ###
 
 #@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/ubi8-nodejs-10:latest)
-FROM registry.ci.openshift.org/ocp/builder:rhel8.2.els.nodejs.10
+FROM registry.access.redhat.com/ubi8/nodejs-10
 ENV BUILD_VERSION=6.8.1
 ENV SOURCE_GIT_COMMIT=${CI_ORIGIN_AGGREGATED_LOGGING_UPSTREAM_COMMIT:-}
 ENV SOURCE_GIT_URL=${CI_ORIGIN_AGGREGATED_LOGGING_UPSTREAM_URL:-}

--- a/kibana/origin-meta.yaml
+++ b/kibana/origin-meta.yaml
@@ -1,3 +1,3 @@
 from:
 - source: registry-proxy.engineering.redhat.com/rh-osbs/ubi8-nodejs-10:(\d)-(?:[\.0-9\-]*)
-  target: registry.ci.openshift.org/ocp/builder:rhel8.2.els.nodejs.10
+  target: registry.access.redhat.com/ubi8/nodejs-10


### PR DESCRIPTION
### Description
This PR:
* Replaces ocp specific base images with those that are publicly available with RH or other subscriptions

/assign @alanconway 

### Links
* https://issues.redhat.com/browse/LOG-2357
