### PR TITLE
Upgrade curator python image to ubi9/python:3.9

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -1,7 +1,7 @@
 ### This is a generated file from Dockerfile.in ###
 
-#@follow_tag(registry.redhat.io/ubi8/python-36:latest)
-FROM registry.ci.openshift.org/ocp/builder:ubi8.python.36
+#@follow_tag(registry.redhat.io/ubi9/python-39:latest)
+FROM registry.ci.openshift.org/ocp/ubi-python-39:9
 
 
 ENV BUILD_VERSION=5.8.1
@@ -51,7 +51,7 @@ LABEL \
         io.k8s.display-name="Curator 5" \
         io.openshift.tags="logging,elk,elasticsearch,curator" \
         vendor="Red Hat" \
-        name="openshift-logging/logging-curator5-rhel8" \
+        name="openshift-logging/logging-curator5-rhel9" \
         com.redhat.component="logging-curator5-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.build.commit.id=${CI_ORIGIN_AGGREGATED_LOGGING_UPSTREAM_COMMIT} \

--- a/curator/Dockerfile.in
+++ b/curator/Dockerfile.in
@@ -1,6 +1,6 @@
 ## EXCLUDE BEGIN ##
-#@follow_tag(registry.redhat.io/ubi8:latest)
-FROM registry.redhat.io/ubi8:8.4-211 AS builder
+#@follow_tag(registry.redhat.io/ubi9:latest)
+FROM registry.redhat.io/ubi9:9.2-489 AS builder
 
 ARG upstream_code=upstream_code
 ARG upstream_tarball=${upstream_code}.tar.gz
@@ -12,8 +12,8 @@ RUN mkdir -p ${upstream_code} \
         -C ${upstream_code}
 ## EXCLUDE END ##
 
-#@follow_tag(registry.redhat.io/ubi8/python-36:latest)
-FROM registry.redhat.io/ubi8/python-36:1-155
+#@follow_tag(registry.redhat.io/ubi9/python-39:latest)
+FROM registry.ci.openshift.org/ocp/ubi-python-39:9
 
 ## EXCLUDE BEGIN ##
 ARG upstream_code=upstream_code/curator
@@ -66,7 +66,7 @@ LABEL \
         io.k8s.display-name="Curator 5" \
         io.openshift.tags="logging,elk,elasticsearch,curator" \
         vendor="Red Hat" \
-        name="openshift-logging/logging-curator5-rhel8" \
+        name="openshift-logging/logging-curator5-rhel9" \
         com.redhat.component="logging-curator5-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.build.commit.id=${CI_ORIGIN_AGGREGATED_LOGGING_UPSTREAM_COMMIT} \

--- a/curator/origin-meta.yaml
+++ b/curator/origin-meta.yaml
@@ -1,3 +1,3 @@
 from:
-- source: registry.redhat.io/ubi8/python-36:(\d)-(?:[\.0-9\-]*)
-  target: registry.ci.openshift.org/ocp/builder:ubi8.python.36 
+- source: registry.redhat.io/ubi9/python-39:(\d)-(?:[\.0-9\-]*)
+  target: registry.ci.openshift.org/ocp/ubi-python-39:9


### PR DESCRIPTION
### Description
Update the curator's python image to `ubi9/python:3.9`

/assign @periklis 

### Links
- JIRA: [LOG-4180](https://issues.redhat.com/browse/LOG-4180)
