### PR TITLE
update admin cluster permissions

### DIFF
--- a/elasticsearch/sgconfig/roles.yml
+++ b/elasticsearch/sgconfig/roles.yml
@@ -161,6 +161,7 @@ admin_user:
     - CLUSTER_MONITOR
     - CLUSTER_COMPOSITE_OPS_RO
     - indices:data/write/bulk  #required for being able to let index mappings update... is this required still with multitenancy?
+    - indices:admin/template/get
   indices:
     '*':
       '*':


### PR DESCRIPTION
### Description
This PR solves the problem of creating new empty indices after rollover. The cluster permission `indices:admin/template/get` was missing for the user `admin`

### Links
- JIRA: [LOG-2823](https://issues.redhat.com/browse/LOG-2823)