### PR TITLE
Bug 2091584: Add Jaeger auth for dependencies index

### DIFF
--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -101,6 +101,13 @@ sg_role_jaeger:
         - READ
         - SEARCH
         - MANAGE
+    '*jaeger-dependencies-*':
+      '*':
+        - CRUD
+        - CREATE_INDEX
+        - READ
+        - SEARCH
+        - MANAGE
     '*jaeger-span-archive':
       '*':
         - CRUD


### PR DESCRIPTION
We need it here too, right?
See: https://github.com/openshift/origin-aggregated-logging/pull/2254

Description

/cc @jcantrill
/assign

/cherry-pick b621a482eedea4bde0cdd6d646de2324e837e19f

**Links**
- Depending on PR(s):
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2091584
- Github issue: 
- JIRA: https://issues.redhat.com/browse/TRACING-2610
- Enhancement proposal:

