### PR TITLE
elasticsearch: jackson-databind to v2.12.7.1 for security plugin

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -21,7 +21,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00020 \
+    ES_VER=6.8.1.redhat-00029 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \
@@ -30,7 +30,7 @@ ENV ES_PATH_CONF=/etc/elasticsearch/ \
     NODE_QUORUM=1 \
     PROMETHEUS_EXPORTER_VER=6.8.1.2-redhat-00001 \
     INGEST_PLUGIN_VER=6.8.1.0-redhat-00003 \
-    OPENDISTRO_VER=0.10.1.2-redhat-00010 \
+    OPENDISTRO_VER=0.10.1.2-redhat-00019 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
     RECOVER_EXPECTED_NODES=1 \

--- a/elasticsearch/Dockerfile.in
+++ b/elasticsearch/Dockerfile.in
@@ -36,7 +36,7 @@ ARG OPENSHIFT_CI
 
 ENV ES_PATH_CONF=/etc/elasticsearch/ \
     ES_HOME=/usr/share/elasticsearch \
-    ES_VER=6.8.1.redhat-00020 \
+    ES_VER=6.8.1.redhat-00029 \
     HOME=/opt/app-root/src \
     INSTANCE_RAM=512G \
     JAVA_VER=11 \
@@ -45,7 +45,7 @@ ENV ES_PATH_CONF=/etc/elasticsearch/ \
     NODE_QUORUM=1 \
     PROMETHEUS_EXPORTER_VER=6.8.1.2-redhat-00001 \
     INGEST_PLUGIN_VER=6.8.1.0-redhat-00003 \
-    OPENDISTRO_VER=0.10.1.2-redhat-00010 \
+    OPENDISTRO_VER=0.10.1.2-redhat-00019 \
     PLUGIN_LOGLEVEL=INFO \
     RECOVER_AFTER_NODES=1 \
     RECOVER_EXPECTED_NODES=1 \

--- a/elasticsearch/fetch-artifacts-koji.yaml
+++ b/elasticsearch/fetch-artifacts-koji.yaml
@@ -1,4 +1,4 @@
-- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00020-1
-- nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.1.2_redhat_00010-1
+- nvr: org.elasticsearch-elasticsearch-6.8.1.redhat_00029-1
+- nvr: com.amazon.opendistroforelasticsearch-opendistro_security-0.10.1.2_redhat_00019-1
 - nvr: org.elasticsearch.plugin.prometheus-prometheus-exporter-6.8.1.2_redhat_00001-1
 - nvr: org.elasticsearch.plugin.ingest-openshift-ingest-plugin-6.8.1.0_redhat_00003-1


### PR DESCRIPTION
### Description
Upgrade dependencies `jackson-databind` to `2.12.7.1` and `jackson-core` to `2.12.7` to address CVEs: 

* [LOG-3044](https://issues.redhat.com//browse/LOG-3044) (CVE-2020-36518)
* [LOG-3205](https://issues.redhat.com//browse/LOG-3205) (CVE-2022-42003) 
* [LOG-3206](https://issues.redhat.com//browse/LOG-3206) (CVE-2022-42004)

/cc @xperimental 