### PR TITLE
Remove deprecated logging options from oc calls

### DIFF
--- a/hack/testing/util.sh
+++ b/hack/testing/util.sh
@@ -12,11 +12,7 @@ OC_BINARY=$( type -p oc )
 # and I'm hoping request-timeout will help, and maybe increasing the loglevel
 # will give us some clues
 oc() {
-    local oclogdir=${OC_LOG_DIR:-${ARTIFACT_DIR:-/tmp}/oclogs}
-    if [ ! -d $oclogdir ] ; then
-        mkdir -p $oclogdir
-    fi
-    $OC_BINARY --request-timeout=15s --logtostderr=false --loglevel=2 --log_dir=$oclogdir "$@"
+    $OC_BINARY --request-timeout=15s --loglevel=2 "$@"
 }
 
 if [ $(id -u) = 0 ] ; then


### PR DESCRIPTION
### Description

The calls to `oc` used in the smoke tests use options that were deprecated for a while and are now removed. This seems to cause issues in the 5.7 smoke tests (see openshift/release#40492 ).

### Links

- JIRA: [LOG-4248](https://issues.redhat.com//browse/LOG-4248)
