### PR TITLE
[release-4.6] Adapt dockerfile to new build environment

### DIFF
--- a/elasticsearch/Dockerfile.rhel8
+++ b/elasticsearch/Dockerfile.rhel8
@@ -60,7 +60,7 @@ ADD extra-jvm.options install-es.sh ci-env.sh /var/tmp
 RUN mkdir /artifacts
 # In an OSBS build, this will COPY artifacts from fetch-artifacts-koji.yaml. In a CI build, it will just
 # copy the README.MD.
-COPY artifacts/* /artifacts
+COPY artifacts/* /artifacts/
 COPY *.zip /
 RUN /var/tmp/install-es.sh
 


### PR DESCRIPTION
### Description
There was a build failure on the new build environment based on podman rather than imagebuilder. `COPY` to a directory should end with a `/`. Test build result: https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2207074

/cc @periklis 
/assign @periklis 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
Omitting jira's for now, as there might or might not be backport rules to `openshift-4.6`

- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
