### PR TITLE
Bug 2064718: Use 8.2 eus base image

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel8.2.els.python.36
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
@@ -28,8 +28,11 @@ RUN mkdir -p $(dirname "$CURATOR_CONF_LOCATION") && \
     chmod -R g=u ${HOME}
 
 WORKDIR ${HOME}/vendor
-RUN pip install $(ls . | grep -v curator) -q --no-index --find-links . && \
-    pip install elasticsearch-curator* --no-index -q && \
+RUN yum install -y python3-pip && \
+    yum clean all && \
+    rm -rf /var/cache/yum && \
+    pip3 install $(ls . | grep -v curator) -q --no-index --find-links . && \
+    pip3 install elasticsearch-curator* --no-index -q && \
     rm -rf $HOME/vendor
 
 WORKDIR ${HOME}


### PR DESCRIPTION
### Description
The curator5 image is currently based on a s2i python image. For 8.2 eus, this causes alerts in the grading. This PR proposes to use the default rhel8 base image as a base instead.

/cc @sosiouxme @periklis 
/assign @jcantrill 

### Links
- Depending on PR(s): (ocp-build-data PR incoming)
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2064718
