### PR TITLE
Remove oc deprecated flags from test script

### DIFF
--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -12,11 +12,7 @@ OC_BINARY=$( type -p oc )
 # and I'm hoping request-timeout will help, and maybe increasing the loglevel
 # will give us some clues
 oc() {
-    local oclogdir=${OC_LOG_DIR:-${ARTIFACT_DIR:-/tmp}/oclogs}
-    if [ ! -d $oclogdir ] ; then
-        mkdir -p $oclogdir
-    fi
-    $OC_BINARY --request-timeout=15s --logtostderr=false --loglevel=2 --log_dir=$oclogdir "$@"
+    $OC_BINARY --request-timeout=15s --loglevel=2 "$@"
 }
 
 if [ $(id -u) = 0 ] ; then


### PR DESCRIPTION
### Description
The flags `--logtostderr` and `--log-dir` are deprecated in the newest version of the `oc` command. This PR removes those flags from one of the test scripts.
Reference: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components#removed-klog-flags

### Links
- Depended on by: https://github.com/openshift/release/pull/40492
- Jira: [LOG-4248](https://issues.redhat.com/browse/LOG-4248)

