### PR TITLE
LOG-2776: Enable FIPS mode to deploy elasticsearch on a FIPS enabled c

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -24,9 +24,8 @@ ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_VER=6.8.1.redhat-00020 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
-    JAVA_VER=11 \
+    JAVA_VER=17 \
     JAVA_HOME=/usr/lib/jvm/jre \
-    _JAVA_OPTIONS="-Dcom.redhat.fips=false" \
     NODE_QUORUM=1 \
     PROMETHEUS_EXPORTER_VER=6.8.1.2-redhat-00001 \
     INGEST_PLUGIN_VER=6.8.1.0-redhat-00003 \

--- a/elasticsearch/Dockerfile.in
+++ b/elasticsearch/Dockerfile.in
@@ -1,6 +1,6 @@
 ## EXCLUDE BEGIN ##
 #@follow_tag(registry.redhat.io/ubi8:latest)
-FROM registry.redhat.io/ubi8:8.4-211 AS builder
+FROM registry.redhat.io/ubi8:8.6-855 AS builder
 
 ARG upstream_code=upstream_code
 ARG upstream_tarball=${upstream_code}.tar.gz
@@ -13,7 +13,7 @@ RUN mkdir -p ${upstream_code} \
 ## EXCLUDE END ##
 
 #@follow_tag(registry.redhat.io/ubi8:latest)
-FROM registry.redhat.io/ubi8:8.4-211
+FROM registry.redhat.io/ubi8:8.6-855
 ## EXCLUDE BEGIN ##
 ARG upstream_code=upstream_code/elasticsearch
 ## EXCLUDE END ##
@@ -39,9 +39,8 @@ ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_VER=6.8.1.redhat-00020 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
-    JAVA_VER=11 \
+    JAVA_VER=17 \
     JAVA_HOME=/usr/lib/jvm/jre \
-    _JAVA_OPTIONS="-Dcom.redhat.fips=false" \
     NODE_QUORUM=1 \
     PROMETHEUS_EXPORTER_VER=6.8.1.2-redhat-00001 \
     INGEST_PLUGIN_VER=6.8.1.0-redhat-00003 \

--- a/elasticsearch/extra-jvm.options
+++ b/elasticsearch/extra-jvm.options
@@ -1,4 +1,1 @@
 -XX:+UnlockExperimentalVMOptions
--XX:MaxRAMFraction=2
--XX:InitialRAMFraction=2
--XX:MinRAMFraction=2

--- a/elasticsearch/install-es.sh
+++ b/elasticsearch/install-es.sh
@@ -32,6 +32,7 @@ install -m 660 config/* ${ES_PATH_CONF}
 popd
 sed -i -e 's/^-Xms/#-Xms/' -e 's/^-Xmx/#-Xmx/' -e '/-Xlog/d' ${ES_PATH_CONF}/jvm.options
 [[ `arch` = x86_64 ]] || sed -i -e '/UseAVX/d' ${ES_PATH_CONF}/jvm.options
+sed -i -e '/-XX:+UseConcMarkSweepGC/s/^\s*/#/' -e '/-XX:CMSInitiatingOccupancyFraction=75/s/^\s*/#/' -e '/-XX:+UseCMSInitiatingOccupancyOnly/s/^\s*/#/' -e '/10-:-XX:+UseG1GC/s/^#*\s*//' -e '/10-:-XX:InitiatingHeapOccupancyPercent=75/s/^#*\s*//' ${ES_PATH_CONF}/jvm.options
 cat extra-jvm.options >> ${ES_PATH_CONF}/jvm.options
 groupadd -r elasticsearch -g 1000
 useradd -r -g elasticsearch -d ${ES_HOME} -u 1000 \


### PR DESCRIPTION
Signed-off-by: Shweta Padubidri <spadubid@redhat.com>

### Description
OpenJDK17 in RHEL 8.6 supports PKSC#12  keystore. Remove the explicit disablement of the FIPS mode in  JAVA_OPTIONS, to test if Elasticsearch can be correctly deployed on a FIPS enabled cluster.


/cc @kabirbhartiRH 
/assign @jcantrill 


### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: [LOG-2776](https://issues.redhat.com//browse/LOG-2776): 

